### PR TITLE
feat(fe): breadcrumb for dashboard concept

### DIFF
--- a/frontend/core/constant/route.ts
+++ b/frontend/core/constant/route.ts
@@ -8,8 +8,10 @@ export const APPLY_COMMUNITY = '/apply/community'
 export const FEEDBACK = '/home/post?for=feedback'
 export const DOCS = '/home/doc'
 
+export const DSB_SEG = 'dashboard'
+
 export const DSB_ROUTE = {
-  OVERVIEW: 'dashboard',
+  OVERVIEW: DSB_SEG,
   // basic-info
   INFO: 'info',
   SEO: 'seo',

--- a/frontend/core/constant/route.ts
+++ b/frontend/core/constant/route.ts
@@ -213,3 +213,7 @@ export const WIDGET_TABS: TDsbTabs = {
     { title: '链接', slug: DSB_WIDGET_ROUTE.LINK },
   ],
 }
+
+export const DSB_COVERS = {
+  INTEGRATIONS: 'integrations',
+}

--- a/frontend/core/containers/thread/AboutThread/LabelList.tsx
+++ b/frontend/core/containers/thread/AboutThread/LabelList.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react'
-
-import type { TSpace } from '~/spec'
 import { Trans } from '~/i18n'
+import type { TSpace } from '~/spec'
 
 import useSalon from './salon/label_list'
 

--- a/frontend/core/containers/thread/AboutThread/salon/label_list.ts
+++ b/frontend/core/containers/thread/AboutThread/salon/label_list.ts
@@ -1,6 +1,5 @@
-import type { TSpace } from '~/spec'
-
 import useTwBelt from '~/hooks/useTwBelt'
+import type { TSpace } from '~/spec'
 
 type TProps = TSpace
 

--- a/frontend/core/containers/thread/DashboardThread/Portal.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Portal.tsx
@@ -1,18 +1,22 @@
 import type { FC, ReactNode } from 'react'
-
+import type { TBreadcrumbItem } from '~/spec'
+import BreadCrumb from '~/widgets/BreadCrumb'
 import useSalon from './salon/portal'
 
 type TProps = {
   title: string
   desc?: ReactNode
   withDivider?: boolean
+  crumbItems?: TBreadcrumbItem[]
 }
 
