### PR TITLE
fix(fe): landing theme switch & tw merge sort

### DIFF
--- a/frontend/core/tailwind/common/animation.css
+++ b/frontend/core/tailwind/common/animation.css
@@ -1,4 +1,4 @@
-@layer utilities {
+@layer components {
   @keyframes loading-grow {
     0% {
       transform: scale(0, 0);

--- a/frontend/core/tailwind/common/shadow.css
+++ b/frontend/core/tailwind/common/shadow.css
@@ -1,4 +1,4 @@
-@layer utilities {
+@layer components {
   .shadow-card {
     box-shadow: var(--shadow-card);
   }

--- a/frontend/core/tailwind/common/todo.css
+++ b/frontend/core/tailwind/common/todo.css
@@ -1,4 +1,4 @@
-@layer utilities {
+@layer components {
   .article-hover-linear::before {
     background: var(--article-hover-linear);
   }

--- a/frontend/core/tailwind/common/utils.css
+++ b/frontend/core/tailwind/common/utils.css
@@ -1,4 +1,4 @@
-@layer utilities {
+@layer components {
   .row {
     @apply flex flex-row;
   }

--- a/frontend/core/tailwind/common/zindex.css
+++ b/frontend/core/tailwind/common/zindex.css
@@ -1,4 +1,4 @@
-@layer utilities {
+@layer components {
    .z-modal {
     z-index: var(--z-modal);
   }

--- a/frontend/core/widgets/HomeHeader/salon/community_intro.ts
+++ b/frontend/core/widgets/HomeHeader/salon/community_intro.ts
@@ -4,13 +4,14 @@ import useTwBelt from '~/hooks/useTwBelt'
 export { cn } from '~/css'
 
 export default () => {
-  const { cn, fill, fg, menu, rainbow, vividDark } = useTwBelt()
+  const { cn, fill, fg, hover, menu, rainbow, vividDark } = useTwBelt()
 
   return {
     wrapper: cn('align-both w-full gap-x-4'),
     block: cn(
       'group column relative min-w-52 w-52 h-28 px-3 py-4 rounded-md pointer overflow-hidden',
-      'trans-all-200',
+      hover('bg'),
+      'items-start',
     ),
     head: 'row-center',
 

--- a/frontend/core/widgets/HomeHeader/salon/feature_intro.ts
+++ b/frontend/core/widgets/HomeHeader/salon/feature_intro.ts
@@ -4,7 +4,7 @@ import useTwBelt from '~/hooks/useTwBelt'
 export { cn } from '~/css'
 
 export default () => {
-  const { cn, fill, bg, fg, menu, rainbow, rainbowSoft, vividDark } = useTwBelt()
+  const { cn, fill, hover, bg, fg, menu, rainbow, rainbowSoft, vividDark } = useTwBelt()
 
   const blockBase = 'relative align-both size-12 min-w-12 mr-4 rounded-lg'
   const blockBg = 'absolute top-0 left-0 w-full h-full rounded-lg trans-all-100'
@@ -14,8 +14,9 @@ export default () => {
   return {
     wrapper: cn('align-both w-full gap-x-4'),
     block: cn(
-      'row group relative min-w-72 w-72 h-28 px-3 pt-5 rounded-md pointer overflow-hidden',
-      'trans-all-200',
+      'row group relative min-w-72 w-72 h-28 px-3 pt-5 rounded-lg pointer overflow-hidden',
+      hover('bg'),
+      'items-start',
     ),
     iconBlock: blockBase,
     blockGrey: cn(blockBg, 'opacity-100 group-hover:opacity-0', bg('sandBox')),

--- a/frontend/dashboard/src/app/domain.css
+++ b/frontend/dashboard/src/app/domain.css
@@ -84,7 +84,7 @@
   }
 }
 
-@layer utilities {
+@layer components {
   .table-col-select {
     overflow: hidden !important;
     transition:

--- a/frontend/landing/app/widgets/Landing/BatteryBento/DarkMode/index.tsx
+++ b/frontend/landing/app/widgets/Landing/BatteryBento/DarkMode/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import THEME from '~/const/theme'
 import useHover from '~/hooks/useHover'
 import useTheme from '~/hooks/useTheme'
@@ -7,22 +7,40 @@ import useSalon, { cn } from '../../salon/battery_bento/dark_mode'
 import Panel from './Panel'
 
 export default function DarkMode() {
-  const [hoverIn, setHoverIn] = useState(false)
   const s = useSalon()
   const { toggle, theme } = useTheme()
 
   const [ref, isHovered] = useHover<HTMLDivElement>()
 
+  const prevHoveredRef = useRef(false)
+  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   useEffect(() => {
-    if (isHovered) {
-      setHoverIn(true)
-      if (hoverIn) {
-        setTimeout(() => toggle(), 300)
-      }
-    } else {
-      setHoverIn(false)
+    const entered = isHovered && !prevHoveredRef.current
+    const left = !isHovered && prevHoveredRef.current
+
+    prevHoveredRef.current = isHovered
+
+    if (entered) {
+      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
+
+      hoverTimeoutRef.current = setTimeout(() => {
+        hoverTimeoutRef.current = null
+        toggle()
+      }, 300)
     }
-  }, [isHovered, hoverIn, toggle])
+
+    if (left && hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current)
+      hoverTimeoutRef.current = null
+    }
+  }, [isHovered, toggle])
+
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current)
+    }
+  }, [])
 
   const showStars = isHovered || theme === THEME.DARK
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed landing page dark mode hover toggle to prevent flicker and accidental multiple switches. Adjusted Tailwind layer order so hover styles and transitions apply consistently.

- **Bug Fixes**
  - Dark mode now toggles once on hover enter after 300ms and cancels on quick leave.
  - Cleanup ensures no stray timeouts on unmount.

- **Refactors**
  - Moved common Tailwind CSS from utilities to components layer to fix class merge order.
  - Updated HomeHeader blocks to use hover('bg'), add items-start, and rounded styling for consistent hover behavior.

<sup>Written for commit 24b7a1b65f964e68c870d6080a2ff36d1fefaa43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced hover interactions with refined state management and delayed toggle behavior (300ms) in dark mode component.
  * Improved hover-driven styling across UI components for better visual feedback.

* **Style**
  * Visual refinement to component border radius for improved design consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->