### PR TITLE
chore: adjust hover align style

### DIFF
--- a/frontend/core/containers/thread/DashboardThread/Portal.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Portal.tsx
@@ -1,6 +1,6 @@
 import type { FC, ReactNode } from 'react'
 import type { TBreadcrumbItem } from '~/spec'
-import BreadCrumb from '~/widgets/BreadCrumb'
+import Breadcrumbs from '~/widgets/Breadcrumbs'
 import useSalon from './salon/portal'
 
 type TProps = {
@@ -15,7 +15,7 @@ const Portal: FC<TProps> = ({ title, desc = null, withDivider = true, crumbItems
 
   return (
     <div className={s.wrapper}>
-      {crumbItems?.length ? <BreadCrumb items={crumbItems} /> : null}
+      {crumbItems?.length ? <Breadcrumbs items={crumbItems} /> : null}
 
       <h3 className={s.title}>{title}</h3>
 

--- a/frontend/core/widgets/Breadcrumbs/index.tsx
+++ b/frontend/core/widgets/Breadcrumbs/index.tsx
@@ -18,11 +18,12 @@ const BreadCrumb: FC<Props> = ({ items, separator = '/', ...spacing }) => {
     <nav aria-label='Breadcrumb' className={s.wrapper}>
       <ol className={s.ol}>
         {items.map((item, index) => {
+          const isFirst = index === 0
           const isLast = index === items.length - 1
           const clickable = !isLast && item.path
 
           return (
-            <li key={item?.key || item.path} className={s.li}>
+            <li key={item?.key || item.path} className={cn(s.li, isFirst && s.hoverShift)}>
               {clickable ? (
                 <Link href={item.path} className={cn(s.item, s.itemHover)}>
                   {item.title}

--- a/frontend/core/widgets/Breadcrumbs/salon/index.ts
+++ b/frontend/core/widgets/Breadcrumbs/salon/index.ts
@@ -9,11 +9,12 @@ export default ({ ...spacing }: TProps) => {
   const { cn, fg, margin, hover } = useTwBelt()
 
   return {
-    wrapper: cn('mb-2.5 -ml-0.5', margin(spacing)),
+    wrapper: cn('mb-2.5', margin(spacing)),
     li: 'row-center group',
     item: cn('text-xs py-0.5 px-1'),
     itemHover: cn(hover('bg'), hover('fg')),
-    ol: 'row-center',
+    hoverShift: 'hover:ml-1 trans-all-100',
+    ol: 'row-center -ml-1',
     curPath: cn('', fg('text.digest')),
     divider: cn('text-xs mx-1.5', fg('text.hint')),
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardizes the Breadcrumbs component and fixes hover alignment so items don’t jump on hover. Renames BreadCrumb to Breadcrumbs in Portal, adds a subtle left shift on the first crumb with a short transition, and moves the negative margin from the wrapper to the list for consistent spacing.

<sup>Written for commit 0de88baca976bc35d24a2291ca9f17071e3ae695. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced breadcrumb navigation with improved hover effects.
  * Adjusted spacing and hover behavior on breadcrumb items for better visual feedback.

* **Refactor**
  * Refined breadcrumb component styling and layout structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->