### PR TITLE
refactor(fe): replace time ago widget with native Intl api

### DIFF
--- a/frontend/core/containers/thread/DashboardThread/CMS/Cell/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/CMS/Cell/index.tsx
@@ -1,18 +1,16 @@
 // import type { FC } from 'react'
 
-import { Cell } from 'rsuite-table'
-import TimeAgo from '~/widgets/TimeAgo'
 import Link from 'next/link'
-
-import { previewArticle } from '~/signal'
+import { Cell } from 'rsuite-table'
 import { COMMUNITY_STATUS } from '~/const/mode'
-
 import Img from '~/Img'
 import PulseSVG from '~/icons/Pulse'
-import Checker from '~/widgets/Checker'
+import { previewArticle } from '~/signal'
 import ArticleCatState from '~/widgets/ArticleCatState'
 import Button from '~/widgets/Buttons/Button'
+import Checker from '~/widgets/Checker'
 import TagsList from '~/widgets/TagsList'
+import TimeAgo from '~/widgets/TimeAgo'
 
 // import { mockTags } from '~/mock'
 
@@ -28,7 +26,7 @@ export const CheckCell = ({ rowData, ...props }) => {
     <Cell {...props}>
       <Checker
         checked={_checked}
-        size="small"
+        size='small'
         top={5}
         onChange={(checked) => batchSelect(id, checked)}
       />
@@ -55,7 +53,7 @@ export const CommunityCell = ({ rowData, ...props }) => {
 
   return (
     <Cell {...props}>
-      <div className="row">
+      <div className='row'>
         <Img className={s.communityLogo} src={logo} />
         <div>
           <div className={s.communityTitle}>{title}</div>
@@ -75,12 +73,12 @@ export const PendingCell = ({ rowData, ...props }) => {
   const _pending = pending === COMMUNITY_STATUS.PENDING
 
   return (
-    <Cell {...props} align="center">
+    <Cell {...props} align='center'>
       <div className={s.actionCell}>
         <div className={cn(s.pending, _pending && s.pendingBlocked)}>
           {_pending ? '待审核' : '正常'}
         </div>
-        <Button className={s.switchButton} size="tiny" ghost>
+        <Button className={s.switchButton} size='tiny' ghost>
           开关
         </Button>
       </div>
@@ -93,12 +91,10 @@ export const ArticleCell = ({ rowData, ...props }) => {
 
   return (
     <Cell {...props}>
-      <>
-        <div className={s.articleTitle} onClick={() => previewArticle(rowData)}>
-          {rowData.title}
-        </div>
-        <TagsList items={rowData.articleTags} left={0} />
-      </>
+      <div className={s.articleTitle} onClick={() => previewArticle(rowData)}>
+        {rowData.title}
+      </div>
+      <TagsList items={rowData.articleTags} left={0} />
     </Cell>
   )
 }
@@ -124,11 +120,11 @@ export const DateCell = ({ rowData, ...props }) => {
       <div className={s.dateCell}>
         <div className={s.dateItem}>
           {/* <PublishIcon /> */}
-          <TimeAgo datetime={insertedAt} locale="zh_CN" />
+          <TimeAgo datetime={insertedAt} />
         </div>
         <div className={s.dateItem}>
           <PulseSVG className={s.pulseIcon} />
-          <TimeAgo datetime={activeAt} locale="zh_CN" />
+          <TimeAgo datetime={activeAt} />
         </div>
       </div>
     </Cell>
@@ -144,7 +140,7 @@ export const TimestampCell = ({ rowData, ...props }) => {
       <Cell {...props}>
         <div className={s.dateCell}>
           <div className={cn(s.dateItem, s.dateItemWarn)}>
-            <TimeAgo datetime={insertedAt} locale="zh_CN" />
+            <TimeAgo datetime={insertedAt} />
           </div>
         </div>
       </Cell>
@@ -156,11 +152,11 @@ export const TimestampCell = ({ rowData, ...props }) => {
       <div className={s.dateCell}>
         <div className={s.dateItem}>
           {/* <PublishIcon /> */}
-          <TimeAgo datetime={insertedAt} locale="zh_CN" />
+          <TimeAgo datetime={insertedAt} />
         </div>
         <div className={s.dateItem}>
           <PulseSVG className={s.pulseIcon} />
-          <TimeAgo datetime={updatedAt} locale="zh_CN" />
+          <TimeAgo datetime={updatedAt} />
         </div>
       </div>
     </Cell>

--- a/frontend/core/containers/unit/Comments/Comment/DesktopView/FoldLayout.tsx
+++ b/frontend/core/containers/unit/Comments/Comment/DesktopView/FoldLayout.tsx
@@ -1,17 +1,14 @@
 import type { FC } from 'react'
-import TimeAgo from '~/widgets/TimeAgo'
-
-import type { TComment } from '~/spec'
-
 import Img from '~/Img'
-import ExpandSVG from '~/icons/Expand'
 import CheckBoldSVG from '~/icons/CheckBold'
+import ExpandSVG from '~/icons/Expand'
+import type { TComment } from '~/spec'
 import ImgFallback from '~/widgets/ImgFallback'
-
-import IllegalBar from './IllegalBar'
+import TimeAgo from '~/widgets/TimeAgo'
+import useSalon, { cn } from '../../salon/comment/desktop_view/fold_layout'
 
 import useLogic from '../../useLogic'
-import useSalon, { cn } from '../../salon/comment/desktop_view/fold_layout'
+import IllegalBar from './IllegalBar'
 
 type TProps = {
   data: TComment
@@ -56,7 +53,7 @@ const FoldLayout: FC<TProps> = ({ data, isReply = false }) => {
         />
       )}
       <div className={s.createDate}>
-        <TimeAgo datetime={data.insertedAt} locale="zh_CN" />
+        <TimeAgo datetime={data.insertedAt} />
       </div>
     </div>
   )

--- a/frontend/core/containers/unit/Comments/Comment/Header/Article.tsx
+++ b/frontend/core/containers/unit/Comments/Comment/Header/Article.tsx
@@ -1,10 +1,9 @@
 import type { FC } from 'react'
-import TimeAgo from '~/widgets/TimeAgo'
+import Img from '~/Img'
 
 import type { TComment } from '~/spec'
-
-import Img from '~/Img'
 import ImgFallback from '~/widgets/ImgFallback'
+import TimeAgo from '~/widgets/TimeAgo'
 
 import useSalon from '../../salon/comment/header/article'
 
@@ -39,15 +38,15 @@ const CommentHeader: FC<TProps> = ({ data, showInnerRef, isReply }) => {
               </div>
             )}
             <div className={s.createDate}>
-              <TimeAgo datetime={data.insertedAt} locale="zh_CN" />
+              <TimeAgo datetime={data.insertedAt} />
             </div>
           </div>
 
           <div className={s.floorNum}>
-            #<span className="mr-0.5" />
+            #<span className='mr-0.5' />
             {data.floor}
           </div>
-          <div className="mr-2.5" />
+          <div className='mr-2.5' />
         </div>
 
         {author.bio && <div className={s.shortBio}>{author.bio}</div>}

--- a/frontend/core/hooks/useNow.ts
+++ b/frontend/core/hooks/useNow.ts
@@ -1,0 +1,7 @@
+import useDashboard from '~/hooks/useDashboard'
+
+export default (): number => {
+  const dashboard$ = useDashboard()
+
+  return dashboard$.now
+}

--- a/frontend/core/hooks/useViewingThread.ts
+++ b/frontend/core/hooks/useViewingThread.ts
@@ -1,17 +1,35 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
 import METRIC from '~/const/metric'
 import { THREAD } from '~/const/thread'
-import useArticleList from '~/hooks/useArticleList'
 import useMetric from '~/hooks/useMetric'
 
 import type { TThread } from '~/spec'
 
+const isThread = (value: string): value is TThread => {
+  return Object.values(THREAD).includes(value as TThread)
+}
+
+const getThreadFromPathname = (pathname: string): TThread | null => {
+  const segments = pathname.split('/').filter(Boolean)
+  const maybeThread = segments.at(-1)
+
+  if (maybeThread && isThread(maybeThread)) {
+    return maybeThread
+  }
+
+  return null
+}
+
 export default (): TThread => {
+  const pathname = usePathname()
+
   const metric = useMetric()
   if (metric === METRIC.LANDING) {
     return THREAD.POST
   }
+  const thread = getThreadFromPathname(pathname)
 
-  const articleList$ = useArticleList()
-
-  return articleList$.thread
+  return thread ?? THREAD.POST
 }

--- a/frontend/core/proxies/avoid-scan.ts
+++ b/frontend/core/proxies/avoid-scan.ts
@@ -6,14 +6,6 @@ import { ROUTE } from '~/const/route'
 export function avoidScanProxy(req: NextRequest) {
   const { pathname } = req.nextUrl
 
-  // if (process.env.NODE_ENV === 'development') {
-  //   if (pathname.startsWith('/.well-known')) {
-  //     console.log('## -----> DEV MODE: Redirecting .well-known request to OOPS page.')
-
-  //     return NextResponse.redirect(new URL(ROUTE.OOPS, req.url))
-  //   }
-  // }
-
   // 检查pathname是否以.php或.php7结束
   if (pathname.endsWith('.php') || pathname.endsWith('.php7')) {
     // 重定向到/oops页面

--- a/frontend/core/stores/dashboard/index.ts
+++ b/frontend/core/stores/dashboard/index.ts
@@ -17,6 +17,7 @@ export default (init: TInit = {}): TStore => {
   const states = Object.assign(
     {
       metric: METRIC.COMMUNITY,
+      now: 0,
       ...FIELDS,
 
       // UI status

--- a/frontend/core/stores/dashboard/spec.d.ts
+++ b/frontend/core/stores/dashboard/spec.d.ts
@@ -164,10 +164,11 @@ export type TDsbFields = {
   widgetsType: TWidgetType
 }
 
-export type TInit = { metric?: TMetric } & Partial<TDsbFields>
+export type TInit = { metric?: TMetric; now?: number } & Partial<TDsbFields>
 
 export type TStore = TDsbFields & {
   metric?: TMetric
+  now?: number
   initFilled: boolean
   original: TDsbFields
 

--- a/frontend/core/stores/provider.tsx
+++ b/frontend/core/stores/provider.tsx
@@ -32,13 +32,14 @@ const MainProvider: FC<TProps> = ({
   metric = METRIC.COMMUNITY,
 }) => {
   const { dashboard, ...base } = initData
+  const now = Date.now()
 
   return (
     <ThemeStoreProvider>
       <LocaleStoreProvider initData={{ locale, localeData }}>
         <AccountWrapper noAccount={noAccount}>
           <CommunityStoreProvider initData={{ ...base }}>
-            <DashboardStoreProvider initData={{ ...dashboard, metric }}>
+            <DashboardStoreProvider initData={{ ...dashboard, metric, now }}>
               <WallpaperStoreProvider>{children}</WallpaperStoreProvider>
             </DashboardStoreProvider>
           </CommunityStoreProvider>

--- a/frontend/core/utils/fmt.ts
+++ b/frontend/core/utils/fmt.ts
@@ -265,3 +265,31 @@ export const fmt2CompStyle = (styleString: string): { [key: string]: string } =>
 
   return result
 }
+
+// for relative time
+// utils/formatRelativeTime.ts
+type Unit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year'
+
+const UNITS: readonly [Unit, number][] = [
+  ['year', 1000 * 60 * 60 * 24 * 365],
+  ['month', 1000 * 60 * 60 * 24 * 30],
+  ['week', 1000 * 60 * 60 * 24 * 7],
+  ['day', 1000 * 60 * 60 * 24],
+  ['hour', 1000 * 60 * 60],
+  ['minute', 1000 * 60],
+  ['second', 1000],
+]
+
+export const fmtRelativeTime = (from: string | Date, now: number, locale: string): string => {
+  const fromTime = typeof from === 'string' ? new Date(from).getTime() : from.getTime()
+  const diff = fromTime - now
+
+  for (const [unit, ms] of UNITS) {
+    const value = Math.trunc(diff / ms)
+    if (Math.abs(value) >= 1) {
+      return new Intl.RelativeTimeFormat(locale, { numeric: 'auto' }).format(value, unit)
+    }
+  }
+
+  return new Intl.RelativeTimeFormat(locale).format(0, 'second')
+}

--- a/frontend/core/widgets/ArticleCard/Footer.tsx
+++ b/frontend/core/widgets/ArticleCard/Footer.tsx
@@ -1,14 +1,13 @@
 import type { FC } from 'react'
-import TimeAgo from '~/widgets/TimeAgo'
-
 import { UPVOTE_LAYOUT } from '~/const/layout'
 import SIZE from '~/const/size'
+import { upvoteArticle } from '~/signal'
 
 import type { TArticle } from '~/spec'
-import { upvoteArticle } from '~/signal'
-import Upvote from '~/widgets/Upvote'
-import DotDivider from '~/widgets/DotDivider'
 import CommentsCount from '~/widgets/CommentsCount'
+import DotDivider from '~/widgets/DotDivider'
+import TimeAgo from '~/widgets/TimeAgo'
+import Upvote from '~/widgets/Upvote'
 
 import useSalon from './salon/footer'
 
@@ -23,8 +22,8 @@ const Footer: FC<TProps> = ({ data }) => {
   return (
     <div className={s.wrapper}>
       <div className={s.publish}>
-        {author.nickname} <DotDivider className="mx-1.5" />
-        <TimeAgo datetime={insertedAt} locale="zh_CN" />
+        {author.nickname} <DotDivider className='mx-1.5' />
+        <TimeAgo datetime={insertedAt} />
       </div>
       <div className={s.bottom}>
         <Upvote

--- a/frontend/core/widgets/NoticeBar/index.tsx
+++ b/frontend/core/widgets/NoticeBar/index.tsx
@@ -4,18 +4,16 @@
  *
  */
 
-import type { FC } from 'react'
 import Link from 'next/link'
-import TimeAgo from '~/widgets/TimeAgo'
+import type { FC } from 'react'
+import QuestionSVG from '~/icons/Question'
 
 import type { TSpace } from '~/spec'
-
-import QuestionSVG from '~/icons/Question'
-import Icon from './Icon'
-
-import type { TType } from './spec'
+import TimeAgo from '~/widgets/TimeAgo'
 import { TYPE } from './constant'
+import Icon from './Icon'
 import useSalon, { cn } from './salon'
+import type { TType } from './spec'
 
 type TProps = {
   testid?: string
@@ -53,7 +51,7 @@ const NoticeBar: FC<TProps> = ({
       </div>
       {timestamp && (
         <div className={s.timestamp}>
-          <TimeAgo datetime={timestamp} locale="zh_CN" />
+          <TimeAgo datetime={timestamp} />
         </div>
       )}
       {explainLink && (

--- a/frontend/core/widgets/PostItem/CoverLayout/Footer.tsx
+++ b/frontend/core/widgets/PostItem/CoverLayout/Footer.tsx
@@ -1,8 +1,8 @@
 import type { FC } from 'react'
-import TimeAgo from '~/widgets/TimeAgo'
+import { UPVOTE_LAYOUT } from '~/const/layout'
 
 import type { TPost } from '~/spec'
-import { UPVOTE_LAYOUT } from '~/const/layout'
+import TimeAgo from '~/widgets/TimeAgo'
 
 import Upvote from '~/widgets/Upvote'
 
@@ -27,9 +27,9 @@ const Footer: FC<TProps> = ({ article }) => {
         left={-2}
         top={-1}
       />
-      <div className="grow" />
+      <div className='grow' />
       <div className={s.createTime}>
-        <TimeAgo datetime={insertedAt} locale="zh_CN" />
+        <TimeAgo datetime={insertedAt} />
       </div>
     </div>
   )

--- a/frontend/core/widgets/PostItem/QuoraLayout/Header.tsx
+++ b/frontend/core/widgets/PostItem/QuoraLayout/Header.tsx
@@ -49,7 +49,7 @@ const Header: FC<TProps> = ({ article }) => {
         <div className={s.dot} />
         <div className='mr-0.5' />
         <div className={s.publish}>
-          <TimeAgo datetime={insertedAt} locale='zh_CN' suppressHydrationWarning />
+          <TimeAgo datetime={insertedAt} />
         </div>
       </div>
       <div className={s.main}>

--- a/frontend/core/widgets/TimeAgo/index.tsx
+++ b/frontend/core/widgets/TimeAgo/index.tsx
@@ -1,5 +1,30 @@
-import dynamic from 'next/dynamic'
+'use client'
 
-export default dynamic(() => import('timeago-react'), {
-  ssr: false,
-})
+import { useEffect, useState } from 'react'
+import useLocale from '~/hooks/useLocale'
+import useNow from '~/hooks/useNow'
+import { fmtRelativeTime } from '~/utils/fmt'
+
+type TProps = {
+  datetime: string | Date
+  tickInterval?: number // refresh every 1 min
+}
+
+export default function TimeAgo({ datetime, tickInterval = 60_000 }: TProps) {
+  const nowFromStore = useNow()
+  const { locale } = useLocale()
+
+  // 本地 state 用于触发自动刷新
+  const [_tick, setTick] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setTick((t) => t + 1)
+    }, tickInterval)
+    return () => clearInterval(id)
+  }, [tickInterval])
+
+  const text = fmtRelativeTime(datetime, nowFromStore, locale)
+
+  return <time dateTime={datetime instanceof Date ? datetime.toISOString() : datetime}>{text}</time>
+}

--- a/frontend/core/widgets/TimeAgo/index.tsx
+++ b/frontend/core/widgets/TimeAgo/index.tsx
@@ -14,7 +14,6 @@ export default function TimeAgo({ datetime, tickInterval = 60_000 }: TProps) {
   const nowFromStore = useNow()
   const { locale } = useLocale()
 
-  // 本地 state 用于触发自动刷新
   const [_tick, setTick] = useState(0)
 
   useEffect(() => {

--- a/frontend/core/widgets/TimeAgo/index.tsx
+++ b/frontend/core/widgets/TimeAgo/index.tsx
@@ -5,25 +5,24 @@ import useLocale from '~/hooks/useLocale'
 import useNow from '~/hooks/useNow'
 import { fmtRelativeTime } from '~/utils/fmt'
 
-type TProps = {
+type Props = {
   datetime: string | Date
-  tickInterval?: number // refresh every 1 min
+  tickInterval?: number // auto refresh in every min
 }
 
-export default function TimeAgo({ datetime, tickInterval = 60_000 }: TProps) {
+export default function TimeAgo({ datetime, tickInterval = 60_000 }: Props) {
   const nowFromStore = useNow()
   const { locale } = useLocale()
 
-  const [_tick, setTick] = useState(0)
+  const [tick, setTick] = useState(0)
 
   useEffect(() => {
-    const id = setInterval(() => {
-      setTick((t) => t + 1)
-    }, tickInterval)
+    const id = setInterval(() => setTick((t) => t + 1), tickInterval)
     return () => clearInterval(id)
   }, [tickInterval])
 
-  const text = fmtRelativeTime(datetime, nowFromStore, locale)
+  const now = tick === 0 ? nowFromStore : Date.now()
+  const text = fmtRelativeTime(datetime, now, locale)
 
   return <time dateTime={datetime instanceof Date ? datetime.toISOString() : datetime}>{text}</time>
 }

--- a/frontend/main/next-env.d.ts
+++ b/frontend/main/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/main/src/app/.well-known/route.ts
+++ b/frontend/main/src/app/.well-known/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return new Response('ok')
+}

--- a/package.json
+++ b/package.json
@@ -158,7 +158,6 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "4.1.13",
     "tailwindcss-animated": "^2.0.0",
-    "timeago-react": "3.0.7",
     "tinykeys": "^2.1.0",
     "tsparticles-confetti": "^2.12.0",
     "typewriter-effect": "^2.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,7 +1284,6 @@ __metadata:
     tailwind-merge: "npm:^3.3.1"
     tailwindcss: "npm:4.1.13"
     tailwindcss-animated: "npm:^2.0.0"
-    timeago-react: "npm:3.0.7"
     tinykeys: "npm:^2.1.0"
     tsc-files: "npm:^1.1.4"
     tsparticles-confetti: "npm:^2.12.0"
@@ -13751,24 +13750,6 @@ __metadata:
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
-  languageName: node
-  linkType: hard
-
-"timeago-react@npm:3.0.7":
-  version: 3.0.7
-  resolution: "timeago-react@npm:3.0.7"
-  dependencies:
-    timeago.js: "npm:^4.0.0"
-  peerDependencies:
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/32069e17428ed0245a30399e7689835f00651c543986320e6e9a0864ad3749d331c1384510661ca3db5dde67921273a48c51eb1dd8d7d02915d09b7bc999cc30
-  languageName: node
-  linkType: hard
-
-"timeago.js@npm:^4.0.0":
-  version: 4.0.2
-  resolution: "timeago.js@npm:4.0.2"
-  checksum: 10c0/e4cf66df2dfa2bc17db6e7a7c591d1e877e09e91e118784347a0b2390c38d7d292d2742e29edde9cdf4eaec61e8c4ef9b9f9c8b539f03d2613403dd7ccfc6cc8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved relative-time component with automatic refresh and new formatting utility
  * Added a small endpoint to respond to .well-known requests

* **Bug Fixes / Behavior**
  * Time display now uses app-managed timing source for more consistent timestamps

* **Style**
  * Consistent styling and string-quote cleanup across multiple UI components

* **Chores**
  * Removed an external timeago dependency and migrated to the in-app implementation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->