### PR TITLE
fix(fe): add custom lint for double slash when import

### DIFF
--- a/frontend/core/biome.json
+++ b/frontend/core/biome.json
@@ -46,7 +46,7 @@
       },
       "correctness": {
         "useExhaustiveDependencies": "warn",
-        "noUnusedVariables": "warn" 
+        "noUnusedVariables": "warn"
       },
       "a11y": {
         "noSvgWithoutTitle": "off",

--- a/frontend/core/biome.json
+++ b/frontend/core/biome.json
@@ -31,11 +31,22 @@
       "style": {
         "noParameterAssign": "warn",
         "useImportType": "error",
-        "useComponentExportOnlyModules": "off"
+        "useComponentExportOnlyModules": "off",
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "patterns": [
+              {
+                "group": ["**//**"],
+                "message": "hi Luka: Import path contains double slashes (`//`). Please normalize the path."
+              }
+            ]
+          }
+        }
       },
       "correctness": {
         "useExhaustiveDependencies": "warn",
-        "noUnusedVariables": "warn"
+        "noUnusedVariables": "warn" 
       },
       "a11y": {
         "noSvgWithoutTitle": "off",
@@ -73,3 +84,4 @@
     }
   }
 }
+

--- a/frontend/dashboard/src/app/[community]/dashboard/alias/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/alias/layout.tsx
@@ -2,7 +2,7 @@
 
 import { ALIAS_TABS } from '~/const/route'
 import VIEW from '~/const/view'
-import Portal from '~/containers/thread/DashboardThread//Portal'
+import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon from '~/containers/thread/DashboardThread/salon/alias'
 import useDsbRouteTab from '~/hooks/useDsbRouteTab'
 import Tabs from '~/widgets/Switcher/Tabs'

--- a/frontend/dashboard/src/app/[community]/dashboard/third-part/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/third-part/layout.tsx
@@ -2,7 +2,7 @@
 
 import { THIRD_PART_TABS } from '~/const/route'
 import VIEW from '~/const/view'
-import Portal from '~/containers/thread/DashboardThread//Portal'
+import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon from '~/containers/thread/DashboardThread/salon/alias'
 import useDsbRouteTab from '~/hooks/useDsbRouteTab'
 import Tabs from '~/widgets/Switcher/Tabs'

--- a/frontend/dashboard/src/app/[community]/dashboard/widgets/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/widgets/layout.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { WIDGET_TABS } from '~/const/route'
-import Portal from '~/containers/thread/DashboardThread//Portal'
+import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon from '~/containers/thread/DashboardThread/salon/widgets'
 import BaseSetting from '~/containers/thread/DashboardThread/Widgets/BaseSetting'
 import useDsbRouteTab from '~/hooks/useDsbRouteTab'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a Biome lint rule to block double slashes in import paths and fixed existing double-slash imports in dashboard layout files. This prevents path issues and keeps imports consistent.

- **New Features**
  - Added noRestrictedImports in biome.json to error on import paths matching "**//**".

- **Bug Fixes**
  - Normalized Portal imports in alias, third-part, and widgets layouts (removed double slash).

<sup>Written for commit 3e326c2f90c128ce6454fdb697bc4cf3dedaaba3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed import path formatting issues in dashboard layout modules to ensure consistent component resolution.

* **Chores**
  * Added import path validation to linter configuration to automatically detect and prevent formatting errors in future changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->