-const Portal: FC<TProps> = ({ title, desc = null, withDivider = true }) => {
+const Portal: FC<TProps> = ({ title, desc = null, withDivider = true, crumbItems = [] }) => {
   const s = useSalon()
 
   return (
     <div className={s.wrapper}>
+      {crumbItems?.length ? <BreadCrumb items={crumbItems} /> : null}
+
       <h3 className={s.title}>{title}</h3>
 
       {desc && <p className={s.desc}>{desc}</p>}

--- a/frontend/core/containers/thread/DashboardThread/Threads/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Threads/index.tsx
@@ -1,13 +1,10 @@
 import ToggleSwitch from '~/widgets/Buttons/ToggleSwitch'
-
-import DocThread from './DocThread'
-import AboutThread from './AboutThread'
-
+import useEnable from '../logic/useEnable'
 import Portal from '../Portal'
 import SectionLabel from '../SectionLabel'
-import useEnable from '../logic/useEnable'
-
 import useSalon from '../salon/threads'
+import AboutThread from './AboutThread'
+import DocThread from './DocThread'
 
 export default () => {
   const s = useSalon()
@@ -15,18 +12,18 @@ export default () => {
 
   return (
     <div className={s.wrapper}>
-      <Portal title="社区板块" desc="按需开启社区对外公开板块，关闭后不会导致内容删除。" />
+      <Portal title='社区板块' desc='按需开启社区对外公开板块，关闭后不会导致内容删除。' />
 
-      <div className="mb-10" />
+      <div className='mb-10' />
 
       <SectionLabel
-        title="讨论区"
+        title='讨论区'
         desc={
           <p className={s.desc}>用户可在此发帖，参与社区讨论，帖子可由团队管理员同步到看板墙。</p>
         }
         addon={
           <ToggleSwitch
-            size="small"
+            size='small'
             checked={settings.post}
             onChange={(c) => enableThread('post', c)}
           />
@@ -34,7 +31,7 @@ export default () => {
       />
       <div className={s.divider} />
       <SectionLabel
-        title="看板墙"
+        title='看板墙'
         desc={
           <p className={s.desc}>
             团队设置为 ToDo, Doing, Done 等状态的帖子会出现在这里，方便向用户同步进度。
@@ -46,7 +43,7 @@ export default () => {
       />
       <div className={s.divider} />
       <SectionLabel
-        title="更新日志"
+        title='更新日志'
         desc={
           <p className={s.desc}>
             新版本发布的新功能，Bug 修复以或性能，UI 优化等，用户同时可以查询历史版本信息。
@@ -61,7 +58,7 @@ export default () => {
       />
       <div className={s.divider} />
       <SectionLabel
-        title="帮助台"
+        title='帮助台'
         desc={<p className={s.desc}>和社区内容相关的开发文档，指南，知识库等等信息。</p>}
         addon={<ToggleSwitch checked={settings.doc} onChange={(c) => enableThread('help', c)} />}
       />
@@ -70,7 +67,7 @@ export default () => {
       <div className={s.divider} />
 
       <SectionLabel
-        title="关于"
+        title='关于'
         desc={<p className={s.desc}>社区基本信息。若更新请到基本信息设置区。</p>}
         addon={<ToggleSwitch checked={settings.about} onChange={(c) => enableThread('about', c)} />}
       />

--- a/frontend/core/containers/thread/DashboardThread/salon/portal.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/portal.ts
@@ -5,8 +5,8 @@ export default () => {
 
   return {
     wrapper: 'column w-full',
-    title: cn('text-lg w-auto', fg('text.title')),
-    desc: cn('text-sm mt-2.5', fg('text.digest')),
+    title: cn('text-xl w-auto', fg('text.title')),
+    desc: cn('text-sm mt-2.5 mb-2', fg('text.digest')),
     divider: cn('w-full h-px mt-5 mb-8', bg('divider')),
   }
 }

--- a/frontend/core/containers/thread/DashboardThread/salon/side_menu/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/side_menu/index.ts
@@ -4,6 +4,6 @@ export default () => {
   const { cn, fg } = useTwBelt()
 
   return {
-    wrapper: cn('column w-40 min-w-40 pt-9', fg('text.digest')),
+    wrapper: cn('column w-40 min-w-40', fg('text.digest')),
   }
 }

--- a/frontend/core/containers/thread/DashboardThread/salon/threads/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/threads/index.ts
@@ -4,7 +4,7 @@ export default () => {
   const { cn, divider } = useTwBelt()
 
   return {
-    wrapper: cn('w-96 ml-40'),
+    wrapper: cn('w-96'),
     desc: 'w-4/5 leading-relaxed',
     divider: cn(divider(), 'mt-6 mb-8'),
   }

--- a/frontend/core/hooks/useDsbCrumbItems.ts
+++ b/frontend/core/hooks/useDsbCrumbItems.ts
@@ -4,35 +4,83 @@ import { usePathname } from 'next/navigation'
 import { useMemo } from 'react'
 import { DSB_SEG } from '~/const/route'
 import useCommunity from '~/hooks/useCommunity'
-import type { TBreadcrumbItem, TDsbCrumbItem } from '~/spec'
 
-export default function useDsbCrumbItems(crumbs: TDsbCrumbItem[]): TBreadcrumbItem[] {
+export type TBreadcrumbItem = { title: string; path: string }
+
+export type TDsbCrumbNode = {
+  title: string
+
+  /**
+   * Segment used for matching current pathname (route semantics).
+   * Example: 'third-part/email'
+   */
+  seg: string
+
+  /**
+   * Segment used for navigation when clicking breadcrumb (link semantics).
+   * If omitted, defaults to `seg`.
+   * Example: for "绑定集成" you may match 'third-part' but link to 'integrations'.
+   */
+  toSeg?: string
+
+  children?: TDsbCrumbNode[]
+}
+
+const joinPath = (...parts: string[]) =>
+  '/' +
+  parts
+    .filter(Boolean)
+    .map((p) => p.replace(/^\/+|\/+$/g, ''))
+    .join('/')
+
+const pickBestChild = (relative: string, children: TDsbCrumbNode[]): TDsbCrumbNode | null => {
+  const candidates = children.filter((c) => relative.startsWith(`/${c.seg}`))
+  if (!candidates.length) return null
+  candidates.sort((a, b) => b.seg.length - a.seg.length)
+  return candidates[0]
+}
+
+const buildActiveChain = (relative: string, root: TDsbCrumbNode): TDsbCrumbNode[] => {
+  const chain: TDsbCrumbNode[] = [root]
+  let current: TDsbCrumbNode | null = root
+
+  while (current?.children?.length) {
+    const next = pickBestChild(relative, current.children)
+    if (!next) break
+    chain.push(next)
+    current = next
+  }
+
+  return chain
+}
+
+export default function useDsbCrumbItems(root: TDsbCrumbNode): TBreadcrumbItem[] {
   const pathname = usePathname()
-  const { slug } = useCommunity() // e.g. 'home'
+  const { slug } = useCommunity()
 
   return useMemo(() => {
-    if (!pathname || !slug || !crumbs.length) return []
+    if (!pathname || !slug) return []
 
-    const base = `/${slug}/${DSB_SEG}` // /home/dashboard
+    const idx = pathname.indexOf(`/${DSB_SEG}`)
+    if (idx === -1) return []
 
-    if (!pathname.startsWith(base)) return []
+    const fromDashboard = pathname.slice(idx) // /dashboard/xxx
+    const relative = fromDashboard.slice(`/${DSB_SEG}`.length) || '/' // /third-part/xxx
 
-    const relative = pathname.slice(base.length) || '/' // /domain/custom
+    if (!relative.startsWith(`/${root.seg}`)) return []
 
-    const reversed = [...crumbs].reverse()
-    const reversedIndex = reversed.findIndex((c) => relative.startsWith(`/${c.seg}`))
+    // cover page defaults to the first child
+    const isOnRoot = relative === `/${root.seg}` || relative === `/${root.seg}/`
+    const firstChildSeg = root.children?.[0]?.seg
+    const effectiveRelative = isOnRoot && firstChildSeg ? `/${firstChildSeg}` : relative
 
-    if (reversedIndex === -1) return []
+    const chain = buildActiveChain(effectiveRelative, root)
 
-    const end = crumbs.length - reversedIndex
-
-    return crumbs.slice(0, end).map((c, index, arr) => {
-      const fullPath = `${base}/${c.seg}`
-
-      return {
-        title: c.title,
-        path: index === arr.length - 1 ? '' : fullPath,
-      }
+    return chain.map((node, i) => {
+      const to = node.toSeg ?? node.seg
+      const full = joinPath(slug, DSB_SEG, to)
+      const isLast = i === chain.length - 1
+      return { title: node.title, path: isLast ? '' : full }
     })
-  }, [pathname, slug, crumbs])
+  }, [pathname, slug, root])
 }

--- a/frontend/core/hooks/useDsbCrumbItems.ts
+++ b/frontend/core/hooks/useDsbCrumbItems.ts
@@ -1,0 +1,38 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useMemo } from 'react'
+import { DSB_SEG } from '~/const/route'
+import useCommunity from '~/hooks/useCommunity'
+import type { TBreadcrumbItem, TDsbCrumbItem } from '~/spec'
+
+export default function useDsbCrumbItems(crumbs: TDsbCrumbItem[]): TBreadcrumbItem[] {
+  const pathname = usePathname()
+  const { slug } = useCommunity() // e.g. 'home'
+
+  return useMemo(() => {
+    if (!pathname || !slug || !crumbs.length) return []
+
+    const base = `/${slug}/${DSB_SEG}` // /home/dashboard
+
+    if (!pathname.startsWith(base)) return []
+
+    const relative = pathname.slice(base.length) || '/' // /domain/custom
+
+    const reversed = [...crumbs].reverse()
+    const reversedIndex = reversed.findIndex((c) => relative.startsWith(`/${c.seg}`))
+
+    if (reversedIndex === -1) return []
+
+    const end = crumbs.length - reversedIndex
+
+    return crumbs.slice(0, end).map((c, index, arr) => {
+      const fullPath = `${base}/${c.seg}`
+
+      return {
+        title: c.title,
+        path: index === arr.length - 1 ? '' : fullPath,
+      }
+    })
+  }, [pathname, slug, crumbs])
+}

--- a/frontend/core/spec/index.ts
+++ b/frontend/core/spec/index.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable import/no-unresolved */
-/* eslint-disable import/extensions */
 import type { TArticle } from './article'
 import type { TCommunity } from './community'
 import type { TThemeName } from './theme'
@@ -26,13 +23,6 @@ export type * from './theme'
 export type * from './thread'
 export type * from './utils'
 export type * from './wallpaper'
-
-export type TRoute = {
-  communityPath?: string
-  threadPath?: string
-  mainPath?: string
-  subPath?: string
-}
 
 export type TViewing = TCommunity | TArticle
 
@@ -65,25 +55,5 @@ interface IWindow extends Window {
 }
 
 export type TWindow = IWindow | null
-
-export type TPathQuery =
-  | 'pagedDocs'
-  | 'pagedChangelogs'
-  | 'pagedBlogs'
-  | 'pagedPosts'
-  | 'doc'
-  | 'changelog'
-  | 'blog'
-  | 'post'
-  | 'community'
-  | 'tags'
-  | 'kanbanPosts'
-
-export type TSearchParams = { [key: string]: string | string[] | undefined }
-
-export type TUrlInfo = {
-  pathname: string
-  searchParams: URLSearchParams
-}
 
 export type TConstValues<T extends Record<PropertyKey, string>> = T[keyof T]

--- a/frontend/core/spec/route.ts
+++ b/frontend/core/spec/route.ts
@@ -31,3 +31,15 @@ export type TPath =
   | {
       DASHBOARD: TDsbPath
     }
+
+export type TDsbCrumbItem = {
+  title: string
+  seg: string
+}
+
+export type TBreadcrumbItem = {
+  key?: string
+  title: string
+  path: string
+  onClick?: () => void
+}

--- a/frontend/core/spec/route.ts
+++ b/frontend/core/spec/route.ts
@@ -1,3 +1,5 @@
+import type { ComponentType } from 'react'
+
 import type {
   DSB_ALIAS_ROUTE,
   DSB_BROADCAST_ROUTE,
@@ -42,4 +44,17 @@ export type TBreadcrumbItem = {
   title: string
   path: string
   onClick?: () => void
+}
+
+export type TIconComp = ComponentType<{ className?: string }>
+
+export type TDsbCoverItem = TDsbCrumbItem & {
+  desc: string
+  Icon?: TIconComp
+}
+
+export type TDsbCoversConfig = {
+  title: string
+  desc?: React.ReactNode
+  items: TDsbCoverItem[]
 }

--- a/frontend/core/spec/route.ts
+++ b/frontend/core/spec/route.ts
@@ -48,13 +48,28 @@ export type TBreadcrumbItem = {
 
 export type TIconComp = ComponentType<{ className?: string }>
 
-export type TDsbCoverItem = TDsbCrumbItem & {
+export type TDsbCoverItem = {
+  title: string
   desc: string
+  seg: string
   Icon?: TIconComp
+
+  pinned?: boolean
+}
+
+export type TDsbCoverGroup = {
+  groupTitle: string
+  items: TDsbCoverItem[]
 }
 
 export type TDsbCoversConfig = {
   title: string
   desc?: React.ReactNode
-  items: TDsbCoverItem[]
+  items: TDsbCoverGroup[]
+
+  /**
+   * Called when user clicks the pin button on a card.
+   * The host page owns the state; DsbCovers is purely presentational.
+   */
+  onTogglePin?: (seg: string, nextPinned: boolean) => void
 }

--- a/frontend/core/widgets/BreadCrumb/index.tsx
+++ b/frontend/core/widgets/BreadCrumb/index.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link'
+import type { FC } from 'react'
+import type { TBreadcrumbItem, TSpace } from '~/spec'
+
+import useSalon, { cn } from './salon'
+
+type Props = {
+  items: TBreadcrumbItem[]
+  separator?: React.ReactNode
+} & TSpace
+
+const BreadCrumb: FC<Props> = ({ items, separator = '/', ...spacing }) => {
+  const s = useSalon(spacing)
+
+  if (!items.length) return null
+
+  return (
+    <nav aria-label='Breadcrumb' className={s.wrapper}>
+      <ol className={s.ol}>
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1
+          const clickable = !isLast && item.path
+
+          return (
+            <li key={item?.key || item.path} className={s.li}>
+              {clickable ? (
+                <Link href={item.path} className={cn(s.item, s.itemHover)}>
+                  {item.title}
+                </Link>
+              ) : (
+                <span aria-current={isLast ? 'page' : undefined} className={cn(s.item, s.curPath)}>
+                  {item.title}
+                </span>
+              )}
+
+              {!isLast && (
+                <span aria-hidden className={s.divider}>
+                  {separator}
+                </span>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}
+
+export default BreadCrumb

--- a/frontend/core/widgets/BreadCrumb/salon/index.ts
+++ b/frontend/core/widgets/BreadCrumb/salon/index.ts
@@ -1,0 +1,20 @@
+import useTwBelt from '~/hooks/useTwBelt'
+import type { TSpace } from '~/spec'
+
+export { cn } from '~/css'
+
+type TProps = TSpace
+
+export default ({ ...spacing }: TProps) => {
+  const { cn, fg, margin, hover } = useTwBelt()
+
+  return {
+    wrapper: cn('mb-2.5 -ml-0.5', margin(spacing)),
+    li: 'row-center group',
+    item: cn('text-xs py-0.5 px-1'),
+    itemHover: cn(hover('bg'), hover('fg')),
+    ol: 'row-center',
+    curPath: cn('', fg('text.digest')),
+    divider: cn('text-xs mx-1.5', fg('text.hint')),
+  }
+}

--- a/frontend/core/widgets/DsbCovers/index.tsx
+++ b/frontend/core/widgets/DsbCovers/index.tsx
@@ -4,8 +4,9 @@ import Link from 'next/link'
 import { DSB_SEG } from '~/const/route'
 import Portal from '~/containers/thread/DashboardThread/Portal'
 import useCommunity from '~/hooks/useCommunity'
+import PinSVG from '~/icons/Pin'
 import type { TDsbCoversConfig } from '~/spec'
-import useSalon from './salon'
+import useSalon, { cn } from './salon'
 
 const joinPath = (...parts: string[]) =>
   '/' +
@@ -20,23 +21,56 @@ type Props = {
 
 export default function DsbCovers({ config }: Props) {
   const s = useSalon()
-  const { slug } = useCommunity() // e.g. 'home'
+  const { slug } = useCommunity()
 
   const buildHref = (seg: string) => joinPath(slug, DSB_SEG, seg)
 
   return (
     <div className={s.wrapper}>
-      <Portal title={config.title} desc={config.desc} withDivider={false} />
+      <Portal title={config.title} desc={config.desc} withDivider />
 
-      <div className={s.content}>
-        {config.items.map((it) => (
-          <Link key={it.seg} className={s.block} href={buildHref(it.seg)}>
-            {it.Icon ? <it.Icon className={s.icon} /> : null}
-            <div className='mt-auto'>
-              <div className={s.title}>{it.title}</div>
-              <p className={s.desc}>{it.desc}</p>
+      <div className={s.groups}>
+        {config.items.map((group) => (
+          <section key={group.groupTitle} className={s.group}>
+            <div className={s.groupHeader}>
+              <h4 className={s.groupTitle}>{group.groupTitle}</h4>
             </div>
-          </Link>
+
+            <div className={s.content}>
+              {group.items.map((it) => {
+                const pinned = Boolean(it.pinned)
+
+                return (
+                  <Link
+                    key={`${group.groupTitle}:${it.seg}`}
+                    className={s.block}
+                    href={buildHref(it.seg)}
+                  >
+                    <button
+                      type='button'
+                      className={cn(s.pinBtn, pinned && s.pinBtnActive)}
+                      aria-pressed={pinned}
+                      aria-label={pinned ? '取消置顶' : '置顶'}
+                      onClick={(e) => {
+                        e.preventDefault()
+                        e.stopPropagation()
+                        config.onTogglePin?.(it.seg, !pinned)
+                      }}
+                    >
+                      <PinSVG className={cn(s.pinIcon, pinned && s.pinIconActive)} />
+                    </button>
+
+                    {it.Icon ? <it.Icon className={s.icon} /> : null}
+
+                    <div className='mt-auto'>
+                      <div className={s.title}>{it.title}</div>
+                      <p className={s.desc}>{it.desc}</p>
+                    </div>
+                  </Link>
+                )
+              })}
+            </div>
+          </section>
         ))}
       </div>
     </div>

--- a/frontend/core/widgets/DsbCovers/index.tsx
+++ b/frontend/core/widgets/DsbCovers/index.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import Link from 'next/link'
+import { DSB_SEG } from '~/const/route'
+import Portal from '~/containers/thread/DashboardThread/Portal'
+import useCommunity from '~/hooks/useCommunity'
+import type { TDsbCoversConfig } from '~/spec'
+import useSalon from './salon'
+
+const joinPath = (...parts: string[]) =>
+  '/' +
+  parts
+    .filter(Boolean)
+    .map((p) => p.replace(/^\/+|\/+$/g, ''))
+    .join('/')
+
+type Props = {
+  config: TDsbCoversConfig
+}
+
+export default function DsbCovers({ config }: Props) {
+  const s = useSalon()
+  const { slug } = useCommunity() // e.g. 'home'
+
+  const buildHref = (seg: string) => joinPath(slug, DSB_SEG, seg)
+
+  return (
+    <div className={s.wrapper}>
+      <Portal title={config.title} desc={config.desc} withDivider={false} />
+
+      <div className={s.content}>
+        {config.items.map((it) => (
+          <Link key={it.seg} className={s.block} href={buildHref(it.seg)}>
+            {it.Icon ? <it.Icon className={s.icon} /> : null}
+            <div className='mt-auto'>
+              <div className={s.title}>{it.title}</div>
+              <p className={s.desc}>{it.desc}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/core/widgets/DsbCovers/salon.ts
+++ b/frontend/core/widgets/DsbCovers/salon.ts
@@ -3,13 +3,20 @@ import useTwBelt from '~/hooks/useTwBelt'
 export { cn } from '~/css'
 
 export default () => {
-  const { cn, fg, hoverBr, bg, fill, primary, isBlackPrimary } = useTwBelt()
+  const { cn, fg, hoverBr, hover, bg, fill, primary, isBlackPrimary } = useTwBelt()
 
   return {
     wrapper: 'column w-3/5',
-    content: cn('grid w-full gap-4', 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-8 -ml-0.5'),
+
+    groups: cn('column w-full mt-8 gap-8'),
+    group: cn('column w-full'),
+    groupHeader: cn('row items-center justify-between -ml-0.5 mb-3'),
+    groupTitle: cn('text-sm font-medium tracking-wide', fg('text.title')),
+
+    content: cn('grid w-full gap-4', 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 -ml-0.5'),
 
     block: cn(
+      'group relative',
       'h-36 w-full rounded-md px-4 py-4 pointer',
       'column',
       'trans-all-100',
@@ -19,6 +26,20 @@ export default () => {
 
     title: cn('text-base', fg('text.title')),
     desc: cn('text-xs', fg('text.digest')),
-    icon: cn('size-5 ml-1 mt-1 opacity-80', primary('fill'), isBlackPrimary && fill('text.link')),
+
+    icon: cn('size-5 ml-1 mt-1 opacity-50', primary('fill'), isBlackPrimary && fill('text.link')),
+
+    // Pin button
+    pinBtn: cn(
+      'align-both',
+      'absolute right-2 top-3',
+      'size-7 circle',
+      'trans-all-100',
+      hover('bg'),
+    ),
+
+    pinBtnActive: cn(bg('alphaBg')),
+    pinIcon: cn('size-4 rotate-12 group-smoky-0', fill('text.digest')),
+    pinIconActive: cn('opacity-80', primary('fill'), isBlackPrimary && fill('text.link')),
   }
 }

--- a/frontend/core/widgets/DsbCovers/salon.ts
+++ b/frontend/core/widgets/DsbCovers/salon.ts
@@ -1,0 +1,24 @@
+import useTwBelt from '~/hooks/useTwBelt'
+
+export { cn } from '~/css'
+
+export default () => {
+  const { cn, fg, hoverBr, bg, fill, primary, isBlackPrimary } = useTwBelt()
+
+  return {
+    wrapper: 'column w-3/5',
+    content: cn('grid w-full gap-4', 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mt-8 -ml-0.5'),
+
+    block: cn(
+      'h-36 w-full rounded-md px-4 py-4 pointer',
+      'column',
+      'trans-all-100',
+      hoverBr(),
+      bg('alphaBg'),
+    ),
+
+    title: cn('text-base', fg('text.title')),
+    desc: cn('text-xs', fg('text.digest')),
+    icon: cn('size-5 ml-1 mt-1 opacity-80', primary('fill'), isBlackPrimary && fill('text.link')),
+  }
+}

--- a/frontend/dashboard/src/app/[community]/dashboard/domain/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/domain/layout.tsx
@@ -4,6 +4,7 @@ import { DOMAIN_TABS } from '~/const/route'
 import VIEW from '~/const/view'
 import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon, { cn } from '~/containers/thread/DashboardThread/salon/layout'
+import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
 import useDsbLayoutTabs from '~/hooks/useDsbLayoutTabs'
 import Tabs from '~/widgets/Switcher/Tabs'
 
@@ -11,9 +12,20 @@ export default ({ children }) => {
   const s = useSalon()
   const { items, activeTab } = useDsbLayoutTabs(DOMAIN_TABS)
 
+  const crumbItems = useDsbCrumbItems([
+    { title: '绑定集成', seg: 'integrations' },
+    { title: '域名绑定', seg: 'domain' },
+    { title: '自定义域名', seg: 'domain/custom' },
+  ])
+
   return (
     <div className={cn(s.wrapper, 'w-3/5')}>
-      <Portal title='域名设置' desc='给你的社区绑定个性化域名。' withDivider={false} />
+      <Portal
+        title='域名设置'
+        desc='给你的社区绑定个性化域名。'
+        withDivider={false}
+        crumbItems={crumbItems}
+      />
       <div className={s.banner}>
         <div className={s.tabs}>
           <Tabs items={items} activeKey={activeTab} view={VIEW.DESKTOP} noAnimation />

--- a/frontend/dashboard/src/app/[community]/dashboard/domain/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/domain/layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { DOMAIN_TABS } from '~/const/route'
+import { DOMAIN_TABS, DSB_COVERS } from '~/const/route'
 import VIEW from '~/const/view'
 import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon, { cn } from '~/containers/thread/DashboardThread/salon/layout'
@@ -8,15 +8,22 @@ import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
 import useDsbLayoutTabs from '~/hooks/useDsbLayoutTabs'
 import Tabs from '~/widgets/Switcher/Tabs'
 
+const seg = DOMAIN_TABS.segment
+export const CRUMB_CONFIG = {
+  title: '域名绑定',
+  seg,
+  toSeg: DSB_COVERS.INTEGRATIONS,
+  children: [
+    { title: '平台子域名', seg },
+    { title: '自定义域名', seg: `${seg}/custom` },
+  ],
+}
+
 export default ({ children }) => {
   const s = useSalon()
   const { items, activeTab } = useDsbLayoutTabs(DOMAIN_TABS)
 
-  const crumbItems = useDsbCrumbItems([
-    { title: '绑定集成', seg: 'integrations' },
-    { title: '域名绑定', seg: 'domain' },
-    { title: '自定义域名', seg: 'domain/custom' },
-  ])
+  const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
   return (
     <div className={cn(s.wrapper, 'w-3/5')}>

--- a/frontend/dashboard/src/app/[community]/dashboard/integrations/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/integrations/page.tsx
@@ -1,6 +1,12 @@
 'use client'
 
+import { DSB_DOMAIN_ROUTE, DSB_ROUTE, DSB_THIRD_PART_ROUTE } from '~/const/route'
 import BindSVG from '~/icons/Bind'
+import BotSVG from '~/icons/Bot'
+import DomainSVG from '~/icons/Domain'
+import AnalysisSVG from '~/icons/Pulse'
+import EmailSVG from '~/icons/social/Email'
+import WebhookSVG from '~/icons/Webhook'
 import DsbCovers from '~/widgets/DsbCovers'
 
 export default function IntegrationsPage() {
@@ -8,19 +14,59 @@ export default function IntegrationsPage() {
     <DsbCovers
       config={{
         title: '绑定与集成',
-        desc: '社区内容的个性化设置',
+        desc: '社区与第三方服务的配置，绑定以及交互策略设置。',
         items: [
           {
-            title: '平台域名',
-            desc: 'Groupher 社区子域名设置',
-            seg: 'domain',
-            Icon: BindSVG,
+            groupTitle: '域名绑定',
+            items: [
+              {
+                title: '平台域名',
+                desc: 'Groupher 社区子域名设置',
+                seg: DSB_ROUTE.DOMAIN,
+                Icon: BindSVG,
+              },
+              {
+                title: '自定义域名',
+                desc: '绑定社区到外部域名',
+                seg: `${DSB_ROUTE.DOMAIN}/${DSB_DOMAIN_ROUTE.CUSTOM}`,
+                Icon: DomainSVG,
+              },
+            ],
           },
           {
-            title: '自定义域名',
-            desc: '绑定社区到外部域名',
-            seg: 'domain/custom',
-            Icon: BindSVG,
+            groupTitle: '三方集成',
+            items: [
+              {
+                title: '统计分析',
+                desc: 'Groupher 社区子域名设置',
+                seg: DSB_ROUTE['THIRD-PART'],
+                Icon: AnalysisSVG,
+              },
+              {
+                title: 'Webhooks',
+                desc: '绑定社区到外部域名',
+                seg: `${DSB_ROUTE['THIRD-PART']}/${DSB_THIRD_PART_ROUTE.WEBHOOKS}`,
+                Icon: WebhookSVG,
+              },
+              {
+                title: '消息机器人',
+                desc: '绑定社区到外部域名',
+                seg: `${DSB_ROUTE['THIRD-PART']}/${DSB_THIRD_PART_ROUTE.BOTS}`,
+                Icon: BotSVG,
+              },
+              {
+                title: '电子邮件',
+                desc: '绑定社区到外部域名',
+                seg: `${DSB_ROUTE['THIRD-PART']}/${DSB_THIRD_PART_ROUTE.EMAIL}`,
+                Icon: EmailSVG,
+              },
+              {
+                title: '内容同步',
+                desc: '绑定社区到外部域名',
+                seg: `${DSB_ROUTE['THIRD-PART']}/${DSB_THIRD_PART_ROUTE.CONTENT_SYNC}`,
+                Icon: BindSVG,
+              },
+            ],
           },
         ],
       }}

--- a/frontend/dashboard/src/app/[community]/dashboard/integrations/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/integrations/page.tsx
@@ -14,20 +14,20 @@ export default function IntegrationsPage() {
     <DsbCovers
       config={{
         title: '绑定与集成',
-        desc: '社区与第三方服务的配置，绑定以及交互策略设置。',
+        desc: '社区与第三方服务的配置、绑定及交互策略设置。',
         items: [
           {
             groupTitle: '域名绑定',
             items: [
               {
                 title: '平台域名',
-                desc: 'Groupher 社区子域名设置',
+                desc: '使用 Groupher 提供的官方子域名访问社区。',
                 seg: DSB_ROUTE.DOMAIN,
                 Icon: BindSVG,
               },
               {
                 title: '自定义域名',
-                desc: '绑定社区到外部域名',
+                desc: '将社区绑定到你自己的域名。',
                 seg: `${DSB_ROUTE.DOMAIN}/${DSB_DOMAIN_ROUTE.CUSTOM}`,
                 Icon: DomainSVG,
               },
@@ -38,31 +38,31 @@ export default function IntegrationsPage() {
             items: [
               {
                 title: '统计分析',
-                desc: 'Groupher 社区子域名设置',
+                desc: '接入第三方分析工具，追踪访问量、用户行为与内容表现。',
                 seg: DSB_ROUTE['THIRD-PART'],
                 Icon: AnalysisSVG,
               },
               {
                 title: 'Webhooks',
-                desc: '绑定社区到外部域名',
+                desc: '在社区事件发生时向外部系统推送实时通知',
                 seg: `${DSB_ROUTE['THIRD-PART']}/${DSB_THIRD_PART_ROUTE.WEBHOOKS}`,
                 Icon: WebhookSVG,
               },
               {
                 title: '消息机器人',
-                desc: '绑定社区到外部域名',
+                desc: '将社区动态同步到聊天工具，用于团队通知与协作。',
                 seg: `${DSB_ROUTE['THIRD-PART']}/${DSB_THIRD_PART_ROUTE.BOTS}`,
                 Icon: BotSVG,
               },
               {
                 title: '电子邮件',
-                desc: '绑定社区到外部域名',
+                desc: '配置社区邮件发送策略，包括通知、订阅与系统邮件。',
                 seg: `${DSB_ROUTE['THIRD-PART']}/${DSB_THIRD_PART_ROUTE.EMAIL}`,
                 Icon: EmailSVG,
               },
               {
                 title: '内容同步',
-                desc: '绑定社区到外部域名',
+                desc: '将社区内容同步到外部平台或从其他系统导入内容。',
                 seg: `${DSB_ROUTE['THIRD-PART']}/${DSB_THIRD_PART_ROUTE.CONTENT_SYNC}`,
                 Icon: BindSVG,
               },

--- a/frontend/dashboard/src/app/[community]/dashboard/integrations/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/integrations/page.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import BindSVG from '~/icons/Bind'
+import DsbCovers from '~/widgets/DsbCovers'
+
+export default function IntegrationsPage() {
+  return (
+    <DsbCovers
+      config={{
+        title: '绑定与集成',
+        desc: '社区内容的个性化设置',
+        items: [
+          {
+            title: '平台域名',
+            desc: 'Groupher 社区子域名设置',
+            seg: 'domain',
+            Icon: BindSVG,
+          },
+          {
+            title: '自定义域名',
+            desc: '绑定社区到外部域名',
+            seg: 'domain/custom',
+            Icon: BindSVG,
+          },
+        ],
+      }}
+    />
+  )
+}

--- a/frontend/dashboard/src/app/[community]/dashboard/salon/index.ts
+++ b/frontend/dashboard/src/app/[community]/dashboard/salon/index.ts
@@ -6,7 +6,7 @@ export default () => {
   return {
     wrapper: cn('column-center justify-start min-h-full w-full'),
     inner: cn('column-center w-full'),
-    content: 'row w-full min-h-screen',
-    main: 'column items-center mt-7 grow bg-transparent',
+    content: 'row w-full min-h-screen mt-7',
+    main: 'column items-center grow bg-transparent',
   }
 }

--- a/frontend/dashboard/src/app/[community]/dashboard/third-part/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/third-part/layout.tsx
@@ -1,15 +1,31 @@
 'use client'
 
-import { THIRD_PART_TABS } from '~/const/route'
+import { DSB_COVERS, THIRD_PART_TABS } from '~/const/route'
 import VIEW from '~/const/view'
 import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon from '~/containers/thread/DashboardThread/salon/alias'
+import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
 import useDsbLayoutTabs from '~/hooks/useDsbLayoutTabs'
 import Tabs from '~/widgets/Switcher/Tabs'
+
+const seg = THIRD_PART_TABS.segment
+const CRUMB_CONFIG = {
+  title: '绑定集成',
+  seg,
+  toSeg: DSB_COVERS.INTEGRATIONS,
+  children: [
+    { title: '统计分析', seg },
+    { title: 'Webhooks', seg: `${seg}/webhooks` },
+    { title: '消息机器人', seg: `${seg}/bots` },
+    { title: '电子邮件', seg: `${seg}/email` },
+    { title: '内容同步', seg: `${seg}/content-sync` },
+  ],
+}
 
 export default ({ children }) => {
   const s = useSalon()
   const { items, activeTab } = useDsbLayoutTabs(THIRD_PART_TABS)
+  const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
   return (
     <div className={s.wrapper}>
@@ -17,6 +33,7 @@ export default ({ children }) => {
         title='绑定集成'
         desc='将社区与外部系统连接，实现数据同步、事件通知与协作管理。支持统计分析、Webhook 事件推送、即时通讯 Bot 及内容同步等集成方式。'
         withDivider={false}
+        crumbItems={crumbItems}
       />
       <div className={s.banner}>
         <div className={s.tabs}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added breadcrumb navigation for dashboard settings and a new Integrations cover page. Improves orientation and quick navigation across domain and third‑party sections.

- **New Features**
  - BreadCrumb widget with useDsbCrumbItems; shown in Domain and Third‑party layouts.
  - DsbCovers component and /dashboard/integrations page with grouped cover cards.
  - Routing/types updates: normalized dashboard segment (DSB_SEG), added DSB_COVERS.integrations and cover config types.

- **Refactors**
  - Portal accepts crumbItems to render breadcrumbs; small style tweaks in portal, side menu, and threads.
  - Removed unused route/search types from spec.

<sup>Written for commit a2923624060e24c9be39eff8089dc3a7b016e857. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breadcrumb navigation added to dashboard pages for clearer, clickable navigation trails.
  * New integrations overview page with grouped cover cards for domain bindings and third‑party services, including icons and pin/unpin actions.

* **Style**
  * Refined portal typography and spacing.
  * Adjusted dashboard layout spacing for improved visual hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->