### PR TITLE
refactor(fe): dashboard addon for portal

### DIFF
--- a/frontend/core/containers/thread/DashboardThread/AdminList.tsx
+++ b/frontend/core/containers/thread/DashboardThread/AdminList.tsx
@@ -1,0 +1,45 @@
+import { type FC, useState } from 'react'
+import SettingSVG from '~/icons/Setting'
+import type { TSpace, TUser } from '~/spec'
+import Drawer from '~/widgets/Drawer'
+import Facepile from '~/widgets/Facepile'
+import useSalon from './salon/admin_list'
+
+type TProps = {
+  title?: string
+  userList?: TUser[]
+} & TSpace
+
+const AdminList: FC<TProps> = ({ title = '参与管理', userList, ...spacing }) => {
+  const s = useSalon({ ...spacing })
+  const [showDrawer, setShowDrawer] = useState(false)
+
+  if (!userList || userList.length === 0) {
+    return null
+  }
+
+  return (
+    <div className={s.wrapper}>
+      <Drawer show={showDrawer} onClose={() => setShowDrawer(false)}>
+        <h2>管理员列表，设置</h2>
+      </Drawer>
+
+      <div className={s.header}>
+        <div className={s.title}>{title}</div>
+        <button className={s.iconBox} onClick={() => setShowDrawer(true)}>
+          <SettingSVG
+            className={s.icon}
+            onClick={() => {
+              console.log('## call the drawer')
+            }}
+          />
+        </button>
+      </div>
+      <div className={s.list}>
+        <Facepile users={userList} size='medium' showMore={false} />
+      </div>
+    </div>
+  )
+}
+
+export default AdminList

--- a/frontend/core/containers/thread/DashboardThread/CMS/Changelogs/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/CMS/Changelogs/index.tsx
@@ -105,7 +105,7 @@ export default () => {
           </Column>
         )}
 
-        <Column width={280} fixed>
+        <Column width={280} fixed flexGrow={1}>
           <HeaderCell>
             <div className={s.title}>标题</div>
           </HeaderCell>
