### PR TITLE
fix(fe): lazyload img logic

### DIFF
--- a/frontend/core/containers/thread/DashboardThread/salon/portal.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/portal.ts
@@ -5,7 +5,7 @@ export default () => {
 
   return {
     wrapper: 'column w-full',
-    title: cn('text-xl w-auto', fg('text.title')),
+    title: cn('text-2xl w-auto', fg('text.title')),
     desc: cn('text-sm mt-2.5 mb-2', fg('text.digest')),
     divider: cn('w-full h-px mt-5 mb-8', bg('divider')),
   }

--- a/frontend/core/widgets/CommunityDigest/DashboardLayout/CommunityBrief.tsx
+++ b/frontend/core/widgets/CommunityDigest/DashboardLayout/CommunityBrief.tsx
@@ -40,6 +40,7 @@ export default () => {
         className={s.logo}
         src={HOME_COMMUNITY.logo}
         fallback={<ImgFallback size={7} title={title} />}
+        visibleByDefault
       />
 
       <div className={s.slash}>/</div>

--- a/frontend/core/widgets/Img/LazyLoadImg.tsx
+++ b/frontend/core/widgets/Img/LazyLoadImg.tsx
@@ -8,7 +8,7 @@ type TProps = {
   src: string
   alt?: string
   fallback?: ReactNode | null
-  visibleByDefault?: boolean
+  visibleByDefault: boolean
   onClick?: () => void
   threshold?: number
 }
@@ -18,7 +18,7 @@ const LazyLoadImg: FC<TProps> = ({
   src,
   alt = 'image',
   fallback = null,
-  visibleByDefault = true,
+  visibleByDefault,
   onClick,
   threshold = 200,
 }) => {

--- a/frontend/core/widgets/Img/LazyLoadImg.tsx
+++ b/frontend/core/widgets/Img/LazyLoadImg.tsx
@@ -1,8 +1,7 @@
 import { pick } from 'ramda'
-import { type FC, type ReactNode, useCallback, useState } from 'react'
-
-import useSalon, { cn } from './salon/lazy_load_image'
+import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import LazyLoad from '~/widgets/LazyLoad'
+import useSalon, { cn } from './salon/lazy_load_image'
 
 type TProps = {
   className?: string
@@ -14,11 +13,6 @@ type TProps = {
   threshold?: number
 }
 
-/**
- * lazy load images like .jpg .jpeg .png  etc
- * the fallback is for the image often block in china, like github avatars
- * fallback 常被用于图片间歇性被墙的情况，比如 github 头像等
- */
 const LazyLoadImg: FC<TProps> = ({
   className = 'img-class',
   src,
@@ -30,63 +24,76 @@ const LazyLoadImg: FC<TProps> = ({
 }) => {
   // @ts-expect-error
   const fallbackOpt = pick(['size', 'left', 'right', 'top', 'bottom'], fallback?.props || {})
-
   const s = useSalon({ ...fallbackOpt })
 
-  const [imgLoaded, setImgLoaded] = useState(true)
-  const [loadError, setLoadError] = useState(false)
-  const [over, setOver] = useState(false)
+  const imgRef = useRef<HTMLImageElement | null>(null)
 
-  const handleBeforeLoad = useCallback(() => {
-    if (!over) {
-      // console.log('## ## handleBeforeLoad')
-      setImgLoaded(false)
-    }
-  }, [over])
+  const [started, setStarted] = useState(visibleByDefault)
+  const [loaded, setLoaded] = useState(false)
+  const [_error, setError] = useState(false)
+
+  useEffect(() => {
+    setStarted(visibleByDefault)
+    setLoaded(false)
+    setError(false)
+  }, [visibleByDefault])
+
+  const handleVisible = useCallback(() => {
+    setStarted(true)
+  }, [])
 
   const handleLoad = useCallback(() => {
-    if (!over) {
-      setImgLoaded(true)
-      setLoadError(false)
-      setOver(true)
-    }
-  }, [over])
+    setLoaded(true)
+    setError(false)
+  }, [])
 
   const handleError = useCallback(() => {
-    console.warn('lazy image load.: ', src)
-    setLoadError(true)
-    setImgLoaded(false)
-    setOver(true)
+    console.warn('[LazyLoadImg] load error:', src)
+    setError(true)
+    setLoaded(false)
   }, [src])
+
+  useEffect(() => {
+    if (!started) return
+    const el = imgRef.current
+    if (!el) return
+
+    if (el.complete && el.naturalWidth > 0) {
+      setLoaded(true)
+      setError(false)
+    }
+  }, [started])
+
+  const showFallback = !!fallback && !loaded
 
   if (!src) {
     return (
-      <div key={src} onClick={onClick} className={cn(s.normal, !imgLoaded && s.fallbackOffset)}>
+      <button onClick={onClick} className={cn(s.normal, showFallback && s.fallbackOffset)}>
         <div className={s.fallback}>{fallback}</div>
-      </div>
+      </button>
     )
   }
-  return (
-    <div onClick={onClick} className={cn(s.normal, 'z-10', !imgLoaded && s.fallbackOffset)}>
-      {!imgLoaded && <div className={s.fallback}>{fallback}</div>}
 
-      {!loadError && (
-        <LazyLoad
-          visibleByDefault={visibleByDefault}
-          threshold={threshold}
-          onVisible={handleBeforeLoad}
-        >
-          <img
-            className={cn(className, 'flex-shrink-0')}
-            src={src}
-            alt={alt}
-            loading='lazy'
-            onLoad={handleLoad}
-            onError={handleError}
-          />
-        </LazyLoad>
-      )}
-    </div>
+  return (
+    <button onClick={onClick} className={cn(s.normal, 'z-10', showFallback && s.fallbackOffset)}>
+      {showFallback && <div className={s.fallback}>{fallback}</div>}
+
+      <LazyLoad visibleByDefault={visibleByDefault} threshold={threshold} onVisible={handleVisible}>
+        {(visible) =>
+          visible || started ? (
+            <img
+              ref={imgRef}
+              className={cn(className, 'flex-shrink-0', !loaded && 'invisible')}
+              src={src}
+              alt={alt}
+              loading='lazy'
+              onLoad={handleLoad}
+              onError={handleError}
+            />
+          ) : null
+        }
+      </LazyLoad>
+    </button>
   )
 }
 

--- a/frontend/core/widgets/Img/LazyLoadImg.tsx
+++ b/frontend/core/widgets/Img/LazyLoadImg.tsx
@@ -68,14 +68,22 @@ const LazyLoadImg: FC<TProps> = ({
 
   if (!src) {
     return (
-      <button onClick={onClick} className={cn(s.normal, showFallback && s.fallbackOffset)}>
+      <button
+        type='button'
+        onClick={onClick}
+        className={cn(s.normal, showFallback && s.fallbackOffset)}
+      >
         <div className={s.fallback}>{fallback}</div>
       </button>
     )
   }
 
   return (
-    <button onClick={onClick} className={cn(s.normal, 'z-10', showFallback && s.fallbackOffset)}>
+    <button
+      type='button'
+      onClick={onClick}
+      className={cn(s.normal, 'z-10', showFallback && s.fallbackOffset)}
+    >
       {showFallback && <div className={s.fallback}>{fallback}</div>}
 
       <LazyLoad visibleByDefault={visibleByDefault} threshold={threshold} onVisible={handleVisible}>

--- a/frontend/core/widgets/Img/NativeImg.tsx
+++ b/frontend/core/widgets/Img/NativeImg.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
 import useSalon, { cn } from './salon'
 
@@ -62,4 +62,4 @@ const NativeImg: FC<TProps> = ({
   )
 }
 
-export default memo(NativeImg)
+export default NativeImg

--- a/frontend/core/widgets/Img/index.tsx
+++ b/frontend/core/widgets/Img/index.tsx
@@ -5,7 +5,7 @@
  * Renders an image, enforcing the usage of the alt="" tag
  */
 
-import { type FC, memo, type ReactNode } from 'react'
+import type { FC, ReactNode } from 'react'
 import LazyLoadImg from './LazyLoadImg'
 import NativeImg from './NativeImg'
 
@@ -58,4 +58,4 @@ const Img: FC<IProps> = ({
   )
 }
 
-export default memo(Img)
+export default Img


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lazy-loaded images to avoid flicker and show fallbacks correctly. Also makes visibleByDefault explicit and tweaks a title size.

- **Bug Fixes**
  - Corrected lazy-load visibility flow; start state is explicit and onVisible now only triggers loading once.
  - Use an img ref and complete/naturalWidth checks to handle cached images; hide the img until onLoad fires.
  - Show fallback only while loading or on error; improved error logging.

- **Refactors**
  - visibleByDefault is now required; CommunityBrief passes it for the logo.
  - Wrap clickable images in a button for proper semantics and focus.
  - Remove memo from Img and NativeImg components; increase salon portal title from text-xl to text-2xl.

<sup>Written for commit eee67953c75e1308cf5d5b4c9ff0dd596853bb73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Increased dashboard title size for improved visibility

* **New Features**
  * Added configurable image visibility defaults (visibleByDefault) to control when images load
  * Improved lazy-loading with richer load/fallback handling for more reliable image display

* **Refactor**
  * Adjusted image component exports and removed memoization to simplify rendering behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->