### PR TITLE
chore(fe): clean up route name

### DIFF
--- a/frontend/core/constant/route.ts
+++ b/frontend/core/constant/route.ts
@@ -8,7 +8,6 @@ export const DOCS = '/home/doc'
 
 export const DSB_ROUTE = {
   OVERVIEW: 'dashboard',
-  DASHBOARD: 'dashboard',
   // basic-info
   INFO: 'info',
   SEO: 'seo',

--- a/frontend/core/containers/thread/DashboardThread/SideMenu/Group.tsx
+++ b/frontend/core/containers/thread/DashboardThread/SideMenu/Group.tsx
@@ -41,14 +41,14 @@ const Group: FC<TProps> = ({ group }) => {
       {!fold && (
         <div className={s.menu}>
           {group.children.map((item) => {
-            const subPath = item.slug === DSB_ROUTE.DASHBOARD ? '' : item.slug
+            const subPath = item.slug === DSB_ROUTE.OVERVIEW ? '' : item.slug
             const isActive = item.slug === curTab
 
             return (
               <Link
                 key={item.slug}
                 className={cn(s.item, isActive && s.itemActive)}
-                href={`/${community}/${DSB_ROUTE.DASHBOARD}/${subPath}`}
+                href={`/${community}/${DSB_ROUTE.OVERVIEW}/${subPath}`}
               >
                 {isActive && <div className={s.itemActiveBar} />}
 

--- a/frontend/core/containers/thread/DashboardThread/constant.tsx
+++ b/frontend/core/containers/thread/DashboardThread/constant.tsx
@@ -83,7 +83,7 @@ export const MENU = {
     children: [
       {
         title: '概览',
-        slug: DSB_ROUTE.DASHBOARD,
+        slug: DSB_ROUTE.OVERVIEW,
       },
       {
         title: '基本信息',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized the dashboard route by removing DSB_ROUTE.DASHBOARD and using DSB_ROUTE.OVERVIEW. Updates the side menu to generate the correct overview link and highlight the active tab.

<sup>Written for commit 2240f3a576a6dae40839ef00d9ca13239bb26362. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced dashboard route references with overview route across navigation and menu components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->