@@ -125,21 +125,21 @@ export default () => {
           <HeaderCell align='center' renderSortIcon={() => renderSortIcon('upvotesCount')}>
             <div className={s.title}>投票</div>
           </HeaderCell>
-          <Cell dataKey='upvotesCount' align='center' />
+          <Cell dataKey='upvotesCount' align='center' className={s.cell} />
         </Column>
 
         <Column width={65} sortable>
           <HeaderCell align='center' renderSortIcon={() => renderSortIcon('views')}>
             <div className={s.title}>浏览</div>
           </HeaderCell>
-          <Cell dataKey='views' align='center' />
+          <Cell dataKey='views' align='center' className={s.cell} />
         </Column>
 
         <Column width={60} sortable>
           <HeaderCell align='center' renderSortIcon={() => renderSortIcon('commentsCount')}>
             <div className={s.title}>评论</div>
           </HeaderCell>
-          <Cell dataKey='commentsCount' align='center' />
+          <Cell dataKey='commentsCount' align='center' className={s.cell} />
         </Column>
 
         <Column width={100}>

--- a/frontend/core/containers/thread/DashboardThread/Portal.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Portal.tsx
@@ -8,6 +8,7 @@ type TProps = {
   desc?: ReactNode
   withDivider?: boolean
   crumbItems?: TBreadcrumbItem[]
+  addon?: ReactNode
 } & TSpace
 
 const Portal: FC<TProps> = ({
@@ -15,6 +16,7 @@ const Portal: FC<TProps> = ({
   desc = null,
   withDivider = true,
   crumbItems = [],
+  addon = null,
   ...spacing
 }) => {
   const s = useSalon({ ...spacing })
@@ -23,7 +25,10 @@ const Portal: FC<TProps> = ({
     <div className={s.wrapper}>
       {crumbItems?.length ? <Breadcrumbs items={crumbItems} /> : null}
 
-      <h3 className={s.title}>{title}</h3>
+      <div className={s.header}>
+        <h3 className={s.title}>{title}</h3>
+        {addon && <>{addon}</>}
+      </div>
 
       {desc && <p className={s.desc}>{desc}</p>}
       {withDivider && <div className={s.divider} />}

--- a/frontend/core/containers/thread/DashboardThread/Tags/GroupSelector.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Tags/GroupSelector.tsx
@@ -20,7 +20,7 @@ export default memo(() => {
         <Button
           ghost
           size='small'
-          className={cn('w-20', active !== null && 'saturate-0')}
+          className={cn(active !== null && 'saturate-0')}
           noBorder={active !== null}
           onClick={() => edit(null, 'activeTagGroup')}
         >

--- a/frontend/core/containers/thread/DashboardThread/Tags/ThreadSelector.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Tags/ThreadSelector.tsx
@@ -17,7 +17,7 @@ export default () => {
           <Button
             key={thread.slug}
             size='small'
-            className={cn('w-20', thread.slug !== active && 'saturate-0')}
+            className={cn(thread.slug !== active && 'saturate-0')}
             noBorder={thread.slug !== active}
             onClick={() => changeThread(thread.slug)}
             ghost

--- a/frontend/core/containers/thread/DashboardThread/Tags/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Tags/index.tsx
@@ -2,7 +2,6 @@ import AddSVG from '~/icons/Plus'
 import { callTagCreateEditor } from '~/signal'
 import Button from '~/widgets/Buttons/Button'
 
-import Portal from '../Portal'
 import useSalon from '../salon/tags'
 import Footer from './Footer'
 import GroupSelector from './GroupSelector'
@@ -13,8 +12,7 @@ export default () => {
   const s = useSalon()
 
   return (
-    <div className={s.wrapper}>
-      <Portal title='标签设置' desc='编辑各板块标签，标签分组，颜色名称等均可编辑。' />
+    <>
       <ThreadSelector />
       <GroupSelector />
       <TagList />
@@ -25,6 +23,6 @@ export default () => {
       </Button>
 
       <Footer />
-    </div>
+    </>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/hooks/useCMSInfo.ts
+++ b/frontend/core/containers/thread/DashboardThread/hooks/useCMSInfo.ts
@@ -73,8 +73,8 @@ export default (): TRet => {
       userHasLogin: false,
     }
     query(S.pagedChangelogs, params).then((data) => {
-      dsb$.commit({ loading: false })
-      console.log('## TODO handle pagedChangelogs: ', data)
+      // @ts-expect-error
+      dsb$.commit({ loading: false, pagedChangelogs: data.pagedChangelogs })
     })
   }
 

--- a/frontend/core/containers/thread/DashboardThread/salon/admin_list.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/admin_list.ts
@@ -1,0 +1,15 @@
+import useTwBelt from '~/hooks/useTwBelt'
+
+export default ({ ...spacing }) => {
+  const { cn, fg, margin, hover } = useTwBelt()
+
+  return {
+    wrapper: cn('column items-end gap-y-5 -mt-7', margin(spacing)),
+    header: cn('row-center gap-x-1'),
+    title: cn('text-xs w-auto', fg('text.digest')),
+    iconBox: cn('size-4', hover('bg')),
+    icon: cn('size-3.5', hover('icon')),
+
+    list: '-mr-2.5 -mt-1.5',
+  }
+}

--- a/frontend/core/containers/thread/DashboardThread/salon/cms/changelogs/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/cms/changelogs/index.ts
@@ -8,5 +8,6 @@ export default () => {
   return {
     title: base.title,
     icon: base.icon,
+    cell: base.cell,
   }
 }

--- a/frontend/core/containers/thread/DashboardThread/salon/portal.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/portal.ts
@@ -5,6 +5,7 @@ export default ({ ...spacing }) => {
 
   return {
     wrapper: cn('column w-full', margin(spacing)),
+    header: cn('row-between w-full'),
     title: cn('text-2xl w-auto', fg('text.title')),
     desc: cn('text-sm mt-2.5 mb-2', fg('text.digest')),
     divider: cn('w-full h-px mt-5 mb-8', bg('divider')),

--- a/frontend/core/containers/thread/DashboardThread/salon/tags/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/tags/index.ts
@@ -4,7 +4,6 @@ export default () => {
   const { cn, primary } = useTwBelt()
 
   return {
-    wrapper: cn('pl-36 pr-48'),
     icon: cn('size-3 mr-1', primary('fill')),
   }
 }

--- a/frontend/core/containers/thread/DashboardThread/salon/tags/tag_action.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/tags/tag_action.ts
@@ -5,11 +5,11 @@ import useTwBelt from '~/hooks/useTwBelt'
 export { cn } from '~/css'
 
 export default () => {
-  const { cn, fill, bg } = useTwBelt()
+  const { cn, hover } = useTwBelt()
 
   return {
     wrapper: cn('row-center gap-x-1'),
-    iconBox: cn('align-both size-4 pointer rounded', `hover:${bg('hoverBg')}`),
-    icon: cn('size-3.5', `hover:${fill('text.title')}`, fill('text.digest')),
+    iconBox: cn('size-4', hover('bg')),
+    icon: cn('size-3.5', hover('icon')),
   }
 }

--- a/frontend/core/tailwind/safelist.css
+++ b/frontend/core/tailwind/safelist.css
@@ -55,6 +55,6 @@
 /* utils */
 @source inline('debug debug-{b,g}');
 @source inline('pointer-events-none pointer');
-@source inline('border-dotted bold bold-{none,sm,lg}');
-@source inline('border-transparent outline-none bg-none bg-transparent select-none hidden');
+@source inline('border-{dotted,table-border,transparent} bold bold-{none,sm,lg}');
+@source inline('outline-none bg-none bg-transparent select-none hidden');
 @source inline('bg-gradient-to-r to-transparent saturate-150 brightness-125 touch-manipulation rounded-3xl hover-underline line-clamp-[15]');

--- a/frontend/core/tailwind/tokens/color.css
+++ b/frontend/core/tailwind/tokens/color.css
@@ -10,7 +10,7 @@
     --color-dot: oklch(55.4% 0.046 257.417); /* slate.500 */
     --article-hover-linear: linear-gradient(315deg, oklch(1 0 0 / 0) 0%, oklch(0.97 0 0) 100%);
 
-    --color-table-border: #9d9999;
+    --color-table-border: #e3e3e3;
 
     /* utils */
     --color-hoverBg: #efefef78;

--- a/frontend/dashboard/src/app/[community]/dashboard/post/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/post/layout.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { DSB_COVERS, DSB_ROUTE } from '~/const/route'
+import AdminList from '~/containers/thread/DashboardThread/AdminList'
 import Portal from '~/containers/thread/DashboardThread/Portal'
 import useSalon from '~/containers/thread/DashboardThread/salon/cms'
 import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
+import { mockUsers } from '~/mock'
 
 import 'rsuite-table/dist/css/rsuite-table.css'
 import '~/containers/thread/DashboardThread/salon/cms/global.css'
@@ -20,10 +22,16 @@ const DashboardPostPage = ({ children }) => {
   const s = useSalon()
   const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
 
+  const adminList = mockUsers(4)
+
   return (
     <div className={s.wrapper}>
-      <Portal title='帖子管理(TODO: 参与管理头像列表)' desc='' crumbItems={crumbItems} />
-
+      <Portal
+        title='帖子管理'
+        desc=''
+        crumbItems={crumbItems}
+        addon={<AdminList userList={adminList} />}
+      />
       {children}
     </div>
   )

--- a/frontend/dashboard/src/app/[community]/dashboard/tags/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/tags/layout.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { DSB_COVERS, DSB_ROUTE } from '~/const/route'
+import Portal from '~/containers/thread/DashboardThread/Portal'
+import useSalon, { cn } from '~/containers/thread/DashboardThread/salon'
+import useDsbCrumbItems from '~/hooks/useDsbCrumbItems'
+
+const seg = DSB_ROUTE.TAGS
+const CRUMB_CONFIG = {
+  title: '内容管理',
+  seg,
+  toSeg: DSB_COVERS.CMS,
+  children: [{ title: '板块管理', seg }],
+}
+
+export default ({ children }) => {
+  const s = useSalon()
+  const crumbItems = useDsbCrumbItems(CRUMB_CONFIG)
+
+  return (
+    <div className={cn(s.content, 'w-1/2')}>
+      <Portal
+        title='标签设置'
+        desc='编辑各板块标签，标签分组，颜色名称等均可编辑。'
+        crumbItems={crumbItems}
+      />
+
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an addon slot to the Dashboard Portal header and introduces an AdminList facepile, improving the post dashboard header and preparing for more header actions. Also moves the Tags page into its own layout with Portal, and polishes changelog table styles and state handling.

- **New Features**
  - Portal now supports an addon prop to render header actions.
  - Added AdminList with Facepile and a settings drawer; used on the post dashboard header.
  - Created a tags layout page that wraps content with Portal and breadcrumbs.

- **Refactors**
  - Moved Portal usage out of Tags/index into the new layout; removed fixed widths from tag selectors.
  - Unified hover styles for tag actions; added portal header styles and changelog cell styles.
  - Changelogs table: flexGrow on title column and cell class for numeric columns.
  - useCMSInfo now commits pagedChangelogs to state.
  - Tailwind: safelist includes border-table-border; table border color lightened.

<sup>Written for commit a9fe37b4fdc60b11764815a263fc84108bdee8a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin list display to dashboard management interface
  * Introduced tags management section for community dashboards
  * Enhanced Portal component with addon content support

* **Bug Fixes**
  * Fixed changelog data not persisting properly to application state

* **Style**
  * Lightened table border colors for improved visibility
  * Enhanced table layout responsiveness
  * Refined button styling for better UI consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->