### PR TITLE
refactor(fe): dashboard cms layout

### DIFF
--- a/frontend/core/constant/route.ts
+++ b/frontend/core/constant/route.ts
@@ -217,4 +217,5 @@ export const WIDGET_TABS: TDsbTabs = {
 export const DSB_COVERS = {
   INTEGRATIONS: 'integrations',
   WORKPLACE: 'workplace',
+  CMS: 'cms',
 }

--- a/frontend/core/containers/thread/DashboardThread/CMS/Cell/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/CMS/Cell/index.tsx
@@ -38,10 +38,18 @@ export const StateCell = ({ rowData, ...props }) => {
   const s = useSalon()
   const { cat, state } = rowData
 
+  if (!state) {
+    return (
+      <Cell {...props}>
+        <div />
+      </Cell>
+    )
+  }
+
   return (
     <Cell {...props}>
       <div className={s.stateWrapper}>
-        <ArticleCatState cat={cat} state={state} left={-8} smaller />
+        <ArticleCatState cat={cat} state={state} smaller />
       </div>
     </Cell>
   )

--- a/frontend/core/containers/thread/DashboardThread/CMS/Changelogs/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/CMS/Changelogs/index.tsx
@@ -1,5 +1,5 @@
 import { pluck } from 'ramda'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { Cell, Column, HeaderCell, Table } from 'rsuite-table'
 
@@ -22,6 +22,11 @@ export default () => {
     useCMSInfo()
   const [showCheckColumn, setShowCheckColumn] = useState(false)
   const [sortColumn, setSortColumn] = useState('id')
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  useEffect(() => {
+    loadChangelogs()
+  }, [])
 
   const allIDs = pluck('id', pagedChangelogs.entries)
   const isAllSelected = allIDs.length === batchSelectedIDs?.length
@@ -102,9 +107,7 @@ export default () => {
 
         <Column width={280} fixed>
           <HeaderCell>
-            <div className={s.title} onClick={() => loadChangelogs()}>
-              标题
-            </div>
+            <div className={s.title}>标题</div>
           </HeaderCell>
           {/* @ts-ignore */}
           <ArticleCell dataKey='title' />

--- a/frontend/core/containers/thread/DashboardThread/CMS/Changelogs/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/CMS/Changelogs/index.tsx
@@ -1,17 +1,15 @@
-import { useCallback, useState } from 'react'
 import { pluck } from 'ramda'
+import { useCallback, useState } from 'react'
 
-import { Table, Column, HeaderCell, Cell } from 'rsuite-table'
+import { Cell, Column, HeaderCell, Table } from 'rsuite-table'
 
 import ArrowSVG from '~/icons/Arrow'
 import FilterSVG from '~/icons/Filter'
 import Checker from '~/widgets/Checker'
-
-import { CheckCell, ArticleCell, StateCell, AuthorDateCell, DateCell } from '../Cell'
-import FilterBar from '../FilterBar'
-
 import useCMSInfo from '../../hooks/useCMSInfo'
 import useSalon from '../../salon/cms/changelogs'
+import { ArticleCell, AuthorDateCell, CheckCell, DateCell, StateCell } from '../Cell'
+import FilterBar from '../FilterBar'
 
 /**
  * example: https://table.rsuitejs.com/#fixed-column
@@ -58,7 +56,7 @@ export default () => {
           return <FilterSVG className={s.icon.filter} />
       }
     },
-    [sortState],
+    [sortState, s.icon.filter, s.icon.arrowUp, s.icon.arrowDown],
   )
 
   return (
@@ -85,7 +83,7 @@ export default () => {
             <HeaderCell>
               <Checker
                 checked={isAllSelected}
-                size="small"
+                size='small'
                 top={4}
                 onChange={(checked) => {
                   if (checked) {
@@ -109,11 +107,11 @@ export default () => {
             </div>
           </HeaderCell>
           {/* @ts-ignore */}
-          <ArticleCell dataKey="title" />
+          <ArticleCell dataKey='title' />
         </Column>
 
-        <Column width={90} fixed>
-          <HeaderCell align="center">
+        <Column width={120} fixed>
+          <HeaderCell align='center'>
             <div className={s.title}>状态</div>
           </HeaderCell>
           {/* @ts-ignore */}
@@ -121,28 +119,28 @@ export default () => {
         </Column>
 
         <Column width={65} fixed sortable>
-          <HeaderCell align="center" renderSortIcon={() => renderSortIcon('upvotesCount')}>
+          <HeaderCell align='center' renderSortIcon={() => renderSortIcon('upvotesCount')}>
             <div className={s.title}>投票</div>
           </HeaderCell>
-          <Cell dataKey="upvotesCount" align="center" />
+          <Cell dataKey='upvotesCount' align='center' />
         </Column>
 
         <Column width={65} sortable>
-          <HeaderCell align="center" renderSortIcon={() => renderSortIcon('views')}>
+          <HeaderCell align='center' renderSortIcon={() => renderSortIcon('views')}>
             <div className={s.title}>浏览</div>
           </HeaderCell>
-          <Cell dataKey="views" align="center" />
+          <Cell dataKey='views' align='center' />
         </Column>
 
         <Column width={60} sortable>
-          <HeaderCell align="center" renderSortIcon={() => renderSortIcon('commentsCount')}>
+          <HeaderCell align='center' renderSortIcon={() => renderSortIcon('commentsCount')}>
             <div className={s.title}>评论</div>
           </HeaderCell>
-          <Cell dataKey="commentsCount" align="center" />
+          <Cell dataKey='commentsCount' align='center' />
         </Column>
 
         <Column width={100}>
-          <HeaderCell align="right">
+          <HeaderCell align='right'>
             <div className={s.title}>发布/活跃</div>
           </HeaderCell>
           {/* @ts-ignore */}
@@ -150,7 +148,7 @@ export default () => {
         </Column>
 
         <Column width={110}>
-          <HeaderCell align="right">
+          <HeaderCell align='right'>
             <div className={s.title}>作者</div>
           </HeaderCell>
           {/* @ts-ignore */}

--- a/frontend/core/containers/thread/DashboardThread/CMS/FilterBar/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/CMS/FilterBar/index.tsx
@@ -1,18 +1,14 @@
 import type { FC } from 'react'
-
-import ResetSVG from '~/icons/Reset'
+import { CONDITION_MODE } from '~/const/mode'
 import DubbleCheckSVG from '~/icons/DubbleCheck'
 import SearchSVG from '~/icons/HeaderSearch'
-import { CONDITION_MODE } from '~/const/mode'
-
-import Input from '~/widgets/Input'
+import ResetSVG from '~/icons/Reset'
 import Button from '~/widgets/Buttons/Button'
 import ConditionSelector from '~/widgets/ConditionSelector'
-
-import ActionBar from './ActionBar'
-
+import Input from '~/widgets/Input'
 import useCMSInfo from '../../hooks/useCMSInfo'
 import useSalon, { cn } from '../../salon/cms/filter_bar'
+import ActionBar from './ActionBar'
 
 type TProps = {
   triggerCheckbox: (show: boolean) => void
@@ -29,8 +25,8 @@ const FilterBar: FC<TProps> = ({ checkboxActive, triggerCheckbox, selectedCount 
     <div className={s.wrapper}>
       <div className={s.main}>
         <Button
-          size="small"
-          className="w-24 min-w-24"
+          size='small'
+          className='w-24 min-w-24'
           left={-5}
           onClick={() => {
             if (checkboxActive) {
@@ -48,15 +44,15 @@ const FilterBar: FC<TProps> = ({ checkboxActive, triggerCheckbox, selectedCount 
 
         <div className={s.inputWrapper}>
           <SearchSVG className={cn(s.icon, 'absolute left-2 top-2')} />
-          <Input placeholder="按标题搜索" className={s.input} />
+          <Input placeholder='按标题搜索' className={s.input} />
         </div>
 
         <ConditionSelector mode={CONDITION_MODE.CAT} selected={false} right={20} />
         <ConditionSelector mode={CONDITION_MODE.STATE} selected={false} right={20} />
 
         <div className={s.dateRange}>日期范围(TODO)</div>
-        <div className="grow" />
-        <Button size="small" className="w-24" ghost noBorder>
+        <div className='grow' />
+        <Button size='small' ghost noBorder>
           <ResetSVG className={s.icon} />
           重置
         </Button>

--- a/frontend/core/containers/thread/DashboardThread/CMS/Posts/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/CMS/Posts/index.tsx
@@ -1,5 +1,5 @@
 import { pluck } from 'ramda'
-import { type FC, useCallback, useState } from 'react'
+import { type FC, useCallback, useEffect, useState } from 'react'
 
 import { Cell, Column, HeaderCell, Table } from 'rsuite-table'
 
@@ -19,9 +19,16 @@ import FilterBar from '../FilterBar'
 const Posts: FC = () => {
   const s = useSalon()
 
+  console.log('## cms posts')
+
   const { pagedPosts, loading, batchSelectedIDs, batchSelectAll, loadPosts } = useCMSInfo()
   const [showCheckColumn, setShowCheckColumn] = useState(false)
   const [sortColumn, setSortColumn] = useState('id')
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  useEffect(() => {
+    loadPosts()
+  }, [])
 
   const allIDs = pluck('id', pagedPosts.entries)
   const isAllSelected = allIDs.length === batchSelectedIDs?.length
@@ -70,7 +77,6 @@ const Posts: FC = () => {
         data={pagedPosts.entries}
         sortColumn={sortColumn}
         onSortColumn={handleSortColumn}
-        rowHeight={68}
         loading={loading}
         hover={false}
         autoHeight
@@ -99,12 +105,8 @@ const Posts: FC = () => {
           </Column>
         )}
 
-        <Column width={280} fixed>
-          <HeaderCell>
-            <div className={s.title} onClick={() => loadPosts()}>
-              标题
-            </div>
-          </HeaderCell>
+        <Column width={280} fixed flexGrow={1}>
+          <HeaderCell>标题</HeaderCell>
           {/* @ts-ignore */}
           <ArticleCell dataKey='title' />
         </Column>
@@ -146,7 +148,7 @@ const Posts: FC = () => {
           <DateCell />
         </Column>
 
-        <Column width={115}>
+        <Column width={115} flexGrow={0}>
           <HeaderCell align='right'>
             <div className={s.title}>作者</div>
           </HeaderCell>

--- a/frontend/core/containers/thread/DashboardThread/CMS/Posts/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/CMS/Posts/index.tsx
@@ -19,8 +19,6 @@ import FilterBar from '../FilterBar'
 const Posts: FC = () => {
   const s = useSalon()
 
-  console.log('## cms posts')
-
   const { pagedPosts, loading, batchSelectedIDs, batchSelectAll, loadPosts } = useCMSInfo()
   const [showCheckColumn, setShowCheckColumn] = useState(false)
   const [sortColumn, setSortColumn] = useState('id')
@@ -106,12 +104,14 @@ const Posts: FC = () => {
         )}
 
         <Column width={280} fixed flexGrow={1}>
-          <HeaderCell>标题</HeaderCell>
+          <HeaderCell>
+            <div className={s.title}>帖子标题</div>
+          </HeaderCell>
           {/* @ts-ignore */}
           <ArticleCell dataKey='title' />
         </Column>
 
-        <Column width={90} fixed>
+        <Column width={120} fixed>
           <HeaderCell align='center'>
             <div className={s.title}>状态</div>
           </HeaderCell>
@@ -123,21 +123,21 @@ const Posts: FC = () => {
           <HeaderCell align='center' renderSortIcon={() => renderSortIcon('upvotesCount')}>
             <div className={s.title}>投票</div>
           </HeaderCell>
-          <Cell dataKey='upvotesCount' align='center' />
+          <Cell dataKey='upvotesCount' align='center' className={s.cell} />
         </Column>
 
         <Column width={65} sortable>
           <HeaderCell align='center' renderSortIcon={() => renderSortIcon('views')}>
             <div className={s.title}>浏览</div>
           </HeaderCell>
-          <Cell dataKey='views' align='center' />
+          <Cell dataKey='views' align='center' className={s.cell} />
         </Column>
 
         <Column width={60} sortable>
           <HeaderCell align='center' renderSortIcon={() => renderSortIcon('commentsCount')}>
             <div className={s.title}>评论</div>
           </HeaderCell>
-          <Cell dataKey='commentsCount' align='center' />
+          <Cell dataKey='commentsCount' align='center' className={s.cell} />
         </Column>
 
         <Column width={100}>

--- a/frontend/core/containers/thread/DashboardThread/hooks/useCMSInfo.ts
+++ b/frontend/core/containers/thread/DashboardThread/hooks/useCMSInfo.ts
@@ -61,10 +61,9 @@ export default (): TRet => {
     }
 
     query(S.pagedPosts, params).then((data) => {
-      dsb$.commit({ loading: false })
-      console.log('## TODO handle pagedChangelogs: ', data)
+      // @ts-expect-error
+      dsb$.commit({ loading: false, pagedPosts: data.pagedPosts })
     })
-    dsb$.commit({ loading: false })
   }
 
   const loadChangelogs = (): void => {

--- a/frontend/core/containers/thread/DashboardThread/salon/cms/cell/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/cms/cell/index.ts
@@ -14,7 +14,7 @@ export default () => {
     switchButton: 'mt-0.5 px-1.5 py-0.5 group-smoky-0 trans-all-100',
     //
     articleTitle: cn('text-sm pointer', cut('w-64'), fg('text.title')),
-    stateWrapper: 'scale-90 ml-2 mt-px',
+    stateWrapper: 'align-both',
     communitySlug: cn('text-sm no-underline -mt-0.5', fg('link'), 'hover:underline'),
     communityLogo: 'size-6 mr-2.5 -mt-1',
     //

--- a/frontend/core/containers/thread/DashboardThread/salon/cms/global.css
+++ b/frontend/core/containers/thread/DashboardThread/salon/cms/global.css
@@ -1,5 +1,5 @@
 .rs-table-bordered {
-  border: none;
+    border: 1px solid var(--color-table-border);
 }
 
 .rs-table-cell, .rs-table-row-header {
@@ -8,8 +8,16 @@
 /* .rs-table-cell-group-fixed-left {
   background: transparent;
 } */
+
 .rs-table-row-header .rs-table-cell {
   background: transparent;
+}
+
+.rs-table-cell-bordered .rs-table-cell {
+  border-right: 1px solid var(--color-table-border);
+}
+.rs-table-cell {
+  border-bottom: 1px solid var(--color-table-border);
 }
 
 .rs-table-row:hover {

--- a/frontend/core/containers/thread/DashboardThread/salon/cms/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/cms/index.ts
@@ -4,7 +4,7 @@ export default () => {
   const { cn, fg, fill } = useTwBelt()
 
   return {
-    wrapper: cn('w-full -ml-8'),
+    wrapper: cn('w-full pl-12'),
     title: cn('text-sm bold-sm', fg('text.title')),
     icon: {
       arrowUp: 'size-2.5 rotate-90 ml-1 mt-px',

--- a/frontend/core/containers/thread/DashboardThread/salon/cms/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/cms/index.ts
@@ -6,6 +6,7 @@ export default () => {
   return {
     wrapper: cn('w-full pl-12'),
     title: cn('text-sm bold-sm', fg('text.title')),
+    cell: cn('text-sm', fg('text.digest')),
     icon: {
       arrowUp: 'size-2.5 rotate-90 ml-1 mt-px',
       arrowDown: 'size-2.5 -rotate-90 ml-1 mt-px',

--- a/frontend/core/containers/thread/DashboardThread/salon/cms/posts/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/cms/posts/index.ts
@@ -8,5 +8,6 @@ export default () => {
   return {
     title: base.title,
     icon: base.icon,
+    cell: base.cell,
   }
 }

--- a/frontend/core/tailwind/tokens/color.css
+++ b/frontend/core/tailwind/tokens/color.css
@@ -10,6 +10,8 @@
     --color-dot: oklch(55.4% 0.046 257.417); /* slate.500 */
     --article-hover-linear: linear-gradient(315deg, oklch(1 0 0 / 0) 0%, oklch(0.97 0 0) 100%);
 
+    --color-table-border: #9d9999;
+
     /* utils */
     --color-hoverBg: #efefef78;
     --color-card: #fff;
@@ -162,6 +164,8 @@
     --color-link: #6b97d4;
     --color-dot: oklch(70.4% 0.04 256.788); /* slate.400 */
     --article-hover-linear: linear-gradient(315deg, oklch(0.55 0 0 / 0) 0%, oklch(0.32 0 0) 100%);
+
+    --color-table-border: #4f4b4b;
 
     /* utils */
     --color-hoverBg: #42424259;

--- a/frontend/dashboard/src/app/[community]/dashboard/changelog/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/changelog/layout.tsx
@@ -4,6 +4,7 @@ import { DSB_COVERS, DSB_ROUTE } from '~/const/route'
 import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon from '~/containers/thread/DashboardThread/salon/cms'
 import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
+
 import 'rsuite-table/dist/css/rsuite-table.css'
 import '~/containers/thread/DashboardThread/salon/cms/global.css'
 

--- a/frontend/dashboard/src/app/[community]/dashboard/changelog/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/changelog/layout.tsx
@@ -4,29 +4,26 @@ import { DSB_COVERS, DSB_ROUTE } from '~/const/route'
 import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon from '~/containers/thread/DashboardThread/salon/cms'
 import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
-
 import 'rsuite-table/dist/css/rsuite-table.css'
 import '~/containers/thread/DashboardThread/salon/cms/global.css'
 
-const seg = DSB_ROUTE.POST
+const seg = DSB_ROUTE.CHANGELOG
 const CRUMB_CONFIG = {
   title: '内容管理',
   seg,
   toSeg: DSB_COVERS.CMS,
-  children: [{ title: '帖子', seg }],
+  children: [{ title: '更新日志', seg }],
 }
 
-const DashboardPostPage = ({ children }) => {
+export default function DashboardChangelogPage({ children }) {
   const s = useSalon()
   const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
   return (
     <div className={s.wrapper}>
-      <Portal title='帖子管理(TODO: 参与管理头像列表)' desc='' crumbItems={crumbItems} />
+      <Portal title='更新日志管理(TODO: 右侧管理员头像列表)' desc='' crumbItems={crumbItems} />
 
       {children}
     </div>
   )
 }
-
-export default DashboardPostPage

--- a/frontend/dashboard/src/app/[community]/dashboard/changelog/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/changelog/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import CMS from '~/containers/thread/DashboardThread/CMS'
+import Changelogs from '~/containers/thread/DashboardThread/CMS/Changelogs'
 
 const DashboardChangelogPage = () => {
-  return <CMS />
+  return <Changelogs />
 }
 
 export default DashboardChangelogPage

--- a/frontend/dashboard/src/app/[community]/dashboard/cms/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/cms/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { DSB_LAYOUT_ROUTE, DSB_ROUTE, DSB_SEO_ROUTE } from '~/const/route'
+import { DSB_ROUTE } from '~/const/route'
 import BindSVG from '~/icons/Bind'
 import KanbanSVG from '~/icons/Kanban'
 import PostSVG from '~/icons/Post'
@@ -49,13 +49,13 @@ export default function CMSCoversPage() {
               {
                 title: '社区用户',
                 desc: '搜索引擎原信息，标准 OG 信息。',
-                seg: DSB_ROUTE.SEO,
+                seg: DSB_ROUTE.BLACKHOUSE,
                 Icon: BindSVG,
               },
               {
                 title: '小黑屋',
                 desc: 'X(Twitter) SEO 信息优化。',
-                seg: `${DSB_ROUTE.SEO}/${DSB_SEO_ROUTE.TWITTER}`,
+                seg: DSB_ROUTE.BLACKHOUSE,
                 Icon: ThemeSVG,
               },
             ],
@@ -72,13 +72,13 @@ export default function CMSCoversPage() {
               {
                 title: 'RSS',
                 desc: '社区主题色，壁纸及各种背景效果。',
-                seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.THEME}`,
+                seg: DSB_ROUTE.RSS,
                 Icon: ThemeSVG,
               },
               {
                 title: '三方导入/导出',
                 desc: '讨论区个性化设置。',
-                seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.POST}`,
+                seg: DSB_ROUTE.INOUT,
                 Icon: PostSVG,
               },
             ],

--- a/frontend/dashboard/src/app/[community]/dashboard/cms/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/cms/page.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { DSB_LAYOUT_ROUTE, DSB_ROUTE, DSB_SEO_ROUTE } from '~/const/route'
+import BindSVG from '~/icons/Bind'
+import KanbanSVG from '~/icons/Kanban'
+import PostSVG from '~/icons/Post'
+import ThemeSVG from '~/icons/Theme'
+import DsbCovers from '~/widgets/DsbCovers'
+
+export default function CMSCoversPage() {
+  return (
+    <DsbCovers
+      config={{
+        title: '内容管理',
+        desc: '社区内容，用户以及导入导出管理。',
+        items: [
+          {
+            groupTitle: '文章管理',
+            items: [
+              {
+                title: '帖子',
+                desc: '帖子内容管理，状态设置等。',
+                seg: DSB_ROUTE.POST,
+                Icon: BindSVG,
+              },
+              {
+                title: '更新日志',
+                desc: '更新日志内容管理，状态设置等。',
+                seg: DSB_ROUTE.CHANGELOG,
+                Icon: ThemeSVG,
+              },
+              {
+                title: '文档',
+                desc: '文档内容，目录管理，状态设置等。',
+                seg: DSB_ROUTE.DOC,
+                Icon: PostSVG,
+              },
+              {
+                title: '标签',
+                desc: '各板块标签内容，样式等。',
+                seg: DSB_ROUTE.TAGS,
+                Icon: KanbanSVG,
+              },
+            ],
+          },
+          {
+            groupTitle: '用户管理',
+            items: [
+              {
+                title: '社区用户',
+                desc: '搜索引擎原信息，标准 OG 信息。',
+                seg: DSB_ROUTE.SEO,
+                Icon: BindSVG,
+              },
+              {
+                title: '小黑屋',
+                desc: 'X(Twitter) SEO 信息优化。',
+                seg: `${DSB_ROUTE.SEO}/${DSB_SEO_ROUTE.TWITTER}`,
+                Icon: ThemeSVG,
+              },
+            ],
+          },
+          {
+            groupTitle: '其他',
+            items: [
+              {
+                title: '广播/广告',
+                desc: '品牌展示，整体布局，头像，标签等全局样式。',
+                seg: DSB_ROUTE.LAYOUT,
+                Icon: BindSVG,
+              },
+              {
+                title: 'RSS',
+                desc: '社区主题色，壁纸及各种背景效果。',
+                seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.THEME}`,
+                Icon: ThemeSVG,
+              },
+              {
+                title: '三方导入/导出',
+                desc: '讨论区个性化设置。',
+                seg: `${DSB_ROUTE.LAYOUT}/${DSB_LAYOUT_ROUTE.POST}`,
+                Icon: PostSVG,
+              },
+            ],
+          },
+        ],
+      }}
+    />
+  )
+}

--- a/frontend/dashboard/src/app/[community]/dashboard/post/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/post/layout.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { DSB_COVERS, DSB_ROUTE } from '~/const/route'
+import Portal from '~/containers/thread/DashboardThread/Portal'
+import useSalon from '~/containers/thread/DashboardThread/salon/cms'
+import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
+import 'rsuite-table/dist/css/rsuite-table.css'
+import '~/containers/thread/DashboardThread/salon/cms/global.css'
+
+const seg = DSB_ROUTE.POST
+const CRUMB_CONFIG = {
+  title: '内容管理',
+  seg,
+  toSeg: DSB_COVERS.CMS,
+  children: [{ title: '帖子', seg }],
+}
+
+const DashboardPostPage = ({ children }) => {
+  const s = useSalon()
+  const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
+
+  return (
+    <div className={s.wrapper}>
+      <Portal title='帖子管理(TODO: 右侧管理员头像列表)' desc='' crumbItems={crumbItems} />
+
+      {children}
+    </div>
+  )
+}
+
+export default DashboardPostPage

--- a/frontend/dashboard/src/app/[community]/dashboard/post/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/post/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import CMS from '~/containers/thread/DashboardThread/CMS'
+import Posts from '~/containers/thread/DashboardThread/CMS/Posts'
 
 const DashboardPostPage = () => {
-  return <CMS />
+  // return <h2>Posts</h2>
+  return <Posts />
 }
 
 export default DashboardPostPage

--- a/frontend/dashboard/src/app/[community]/dashboard/post/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/post/page.tsx
@@ -3,7 +3,6 @@
 import Posts from '~/containers/thread/DashboardThread/CMS/Posts'
 
 const DashboardPostPage = () => {
-  // return <h2>Posts</h2>
   return <Posts />
 }
 

--- a/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/workplace/page.tsx
@@ -15,7 +15,7 @@ import PostSVG from '~/icons/Post'
 import ThemeSVG from '~/icons/Theme'
 import DsbCovers from '~/widgets/DsbCovers'
 
-export default function LayoutsPage() {
+export default function WorkplaceCoversPage() {
   return (
     <DsbCovers
       config={{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Dashboard CMS with dedicated Post and Changelog pages, a new CMS cover, and consistent table styling. Improves initial data loading and fixes state cell edge cases.

- **New Features**
  - Added /dashboard/cms cover with grouped navigation (DSB_COVERS.CMS).
  - Added layout wrappers for Post and Changelog with Portal breadcrumbs and shared table CSS.
  - Routed Post and Changelog pages to their dedicated lists.

- **Refactors**
  - Standardized rsuite-table borders and cell rules; introduced table border color tokens (light/dark).
  - Adjusted layout spacing and columns (flexGrow, widths), removed fixed rowHeight, and refined titles.
  - Auto-load Posts/Changelogs on mount; fixed pagedPosts state commit and loading handling.
  - StateCell now handles missing state safely and aligns the status indicator.

<sup>Written for commit 71c28ce083b69178a62f5e85b301d5c0850d7999. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CMS dashboard pages for Posts, Changelogs and CMS covers, organized into Article, User and Other sections.
  * Posts and Changelogs now load automatically on page entry.

* **Bug Fixes**
  * Fixed rendering when an item state is missing to prevent empty/incorrect cells.

* **Style**
  * Improved table borders, cell dividers and column spacing for clearer layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->