### PR TITLE
refactor(fe): dashboard more cover pages

### DIFF
--- a/frontend/core/constant/route.ts
+++ b/frontend/core/constant/route.ts
@@ -216,4 +216,5 @@ export const WIDGET_TABS: TDsbTabs = {
 
 export const DSB_COVERS = {
   INTEGRATIONS: 'integrations',
+  WORKPLACE: 'workplace',
 }

--- a/frontend/core/constant/route.ts
+++ b/frontend/core/constant/route.ts
@@ -140,7 +140,7 @@ export const DSB_TAB = {
 export const INFO_TABS: TDsbTabs = {
   segment: DSB_ROUTE.INFO,
   items: [
-    { title: '基本信息', slug: DSB_INFO_ROUTE.BASIC, segment: '' },
+    { title: '常规信息', slug: DSB_INFO_ROUTE.BASIC, segment: '' },
     { title: 'Logo', slug: DSB_INFO_ROUTE.LOGOS },
     { title: '社交媒体', slug: DSB_INFO_ROUTE.SOCIAL },
     { title: '其他', slug: DSB_INFO_ROUTE.OTHER },

--- a/frontend/core/containers/thread/DashboardThread/Threads/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Threads/index.tsx
@@ -1,6 +1,5 @@
 import ToggleSwitch from '~/widgets/Buttons/ToggleSwitch'
 import useEnable from '../logic/useEnable'
-import Portal from '../Portal'
 import SectionLabel from '../SectionLabel'
 import useSalon from '../salon/threads'
 import AboutThread from './AboutThread'
@@ -12,8 +11,6 @@ export default () => {
 
   return (
     <div className={s.wrapper}>
-      <Portal title='社区板块' desc='按需开启社区对外公开板块，关闭后不会导致内容删除。' />
-
       <div className='mb-10' />
 
       <SectionLabel

--- a/frontend/core/containers/thread/DashboardThread/constant.tsx
+++ b/frontend/core/containers/thread/DashboardThread/constant.tsx
@@ -85,7 +85,7 @@ export const MENU = {
         slug: DSB_ROUTE.SEO,
       },
       {
-        title: '社区板块',
+        title: '板块管理',
         slug: DSB_ROUTE.THREADS,
       },
       {
@@ -108,10 +108,6 @@ export const MENU = {
       {
         title: '页脚',
         slug: DSB_ROUTE.FOOTER,
-      },
-      {
-        title: '导入/导出',
-        slug: DSB_ROUTE.INOUT,
       },
     ],
   },
@@ -152,6 +148,10 @@ export const MENU = {
       {
         title: 'RSS',
         slug: DSB_ROUTE.RSS,
+      },
+      {
+        title: '导入/导出',
+        slug: DSB_ROUTE.INOUT,
       },
     ],
   },

--- a/frontend/core/containers/thread/DashboardThread/salon/broadcast/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/broadcast/index.ts
@@ -11,7 +11,7 @@ export default () => {
 
     blockBase: cn(
       'relative w-72 rounded-md px-4 py-4 pointer saturate-0 opacity-80',
-      'hover:opacity-100 hover:saturate-100 trans-all-200',
+      'hover:opacity-100 hover:saturate-100',
       hoverBr(),
       bg('alphaBg'),
     ),

--- a/frontend/core/containers/thread/DashboardThread/salon/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/index.ts
@@ -1,0 +1,13 @@
+import useTwBelt from '~/hooks/useTwBelt'
+
+export { cn } from '~/css'
+
+export default () => {
+  const { cn, br } = useTwBelt()
+
+  return {
+    content: 'column w-3/5',
+    banner: cn('relative h-16 w-full border-b mb-10', br('divider')),
+    tabs: 'absolute -left-2 bottom-0',
+  }
+}

--- a/frontend/core/containers/thread/DashboardThread/salon/layout/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/layout/index.ts
@@ -7,14 +7,14 @@ export default () => {
     useTwBelt()
 
   return {
-    wrapper: 'column w-10/12 items-center',
+    wrapper: 'column w-3/5 ',
     banner: cn('relative h-16 w-full border-b mb-10', br('divider')),
     tabs: 'absolute -left-2 bottom-0',
     //
     baseSection: 'pb-7',
     blockBase: cn(
       'relative w-72 rounded-md px-4 py-4 pointer saturate-0 opacity-80',
-      'hover:opacity-100 hover:saturate-100 trans-all-200',
+      'hover:opacity-100 hover:saturate-100',
       hoverBr(),
       bg('alphaBg'),
     ),

--- a/frontend/core/containers/thread/DashboardThread/salon/third_part/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/third_part/index.ts
@@ -1,15 +1,9 @@
-import useMetric from '~/hooks/useMetric'
 import useTwBelt from '~/hooks/useTwBelt'
 
 export { cn } from '~/css'
 
 export default () => {
-  const { cn, fg, hoverBr, isDarkBlack } = useTwBelt()
-
-  const metric = useMetric()
-
-  console.log('## metric: ', metric)
-  console.log('## isDarkBlack: ', isDarkBlack)
+  const { cn, fg, hoverBr } = useTwBelt()
 
   return {
     wrapper: cn('row -ml-1'),

--- a/frontend/core/containers/thread/DashboardThread/salon/third_part/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/third_part/index.ts
@@ -1,9 +1,15 @@
+import useMetric from '~/hooks/useMetric'
 import useTwBelt from '~/hooks/useTwBelt'
 
 export { cn } from '~/css'
 
 export default () => {
-  const { cn, fg, hoverBr } = useTwBelt()
+  const { cn, fg, hoverBr, isDarkBlack } = useTwBelt()
+
+  const metric = useMetric()
+
+  console.log('## metric: ', metric)
+  console.log('## isDarkBlack: ', isDarkBlack)
 
   return {
     wrapper: cn('row -ml-1'),

--- a/frontend/core/hooks/useTwBelt.ts
+++ b/frontend/core/hooks/useTwBelt.ts
@@ -1,6 +1,5 @@
 import { type ClassValue, clsx } from 'clsx'
 import { COLOR_NAME } from '~/const/colors'
-import METRIC from '~/const/metric'
 import { cn } from '~/css'
 import { camelize } from '~/fmt'
 import useAvatarLayout from '~/hooks/useAvatarLayout'
@@ -87,7 +86,7 @@ export default (): TRet => {
   const fill = (key: TFlatThemeKey) => _theme(key, 'fill')
   const br = (key: TFlatThemeKey) => _theme(key, 'border')
 
-  const hoverBr = () => cn('border', br('divider'), `hover:${primary('borderSoft')}`)
+  const hoverBr = () => cn('border trans-all-100', br('divider'), `hover:${primary('borderSoft')}`)
 
   const _rainbowAlias = (prefix: TColorPrefix): string => {
     switch (prefix) {
@@ -125,9 +124,9 @@ export default (): TRet => {
     }
 
     if (prefix === 'borderSoft') {
-      if (isDarkBlack && metric !== METRIC.LANDING) {
-        return 'border-text-hint'
-      }
+      // if (isDarkBlack && metric !== METRIC.LANDING) {
+      //   return 'border-text-hint'
+      // }
 
       return `${prefix$}-${color$}/50`
     }

--- a/frontend/core/tailwind/safelist.css
+++ b/frontend/core/tailwind/safelist.css
@@ -31,7 +31,7 @@
 
 /* hover */
 @source inline('hover:{text,fill}-text-title');
-@source inline('hover:{border-divider,border-text-digest}');
+@source inline('hover:{border-divider,border-text-digest,border-text-hint}');
 @source inline('hover:text-rainbow-red');
 @source inline('hover:bg-rainbow-{redBg,redSoftBg}');
 @source inline('hover:{bg-hoverBg,bg-menuHoverBg,bg-sandBox,bg-card,bg-alphaBg2}');

--- a/frontend/core/tailwind/tokens/color.css
+++ b/frontend/core/tailwind/tokens/color.css
@@ -5,6 +5,7 @@
     --color-text-title: oklch(27.8% 0.033 256.848); /* gray.800 */
     --color-text-digest: oklch(55.1% 0.027 264.364); /* gray.500 */
     --color-text-hint: #9d9999;
+    --color-text-link: #5073c6;
     --color-link: #5073c6;
     --color-dot: oklch(55.4% 0.046 257.417); /* slate.500 */
     --article-hover-linear: linear-gradient(315deg, oklch(1 0 0 / 0) 0%, oklch(0.97 0 0) 100%);
@@ -156,7 +157,8 @@
     /* articles */
     --color-text-title: oklch(96.7% 0.003 264.542);
     --color-text-digest: #949494; /*oklch(70.5% 0.015 286.067);*/
-    --color-text-hint: #9d9999;
+    --color-text-hint: #919191;
+    --color-text-link: #6b97d4;
     --color-link: #6b97d4;
     --color-dot: oklch(70.4% 0.04 256.788); /* slate.400 */
     --article-hover-linear: linear-gradient(315deg, oklch(0.55 0 0 / 0) 0%, oklch(0.32 0 0) 100%);
@@ -194,7 +196,7 @@
 
     /* modal */
     --color-modal-bg: #222222;
-    --color-modal-mask: oklch(13.5% 0.02 260deg / 0.1);
+    --color-modal-mask: oklch(0.19 0 0 / 0.49);
 
     /* menu */
     --color-menuHoverBg: #42424259;

--- a/frontend/core/tailwind/tokens/shadow.css
+++ b/frontend/core/tailwind/tokens/shadow.css
@@ -9,7 +9,7 @@
   --shadow-modal: -2px 4px 20px 0px rgb(158 157 157 / 23%);
 }
 
-.dark {
+:root[data-theme="dark"] {
   --shadow-sm: #19191b66 1px 2px 29px 0px;
   --shadow-md: rgba(0, 0, 0, 0.03) 0px 6px 24px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px;
   --shadow-lg: -9px 7px 20px 9px rgb(24 24 24 / 15%);

--- a/frontend/core/widgets/CommunityDigest/index.tsx
+++ b/frontend/core/widgets/CommunityDigest/index.tsx
@@ -4,14 +4,12 @@
  *
  */
 
-import { usePathname } from 'next/navigation'
 import { Fragment } from 'react'
 
 import { BANNER_LAYOUT } from '~/const/layout'
 // import { ROUTE } from '~/const/route'
 import useLayout from '~/hooks/useLayout'
 
-import DashboardLayout from './DashboardLayout'
 import HeaderLayout from './HeaderLayout'
 import SidebarLayout from './SidebarLayout'
 import TabberLayout from './TabberLayout'
@@ -19,11 +17,6 @@ import TabberLayout from './TabberLayout'
 export default () => {
   // const router = useRouter()
   const { bannerLayout } = useLayout()
-  const pathname = usePathname()
-
-  if (pathname.split('/')[2] === 'dashboard') {
-    return <DashboardLayout />
-  }
 
   return (
     <Fragment>

--- a/frontend/core/widgets/DsbCovers/salon.ts
+++ b/frontend/core/widgets/DsbCovers/salon.ts
@@ -1,33 +1,27 @@
+import useTheme from '~/hooks/useTheme'
 import useTwBelt from '~/hooks/useTwBelt'
 
 export { cn } from '~/css'
 
 export default () => {
+  const { isDarkTheme } = useTheme()
   const { cn, fg, hoverBr, hover, bg, fill, primary, isBlackPrimary } = useTwBelt()
 
   return {
     wrapper: 'column w-3/5',
 
-    groups: cn('column w-full mt-8 gap-8'),
+    groups: cn('column w-full mt-5 gap-y-10'),
     group: cn('column w-full'),
-    groupHeader: cn('row items-center justify-between -ml-0.5 mb-3'),
-    groupTitle: cn('text-sm font-medium tracking-wide', fg('text.title')),
+    groupHeader: cn('row-center ml-1 mb-3'),
+    groupTitle: cn('text-base', fg('text.title')),
 
     content: cn('grid w-full gap-4', 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 -ml-0.5'),
-
-    block: cn(
-      'group relative',
-      'h-36 w-full rounded-md px-4 py-4 pointer',
-      'column',
-      'trans-all-100',
-      hoverBr(),
-      bg('alphaBg'),
-    ),
+    block: cn('column group relative h-36 w-full rounded-md p-4', hoverBr()),
 
     title: cn('text-base', fg('text.title')),
     desc: cn('text-xs', fg('text.digest')),
 
-    icon: cn('size-5 ml-1 mt-1 opacity-50', primary('fill'), isBlackPrimary && fill('text.link')),
+    icon: cn('size-5 ml-1 mt-1', isDarkTheme ? 'opacity-80' : 'opacity-50', fill('text.digest')),
 
     // Pin button
     pinBtn: cn(

--- a/frontend/core/widgets/Img/index.tsx
+++ b/frontend/core/widgets/Img/index.tsx
@@ -25,7 +25,7 @@ const Img: FC<IProps> = ({
   alt = 'img',
   fallback = null,
   noLazy = false,
-  visibleByDefault = true,
+  visibleByDefault = false,
   onClick = console.log,
 }) => {
   if (/\.(svg)$/i.test(src)) {

--- a/frontend/dashboard/src/app/[community]/dashboard/Client.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/Client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import SideMenu from '~/containers/thread/DashboardThread/SideMenu'
-import CommunityDigest from '~/widgets/CommunityDigest'
+import CommunityDigest from '~/widgets/CommunityDigest/DashboardLayout'
 import useSalon from './salon'
 
 const ClientLayout = ({ children }) => {
@@ -12,10 +12,8 @@ const ClientLayout = ({ children }) => {
       <CommunityDigest />
 
       <div className={s.inner}>
-        <div className={s.content}>
-          <SideMenu />
-          <div className={s.main}>{children}</div>
-        </div>
+        <SideMenu />
+        <div className={s.children}>{children}</div>
       </div>
     </div>
   )

--- a/frontend/dashboard/src/app/[community]/dashboard/alias/kanban/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/alias/kanban/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { ALIAS_GROUP } from '~/containers/thread/DashboardThread//constant'
 import Item from '~/containers/thread/DashboardThread/Alias/Item'
+import { ALIAS_GROUP } from '~/containers/thread/DashboardThread/constant'
 import useAlias from '~/containers/thread/DashboardThread/logic/useAlias'
 import { groupByKey } from '~/helper'
 

--- a/frontend/dashboard/src/app/[community]/dashboard/alias/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/alias/layout.tsx
@@ -3,7 +3,7 @@
 import { ALIAS_TABS, DSB_COVERS } from '~/const/route'
 import VIEW from '~/const/view'
 import Portal from '~/containers/thread/DashboardThread/Portal'
-import useSalon from '~/containers/thread/DashboardThread/salon/alias'
+import useSalon, { cn } from '~/containers/thread/DashboardThread/salon'
 import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
 import useDsbLayoutTabs from '~/hooks/useDsbLayoutTabs'
 import Tabs from '~/widgets/Switcher/Tabs'
@@ -26,7 +26,7 @@ export default ({ children }) => {
   const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
   return (
-    <div className={s.wrapper}>
+    <div className={cn(s.content, 'w-1/2')}>
       <Portal
         title='别名设置'
         desc='覆盖社区内默认的板块，组件，提示信息等名称，注意对应的路由不会改变。'

--- a/frontend/dashboard/src/app/[community]/dashboard/alias/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/alias/layout.tsx
@@ -1,21 +1,36 @@
 'use client'
 
-import { ALIAS_TABS } from '~/const/route'
+import { ALIAS_TABS, DSB_COVERS } from '~/const/route'
 import VIEW from '~/const/view'
 import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon from '~/containers/thread/DashboardThread/salon/alias'
+import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
 import useDsbLayoutTabs from '~/hooks/useDsbLayoutTabs'
 import Tabs from '~/widgets/Switcher/Tabs'
+
+const seg = ALIAS_TABS.segment
+const CRUMB_CONFIG = {
+  title: '工作区',
+  seg,
+  toSeg: DSB_COVERS.WORKPLACE,
+  children: [
+    { title: '板块入口', seg },
+    { title: '看板', seg: `${seg}/kanban` },
+    { title: '其他', seg: `${seg}/others` },
+  ],
+}
 
 export default ({ children }) => {
   const s = useSalon()
   const { items, activeTab } = useDsbLayoutTabs(ALIAS_TABS)
+  const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
   return (
     <div className={s.wrapper}>
       <Portal
         title='别名设置'
         desc='覆盖社区内默认的板块，组件，提示信息等名称，注意对应的路由不会改变。'
+        crumbItems={crumbItems}
         withDivider={false}
       />
       <div className={s.banner}>

--- a/frontend/dashboard/src/app/[community]/dashboard/alias/others/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/alias/others/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { ALIAS_GROUP } from '~/containers/thread/DashboardThread//constant'
 import Item from '~/containers/thread/DashboardThread/Alias/Item'
+import { ALIAS_GROUP } from '~/containers/thread/DashboardThread/constant'
 import useAlias from '~/containers/thread/DashboardThread/logic/useAlias'
 import { groupByKey } from '~/helper'
 

--- a/frontend/dashboard/src/app/[community]/dashboard/alias/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/alias/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { ALIAS_GROUP } from '~/containers/thread/DashboardThread//constant'
 import Item from '~/containers/thread/DashboardThread/Alias/Item'
+import { ALIAS_GROUP } from '~/containers/thread/DashboardThread/constant'
 import useAlias from '~/containers/thread/DashboardThread/logic/useAlias'
 import { groupByKey } from '~/helper'
 

--- a/frontend/dashboard/src/app/[community]/dashboard/domain/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/domain/layout.tsx
@@ -3,7 +3,7 @@
 import { DOMAIN_TABS, DSB_COVERS } from '~/const/route'
 import VIEW from '~/const/view'
 import Portal from '~/containers/thread/DashboardThread/Portal'
-import useSalon, { cn } from '~/containers/thread/DashboardThread/salon/layout'
+import useSalon, { cn } from '~/containers/thread/DashboardThread/salon'
 import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
 import useDsbLayoutTabs from '~/hooks/useDsbLayoutTabs'
 import Tabs from '~/widgets/Switcher/Tabs'
@@ -26,7 +26,7 @@ export default ({ children }) => {
   const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
   return (
-    <div className={cn(s.wrapper, 'w-3/5')}>
+    <div className={cn(s.content)}>
       <Portal
         title='域名设置'
         desc='给你的社区绑定个性化域名。'

--- a/frontend/dashboard/src/app/[community]/dashboard/info/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/info/layout.tsx
@@ -1,21 +1,37 @@
 'use client'
 
-import { INFO_TABS } from '~/const/route'
+import { DSB_COVERS, INFO_TABS } from '~/const/route'
 import VIEW from '~/const/view'
 import Portal from '~/containers/thread/DashboardThread/Portal'
-import useSalon from '~/containers/thread/DashboardThread/salon/basic_info'
+import useSalon, { cn } from '~/containers/thread/DashboardThread/salon'
+import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
 import useDsbLayoutTabs from '~/hooks/useDsbLayoutTabs'
 import Tabs from '~/widgets/Switcher/Tabs'
+
+const seg = INFO_TABS.segment
+const CRUMB_CONFIG = {
+  title: '工作区',
+  seg,
+  toSeg: DSB_COVERS.WORKPLACE,
+  children: [
+    { title: '基本信息', seg },
+    { title: 'Logo', seg: `${seg}/logos` },
+    { title: '社交媒体', seg: `${seg}/social` },
+    { title: '其他', seg: `${seg}/others` },
+  ],
+}
 
 export default ({ children }) => {
   const s = useSalon()
   const { items, activeTab } = useDsbLayoutTabs(INFO_TABS)
+  const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
   return (
-    <div className={s.wrapper}>
+    <div className={cn(s.content, 'w-1/2')}>
       <Portal
-        title='社区信息'
+        title='基本信息'
         desc='社区基本信息，社交媒体，关于页面主要信息等。'
+        crumbItems={crumbItems}
         withDivider={false}
       />
 

--- a/frontend/dashboard/src/app/[community]/dashboard/layout/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/layout/layout.tsx
@@ -1,19 +1,41 @@
 'use client'
 
-import { LAYOUT_TABS } from '~/const/route'
+import { DSB_COVERS, LAYOUT_TABS } from '~/const/route'
 import VIEW from '~/const/view'
 import Portal from '~/containers/thread/DashboardThread/Portal'
-import useSalon from '~/containers/thread/DashboardThread/salon/layout'
+import useSalon from '~/containers/thread/DashboardThread/salon'
+import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
 import useDsbLayoutTabs from '~/hooks/useDsbLayoutTabs'
 import Tabs from '~/widgets/Switcher/Tabs'
+
+const seg = LAYOUT_TABS.segment
+const CRUMB_CONFIG = {
+  title: '工作区',
+  seg,
+  toSeg: DSB_COVERS.WORKPLACE,
+  children: [
+    { title: '通用', seg },
+    { title: '主题/背景', seg: `${seg}/theme` },
+    { title: '讨论区', seg: `${seg}/post` },
+    { title: '看板', seg: `${seg}/kanban` },
+    { title: '更新日志', seg: `${seg}/changelog` },
+    { title: '帮助台', seg: `${seg}/doc` },
+  ],
+}
 
 export default ({ children }) => {
   const s = useSalon()
   const { items, activeTab } = useDsbLayoutTabs(LAYOUT_TABS)
+  const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
   return (
-    <div className={s.wrapper}>
-      <Portal title='布局与样式' desc='社区板块自定义布局与全局样式。' withDivider={false} />
+    <div className={s.content}>
+      <Portal
+        title='布局与样式'
+        desc='社区板块自定义布局与全局样式。'
+        withDivider={false}
+        crumbItems={crumbItems}
+      />
       <div className={s.banner}>
         <div className={s.tabs}>
           <Tabs items={items} activeKey={activeTab} view={VIEW.DESKTOP} noAnimation />

--- a/frontend/dashboard/src/app/[community]/dashboard/salon/index.ts
+++ b/frontend/dashboard/src/app/[community]/dashboard/salon/index.ts
@@ -5,8 +5,7 @@ export default () => {
 
   return {
     wrapper: cn('column-center justify-start min-h-full w-full'),
-    inner: cn('column-center w-full'),
-    content: 'row w-full min-h-screen mt-7',
-    main: 'column items-center grow bg-transparent',
+    inner: cn('row w-full mt-7 min-h-screen'),
+    children: 'column items-center grow bg-transparent',
   }
 }

--- a/frontend/dashboard/src/app/[community]/dashboard/third-part/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/third-part/layout.tsx
@@ -3,7 +3,7 @@
 import { DSB_COVERS, THIRD_PART_TABS } from '~/const/route'
 import VIEW from '~/const/view'
 import Portal from '~/containers/thread/DashboardThread/Portal'
-import useSalon from '~/containers/thread/DashboardThread/salon/alias'
+import useSalon from '~/containers/thread/DashboardThread/salon'
 import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
 import useDsbLayoutTabs from '~/hooks/useDsbLayoutTabs'
 import Tabs from '~/widgets/Switcher/Tabs'
@@ -28,7 +28,7 @@ export default ({ children }) => {
   const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
   return (
-    <div className={s.wrapper}>
+    <div className={s.content}>
       <Portal
         title='绑定集成'
         desc='将社区与外部系统连接，实现数据同步、事件通知与协作管理。支持统计分析、Webhook 事件推送、即时通讯 Bot 及内容同步等集成方式。'

--- a/frontend/dashboard/src/app/[community]/dashboard/threads/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/threads/layout.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { DSB_COVERS, DSB_ROUTE } from '~/const/route'
+import Portal from '~/containers/thread/DashboardThread/Portal'
+import useSalon, { cn } from '~/containers/thread/DashboardThread/salon'
+import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
+
+const seg = DSB_ROUTE.THREADS
+const CRUMB_CONFIG = {
+  title: '工作区',
+  seg,
+  toSeg: DSB_COVERS.WORKPLACE,
+  children: [{ title: '板块管理', seg }],
+}
+
+export default ({ children }) => {
+  const s = useSalon()
+  const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
+
+  return (
+    <div className={cn(s.content, 'w-2/5')}>
+      <Portal
+        title='板块管理'
+        desc='按需开启社区对外公开板块，关闭后不会导致内容删除。'
+        crumbItems={crumbItems}
+      />
+
+      {children}
+    </div>
+  )
+}

--- a/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { DSB_LAYOUT_ROUTE, DSB_ROUTE } from '~/const/route'
+import { DSB_INFO_ROUTE, DSB_LAYOUT_ROUTE, DSB_ROUTE } from '~/const/route'
 import BindSVG from '~/icons/Bind'
 import BookSVG from '~/icons/Book'
 import DomainSVG from '~/icons/Domain'
@@ -16,6 +16,35 @@ export default function LayoutsPage() {
         title: '工作区',
         desc: '社区基本信息，各板块或组件的个性化，管理员等设置。',
         items: [
+          {
+            groupTitle: '基本信息',
+            items: [
+              {
+                title: '常规信息',
+                desc: '品牌展示，整体布局，头像，标签等全局样式。',
+                seg: DSB_ROUTE.INFO,
+                Icon: BindSVG,
+              },
+              {
+                title: 'Logo',
+                desc: '社区主题色，壁纸及各种背景效果。',
+                seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.LOGOS}`,
+                Icon: ThemeSVG,
+              },
+              {
+                title: '社交媒体',
+                desc: '讨论区个性化设置。',
+                seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.SOCIAL}`,
+                Icon: PostSVG,
+              },
+              {
+                title: '其他',
+                desc: '看板展示个性化设置。',
+                seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.OTHER}`,
+                Icon: KanbanSVG,
+              },
+            ],
+          },
           {
             groupTitle: '布局与样式',
             items: [

--- a/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
@@ -27,19 +27,19 @@ export default function LayoutsPage() {
               },
               {
                 title: 'Logo',
-                desc: '社区主题色，壁纸及各种背景效果。',
+                desc: '社区 Logo 的上传与展示设置。',
                 seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.LOGOS}`,
                 Icon: ThemeSVG,
               },
               {
                 title: '社交媒体',
-                desc: '讨论区个性化设置。',
+                desc: '社区社交媒体账号与外部链接设置。',
                 seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.SOCIAL}`,
                 Icon: PostSVG,
               },
               {
                 title: '其他',
-                desc: '看板展示个性化设置。',
+                desc: '其他基础信息与扩展配置。',
                 seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.OTHER}`,
                 Icon: KanbanSVG,
               },

--- a/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
@@ -91,19 +91,19 @@ export default function LayoutsPage() {
             items: [
               {
                 title: '板块入口',
-                desc: '品牌展示，整体布局，头像，标签等全局样式。',
+                desc: '板块全局命名。',
                 seg: DSB_ROUTE.ALIAS,
                 Icon: BindSVG,
               },
               {
                 title: '看板',
-                desc: '社区主题色，壁纸及各种背景效果。',
+                desc: '看板相关模块命名。',
                 seg: `${DSB_ROUTE.ALIAS}/${DSB_ALIAS_ROUTE.KANBAN}`,
                 Icon: ThemeSVG,
               },
               {
                 title: '其他',
-                desc: '讨论区个性化设置。',
+                desc: '其他组件命名。',
                 seg: `${DSB_ROUTE.ALIAS}/${DSB_ALIAS_ROUTE.OTHERS}`,
                 Icon: PostSVG,
               },
@@ -126,19 +126,19 @@ export default function LayoutsPage() {
               },
               {
                 title: '页眉',
-                desc: '讨论区个性化设置。',
+                desc: '页头自定义链接，编组等',
                 seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.SOCIAL}`,
                 Icon: PostSVG,
               },
               {
                 title: '页脚',
-                desc: '看板展示个性化设置。',
+                desc: '页脚自定义链接，编组等',
                 seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.OTHER}`,
                 Icon: KanbanSVG,
               },
               {
                 title: '管理员',
-                desc: '看板展示个性化设置。',
+                desc: '管理员管理，权限设置。',
                 seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.OTHER}`,
                 Icon: KanbanSVG,
               },

--- a/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { DSB_LAYOUT_ROUTE, DSB_ROUTE } from '~/const/route'
+import BindSVG from '~/icons/Bind'
+import BookSVG from '~/icons/Book'
+import DomainSVG from '~/icons/Domain'
+import KanbanSVG from '~/icons/Kanban'
+import PostSVG from '~/icons/Post'
+import ThemeSVG from '~/icons/Theme'
+import DsbCovers from '~/widgets/DsbCovers'
+
+export default function LayoutsPage() {
+  return (
+    <DsbCovers
+      config={{
+        title: '工作区',
+        desc: '社区基本信息，各板块或组件的个性化，管理员等设置。',
+        items: [
+          {
+            groupTitle: '布局与样式',
+            items: [
+              {
+                title: '通用',
+                desc: '使用 Groupher 提供的官方子域名访问社区。',
+                seg: DSB_ROUTE.LAYOUT,
+                Icon: BindSVG,
+              },
+              {
+                title: '主题/背景',
+                desc: '将社区绑定到你自己的域名。',
+                seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.THEME}`,
+                Icon: ThemeSVG,
+              },
+              {
+                title: '讨论区',
+                desc: '将社区绑定到你自己的域名。',
+                seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.POST}`,
+                Icon: PostSVG,
+              },
+              {
+                title: '看板',
+                desc: '将社区绑定到你自己的域名。',
+                seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.KANBAN}`,
+                Icon: KanbanSVG,
+              },
+              {
+                title: '更新日志',
+                desc: '将社区绑定到你自己的域名。',
+                seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.CHANGELOG}`,
+                Icon: DomainSVG,
+              },
+              {
+                title: '帮助台',
+                desc: '将社区绑定到你自己的域名。',
+                seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.DOC}`,
+                Icon: BookSVG,
+              },
+            ],
+          },
+        ],
+      }}
+    />
+  )
+}

--- a/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { DSB_INFO_ROUTE, DSB_LAYOUT_ROUTE, DSB_ROUTE } from '~/const/route'
+import { DSB_ALIAS_ROUTE, DSB_INFO_ROUTE, DSB_LAYOUT_ROUTE, DSB_ROUTE } from '~/const/route'
 import BindSVG from '~/icons/Bind'
 import BookSVG from '~/icons/Book'
 import DomainSVG from '~/icons/Domain'
@@ -83,6 +83,64 @@ export default function LayoutsPage() {
                 desc: '文档展示个性化设置。',
                 seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.DOC}`,
                 Icon: BookSVG,
+              },
+            ],
+          },
+          {
+            groupTitle: '别名映射',
+            items: [
+              {
+                title: '板块入口',
+                desc: '品牌展示，整体布局，头像，标签等全局样式。',
+                seg: DSB_ROUTE.ALIAS,
+                Icon: BindSVG,
+              },
+              {
+                title: '看板',
+                desc: '社区主题色，壁纸及各种背景效果。',
+                seg: `${DSB_ROUTE.ALIAS}/${DSB_ALIAS_ROUTE.KANBAN}`,
+                Icon: ThemeSVG,
+              },
+              {
+                title: '其他',
+                desc: '讨论区个性化设置。',
+                seg: `${DSB_ROUTE.ALIAS}/${DSB_ALIAS_ROUTE.OTHERS}`,
+                Icon: PostSVG,
+              },
+            ],
+          },
+          {
+            groupTitle: '其他',
+            items: [
+              {
+                title: '概览',
+                desc: '品牌展示，整体布局，头像，标签等全局样式。',
+                seg: DSB_ROUTE.INFO,
+                Icon: BindSVG,
+              },
+              {
+                title: 'Logo',
+                desc: '社区主题色，壁纸及各种背景效果。',
+                seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.LOGOS}`,
+                Icon: ThemeSVG,
+              },
+              {
+                title: '页眉',
+                desc: '讨论区个性化设置。',
+                seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.SOCIAL}`,
+                Icon: PostSVG,
+              },
+              {
+                title: '页脚',
+                desc: '看板展示个性化设置。',
+                seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.OTHER}`,
+                Icon: KanbanSVG,
+              },
+              {
+                title: '管理员',
+                desc: '看板展示个性化设置。',
+                seg: `${DSB_ROUTE.INFO}/${DSB_INFO_ROUTE.OTHER}`,
+                Icon: KanbanSVG,
               },
             ],
           },

--- a/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
@@ -21,37 +21,37 @@ export default function LayoutsPage() {
             items: [
               {
                 title: '通用',
-                desc: '使用 Groupher 提供的官方子域名访问社区。',
+                desc: '品牌展示，整体布局，头像，标签等全局样式。',
                 seg: DSB_ROUTE.LAYOUT,
                 Icon: BindSVG,
               },
               {
                 title: '主题/背景',
-                desc: '将社区绑定到你自己的域名。',
+                desc: '社区主题色，壁纸及各种背景效果。',
                 seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.THEME}`,
                 Icon: ThemeSVG,
               },
               {
                 title: '讨论区',
-                desc: '将社区绑定到你自己的域名。',
+                desc: '讨论区个性化设置。',
                 seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.POST}`,
                 Icon: PostSVG,
               },
               {
                 title: '看板',
-                desc: '将社区绑定到你自己的域名。',
+                desc: '看板展示个性化设置。',
                 seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.KANBAN}`,
                 Icon: KanbanSVG,
               },
               {
                 title: '更新日志',
-                desc: '将社区绑定到你自己的域名。',
+                desc: '更新日志展示个性化设置。',
                 seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.CHANGELOG}`,
                 Icon: DomainSVG,
               },
               {
                 title: '帮助台',
-                desc: '将社区绑定到你自己的域名。',
+                desc: '文档展示个性化设置。',
                 seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.DOC}`,
                 Icon: BookSVG,
               },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9400,13 +9400,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.debounce@npm:^4.0.8":
-  version: 4.0.8
-  resolution: "lodash.debounce@npm:4.0.8"
-  checksum: 10c0/762998a63e095412b6099b8290903e0a8ddcb353ac6e2e0f2d7e7d03abd4275fe3c689d88960eb90b0dde4f177554d51a690f22a343932ecbc50a5d111849987
-  languageName: node
-  linkType: hard
-
 "lodash.isfunction@npm:^3.0.9":
   version: 3.0.9
   resolution: "lodash.isfunction@npm:3.0.9"
@@ -9474,13 +9467,6 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.startcase@npm:4.4.0"
   checksum: 10c0/bd82aa87a45de8080e1c5ee61128c7aee77bf7f1d86f4ff94f4a6d7438fc9e15e5f03374b947be577a93804c8ad6241f0251beaf1452bf716064eeb657b3a9f0
-  languageName: node
-  linkType: hard
-
-"lodash.throttle@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "lodash.throttle@npm:4.1.1"
-  checksum: 10c0/14628013e9e7f65ac904fc82fd8ecb0e55a9c4c2416434b1dd9cf64ae70a8937f0b15376a39a68248530adc64887ed0fe2b75204b2c9ec3eea1cb2d66ddd125d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Workplace landing page with grouped covers and introduces breadcrumb navigation across dashboard sections to improve discoverability. Refactors shared layout/styles and polishes dark theme visuals.

- **New Features**
  - Workplace landing with grouped covers for Info, Layout, Alias, etc.
  - Breadcrumbs added to Info, Layout, Alias, Threads, Domain, and Integrations; labels updated (基本信息 → 常规信息, 社区板块 → 板块管理).

- **Refactors**
  - Unified dashboard layout via shared salon styles; simplified Client layout and moved dashboard rendering out of CommunityDigest.
  - UI polish: consistent hover borders, improved DsbCovers spacing/icons, updated dark theme colors/shadows, stronger modal mask, and safelist for hover:border-text-hint.
  - Img now hidden by default before load; removed lodash.debounce and lodash.throttle from dependencies.

<sup>Written for commit d04e672cde78808c73d4833247899c0b030178af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

