### PR TITLE
refactor(be): add raw for oauth provider and refactor tests

### DIFF
--- a/backend/main/lib/groupher_server/accounts/delegates/profile.ex
+++ b/backend/main/lib/groupher_server/accounts/delegates/profile.ex
@@ -113,9 +113,10 @@ defmodule GroupherServer.Accounts.Delegate.Profile do
   def update_geo(_user, _remote_ip), do: {:ok, :pass}
 
   def link_oauth(login, provider) do
-    provider = provider |> keys_to_atoms
+    provider = normalize_oauth_provider(provider)
 
     with {:ok, user} <- ORM.find_by(User, login: login),
+         {:ok, :pass} <- assert_oauth_provider_not_linked(provider, user),
          create_profile(user, provider),
          update_profile_social(user, provider) do
       gen_token(user)
@@ -123,10 +124,10 @@ defmodule GroupherServer.Accounts.Delegate.Profile do
   end
 
   def unlink_oauth(login, provider) do
-    provider = provider |> keys_to_atoms
+    provider = normalize_oauth_provider(provider)
 
     with {:ok, user} <- ORM.find_by(User, login: login),
-         {:ok, oauth_provider} <- find_oauth_provider(provider) do
+         {:ok, oauth_provider} <- find_user_oauth_provider(user, provider) do
       {:ok, provider_count} =
         from(o in OauthProvider, where: o.user_id == ^user.id)
         |> ORM.count()
@@ -145,7 +146,7 @@ defmodule GroupherServer.Accounts.Delegate.Profile do
   user_info be like
   """
   def signin_oauth(provider) do
-    provider = provider |> keys_to_atoms
+    provider = normalize_oauth_provider(provider)
 
     case find_oauth_provider(provider) do
       {:ok, oauth_provider} ->
@@ -163,6 +164,45 @@ defmodule GroupherServer.Accounts.Delegate.Profile do
       provider: provider.provider,
       provider_id: provider.provider_id
     )
+  end
+
+  # `keys_to_atoms/1` is convenient for top-level oauth provider fields, but it will
+  # try to convert nested map keys as atoms as well.
+  # `raw` is provider-native profile and can contain arbitrary keys (ex: "profile_image_url"),
+  # so we keep it as-is to avoid atom conversion errors / atom leaks.
+  defp normalize_oauth_provider(provider) when is_map(provider) do
+    raw = Map.get(provider, :raw, Map.get(provider, "raw"))
+
+    provider
+    |> Map.drop([:raw, "raw"])
+    |> keys_to_atoms()
+    |> maybe_put_raw(raw)
+  end
+
+  defp maybe_put_raw(provider, %{} = raw), do: Map.put(provider, :raw, raw)
+  defp maybe_put_raw(provider, raw) when is_list(raw), do: Map.put(provider, :raw, raw)
+  defp maybe_put_raw(provider, _raw), do: provider
+
+  defp find_user_oauth_provider(%User{} = user, provider) do
+    OauthProvider
+    |> ORM.find_by(
+      user_id: user.id,
+      provider: provider.provider,
+      provider_id: provider.provider_id
+    )
+  end
+
+  defp assert_oauth_provider_not_linked(provider, %User{} = user) do
+    case find_oauth_provider(provider) do
+      {:ok, oauth_provider} when oauth_provider.user_id == user.id ->
+        {:ok, :pass}
+
+      {:ok, _oauth_provider} ->
+        raise_error(:already_exist, "oauth provider already linked")
+
+      {:error, _} ->
+        {:ok, :pass}
+    end
   end
 
   @doc """

--- a/backend/main/lib/groupher_server/accounts/delegates/profile.ex
+++ b/backend/main/lib/groupher_server/accounts/delegates/profile.ex
@@ -317,8 +317,15 @@ defmodule GroupherServer.Accounts.Delegate.Profile do
   def update_profile_social(_, _), do: {:ok, :pass}
 
   defp create_profile(user, oauth_profile) do
-    # OauthProvider |> ORM.create(Map.merge(oauth_profile, %{"user_id" => user.id}))
-    OauthProvider |> ORM.create(Map.merge(oauth_profile, %{user_id: user.id}))
+    attrs = Map.merge(oauth_profile, %{user_id: user.id})
+
+    # link_oauth can be called repeatedly for the same provider.
+    # after `assert_oauth_provider_not_linked/2` passes, we can safely upsert.
+    OauthProvider
+    |> ORM.upsert_by(
+      [provider: oauth_profile.provider, provider_id: oauth_profile.provider_id],
+      attrs
+    )
   end
 
   defp update_social_ifneed(%User{} = user, %{social: attrs}) do

--- a/backend/main/lib/groupher_server/accounts/models/oauth_provider.ex
+++ b/backend/main/lib/groupher_server/accounts/models/oauth_provider.ex
@@ -10,7 +10,7 @@ defmodule GroupherServer.Accounts.Model.OauthProvider do
 
   @schema_prefix DBPrefix.account()
   @required_fields ~w(provider_id provider login nickname avatar user_id)a
-  @optional_fields ~w(email locale country city company bio)a
+  @optional_fields ~w(email locale country city company bio raw)a
 
   @type t :: %OauthProvider{}
   schema "oauth_providers" do
@@ -26,6 +26,7 @@ defmodule GroupherServer.Accounts.Model.OauthProvider do
     field(:country, :string)
     field(:city, :string)
     field(:company, :string)
+    field(:raw, :map)
 
     belongs_to(:user, User, foreign_key: :user_id)
   end

--- a/backend/main/lib/groupher_server_web/context.ex
+++ b/backend/main/lib/groupher_server_web/context.ex
@@ -31,15 +31,8 @@ defmodule GroupherServerWeb.Context do
   authorization header is sent.
   """
   def build_context(conn) do
-    IO.inspect(conn.cookies, label: "## ---> Conn Cookies")
-
     with token when not is_nil(token) <- get_token_from(conn),
          {:ok, cur_user} <- authorize(token) do
-      # IO.inspect(
-      #   RemoteIP.parse(get_req_header(conn, "x-forwarded-for")),
-      #   label: "#># x-forwarded-for"
-      # )
-
       case RemoteIP.parse(get_req_header(conn, "x-forwarded-for")) do
         {:ok, remote_ip} ->
           %{cur_user: cur_user, remote_ip: remote_ip}

--- a/backend/main/lib/groupher_server_web/resolvers/accounts_resolver.ex
+++ b/backend/main/lib/groupher_server_web/resolvers/accounts_resolver.ex
@@ -84,25 +84,22 @@ defmodule GroupherServerWeb.Resolvers.Accounts do
   end
 
   def follow(_root, ~m(login)a, %{context: %{cur_user: cur_user}}) do
-    with {:ok, user_id} <- Accounts.get_userid_and_cache(login) do
-      Accounts.follow(cur_user, %User{id: user_id})
-    else
+    case Accounts.get_userid_and_cache(login) do
+      {:ok, user_id} -> Accounts.follow(cur_user, %User{id: user_id})
       _ -> raise_error(:not_exist, "#{login} not found")
     end
   end
 
   def undo_follow(_root, ~m(login)a, %{context: %{cur_user: cur_user}}) do
-    with {:ok, user_id} <- Accounts.get_userid_and_cache(login) do
-      Accounts.undo_follow(cur_user, %User{id: user_id})
-    else
+    case Accounts.get_userid_and_cache(login) do
+      {:ok, user_id} -> Accounts.undo_follow(cur_user, %User{id: user_id})
       _ -> raise_error(:not_exist, "#{login} not found")
     end
   end
 
   def paged_followers(_root, ~m(login filter)a, %{context: %{cur_user: cur_user}}) do
-    with {:ok, user_id} <- Accounts.get_userid_and_cache(login) do
-      Accounts.paged_followers(%User{id: user_id}, filter, cur_user)
-    else
+    case Accounts.get_userid_and_cache(login) do
+      {:ok, user_id} -> Accounts.paged_followers(%User{id: user_id}, filter, cur_user)
       _ -> raise_error(:not_exist, "#{login} not found")
     end
   end

--- a/backend/main/lib/groupher_server_web/schema/account/account_metrics.ex
+++ b/backend/main/lib/groupher_server_web/schema/account/account_metrics.ex
@@ -60,6 +60,7 @@ defmodule GroupherServerWeb.Schema.Account.Metrics do
     field(:country, :string)
     field(:city, :string)
     field(:company, :string)
+    field(:raw, :json)
   end
 
   input_object :customization_input do

--- a/backend/main/lib/helper/parse_remote_ip.ex
+++ b/backend/main/lib/helper/parse_remote_ip.ex
@@ -10,7 +10,7 @@ defmodule Helper.RemoteIP do
     if Mix.env() == :test, do: {:ok, @remote_ip}, else: {:error, "NOT_FOUND"}
   end
 
-  # remote ip is the fisrt ip in the proxy_ips chain
+  # remote ip is the first ip in the proxy_ips chain
   def parse([proxy_ips]) do
     client_ip = proxy_ips |> String.split(",") |> List.first()
 

--- a/backend/main/lib/support/factory/articles.ex
+++ b/backend/main/lib/support/factory/articles.ex
@@ -1,0 +1,180 @@
+defmodule GroupherServer.Support.Factory.Articles do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      def mock_rich_text(text \\ "text"), do: unquote(__MODULE__).rich_text(text)
+      def mock_rich_text(text1, text2), do: unquote(__MODULE__).rich_text(text1, text2)
+
+      defp mock_meta(:post) do
+        unquote(__MODULE__).post_base(@default_article_meta, @default_emotions)
+        |> Map.merge(%{
+          author: mock(:author),
+          community: mock(:community),
+          communities: [mock(:community), mock(:community)]
+        })
+      end
+
+      defp mock_meta(:changelog) do
+        unquote(__MODULE__).changelog_base(@default_article_meta, @default_emotions)
+        |> Map.merge(%{
+          author: mock(:author),
+          community: mock(:community),
+          communities: [mock(:community), mock(:community)]
+        })
+      end
+
+      defp mock_meta(:doc) do
+        unquote(__MODULE__).doc_base(@default_article_meta, @default_emotions)
+        |> Map.merge(%{
+          author: mock(:author),
+          community: mock(:community),
+          communities: [mock(:community), mock(:community)]
+        })
+      end
+
+      defp mock_meta(:blog) do
+        unquote(__MODULE__).blog_base(@default_article_meta, @default_emotions)
+        |> Map.merge(%{
+          author: mock(:author),
+          community: mock(:community),
+          communities: [mock(:community)]
+        })
+      end
+    end
+  end
+
+  # simulate editor.js fmt rich text
+  def rich_text(text \\ "text") do
+    """
+    {
+      "time": 111,
+      "blocks": [
+        {
+          "id": "lldjfiek",
+          "type": "paragraph",
+          "data": {
+            "text": "#{text}"
+          }
+        }
+      ],
+      "version": "2.22.0"
+    }
+    """
+  end
+
+  # for link tasks
+  def rich_text(text1, text2) do
+    """
+    {
+      "time": 111,
+      "blocks": [
+        {
+          "id": "lldjfiek",
+          "type": "paragraph",
+          "data": {
+            "text": "#{text1}"
+          }
+        },
+        {
+          "id": "llddiekek",
+          "type": "paragraph",
+          "data": {
+            "text": "#{text2}"
+          }
+        }
+      ],
+      "version": "2.22.0"
+    }
+    """
+  end
+
+  def article_base(meta, title, text, default_emotions, opts \\ []) do
+    active_at_offset = Keyword.get(opts, :active_at_offset, -1)
+
+    active_at =
+      Timex.shift(Timex.now(), seconds: active_at_offset)
+      |> DateTime.truncate(:second)
+
+    %{
+      meta: meta,
+      title: title,
+      body: rich_text(text),
+      views: 0,
+      emotions: default_emotions,
+      active_at: active_at,
+      pending: 0
+    }
+  end
+
+  def post_base(default_article_meta, default_emotions) do
+    text = Faker.Lorem.sentence(10)
+
+    title = "post-#{String.slice(text, 1, 49)}"
+
+    article_base(
+      default_article_meta,
+      title,
+      text,
+      default_emotions
+    )
+    |> Map.merge(%{
+      digest: String.slice(text, 100, 150),
+      solution_digest: String.slice(text, 1, 150)
+    })
+  end
+
+  def changelog_base(default_article_meta, default_emotions) do
+    text = Faker.Lorem.sentence(10)
+
+    title = "changelog-#{String.slice(text, 1, 49)}"
+    meta = Map.merge(default_article_meta, %{thread: "CHANGELOG"})
+
+    article_base(
+      meta,
+      title,
+      text,
+      default_emotions
+    )
+    |> Map.merge(%{
+      digest: String.slice(text, 100, 150),
+      solution_digest: String.slice(text, 1, 150),
+      length: String.length(text)
+    })
+  end
+
+  def doc_base(default_article_meta, default_emotions) do
+    text = Faker.Lorem.sentence(10)
+
+    title = "doc-#{String.slice(text, 1, 49)}"
+    meta = Map.merge(default_article_meta, %{thread: "DOC"})
+
+    article_base(
+      meta,
+      title,
+      text,
+      default_emotions
+    )
+    |> Map.merge(%{
+      digest: String.slice(text, 100, 150),
+      solution_digest: String.slice(text, 1, 150),
+      length: String.length(text)
+    })
+  end
+
+  def blog_base(default_article_meta, default_emotions) do
+    text = Faker.Lorem.sentence(10)
+
+    title = "blog-#{String.slice(text, 1, 49)}"
+    meta = Map.merge(default_article_meta, %{thread: "BLOG"})
+
+    article_base(
+      meta,
+      title,
+      text,
+      default_emotions,
+      active_at_offset: 1
+    )
+    |> Map.merge(%{length: String.length(text)})
+  end
+end

--- a/backend/main/lib/support/factory/factory.ex
+++ b/backend/main/lib/support/factory/factory.ex
@@ -26,50 +26,8 @@ defmodule GroupherServer.Support.Factory do
   @default_article_meta CMS.Model.Embeds.ArticleMeta.default_meta()
   @default_emotions CMS.Model.Embeds.CommentEmotion.default_emotions()
 
-  # simulate editor.js fmt rich text
-  def mock_rich_text(text \\ "text") do
-    """
-    {
-      "time": 111,
-      "blocks": [
-        {
-          "id": "lldjfiek",
-          "type": "paragraph",
-          "data": {
-            "text": "#{text}"
-          }
-        }
-      ],
-      "version": "2.22.0"
-    }
-    """
-  end
-
-  # for link tasks
-  def mock_rich_text(text1, text2) do
-    """
-    {
-      "time": 111,
-      "blocks": [
-        {
-          "id": "lldjfiek",
-          "type": "paragraph",
-          "data": {
-            "text": "#{text1}"
-          }
-        },
-        {
-          "id": "llddiekek",
-          "type": "paragraph",
-          "data": {
-            "text": "#{text2}"
-          }
-        }
-      ],
-      "version": "2.22.0"
-    }
-    """
-  end
+  use GroupherServer.Support.Factory.Articles
+  use GroupherServer.Support.Factory.Oauth
 
   def mock_xss_string(:safe) do
     mock_rich_text("&lt;script&gt;blackmail&lt;/script&gt;")
@@ -81,100 +39,6 @@ defmodule GroupherServer.Support.Factory do
 
   def mock_comment(text \\ "comment") do
     mock_rich_text(text)
-  end
-
-  # alias CMS.Model.Post
-  defp mock_meta(:post) do
-    text = Faker.Lorem.sentence(10)
-
-    %{
-      meta: @default_article_meta,
-      title: "post-#{String.slice(text, 1, 49)}",
-      body: mock_rich_text(text),
-      digest: String.slice(text, 100, 150),
-      solution_digest: String.slice(text, 1, 150),
-      author: mock(:author),
-      # views: Enum.random(0..2000),
-      views: 0,
-      community: mock(:community),
-      communities: [
-        mock(:community),
-        mock(:community)
-      ],
-      emotions: @default_emotions,
-      active_at: Timex.shift(Timex.now(), seconds: -1) |> DateTime.truncate(:second),
-      pending: 0
-    }
-  end
-
-  defp mock_meta(:changelog) do
-    text = Faker.Lorem.sentence(10)
-
-    %{
-      meta: @default_article_meta |> Map.merge(%{thread: "CHANGELOG"}),
-      title: "changelog-#{String.slice(text, 1, 49)}",
-      body: mock_rich_text(text),
-      digest: String.slice(text, 100, 150),
-      solution_digest: String.slice(text, 1, 150),
-      length: String.length(text),
-      author: mock(:author),
-      # views: Enum.random(0..2000),
-      views: 0,
-      community: mock(:community),
-      communities: [
-        mock(:community),
-        mock(:community)
-      ],
-      emotions: @default_emotions,
-      active_at: Timex.shift(Timex.now(), seconds: -1) |> DateTime.truncate(:second),
-      pending: 0
-    }
-  end
-
-  defp mock_meta(:doc) do
-    text = Faker.Lorem.sentence(10)
-
-    %{
-      meta: @default_article_meta |> Map.merge(%{thread: "DOC"}),
-      title: "doc-#{String.slice(text, 1, 49)}",
-      body: mock_rich_text(text),
-      digest: String.slice(text, 100, 150),
-      solution_digest: String.slice(text, 1, 150),
-      length: String.length(text),
-      author: mock(:author),
-      # views: Enum.random(0..2000),
-      views: 0,
-      community: mock(:community),
-      communities: [
-        mock(:community),
-        mock(:community)
-      ],
-      emotions: @default_emotions,
-      active_at: Timex.shift(Timex.now(), seconds: -1) |> DateTime.truncate(:second),
-      pending: 0
-    }
-  end
-
-  defp mock_meta(:blog) do
-    text = Faker.Lorem.sentence(10)
-
-    %{
-      meta: @default_article_meta |> Map.merge(%{thread: "BLOG"}),
-      title: "blog-#{String.slice(text, 1, 49)}",
-      body: mock_rich_text(text),
-      # digest: String.slice(text, 1, 150),
-      length: String.length(text),
-      author: mock(:author),
-      # views: Enum.random(0..2000),
-      views: 0,
-      community: mock(:community),
-      communities: [
-        mock(:community)
-      ],
-      emotions: @default_emotions,
-      active_at: Timex.shift(Timex.now(), seconds: +1) |> DateTime.truncate(:second),
-      pending: 0
-    }
   end
 
   defp mock_meta(:comment) do
@@ -264,43 +128,6 @@ defmodule GroupherServer.Support.Factory do
     }
   end
 
-  defp mock_meta(:github_profile) do
-    unique_num = System.unique_integer([:positive, :monotonic])
-
-    %{
-      id: "#{Faker.Person.first_name()} #{unique_num}",
-      login: "#{Faker.Person.first_name()}#{unique_num}",
-      github_id: "#{unique_num + 1000}",
-      node_id: "#{unique_num + 2000}",
-      access_token: "#{unique_num + 3000}",
-      bio: Faker.Lorem.Shakespeare.romeo_and_juliet(),
-      company: Faker.Company.name(),
-      location: "chengdu",
-      email: Faker.Internet.email(),
-      avatar_url: Faker.Avatar.image_url(),
-      html_url: Faker.Avatar.image_url(),
-      followers: unique_num * unique_num,
-      following: unique_num * unique_num * unique_num
-    }
-  end
-
-  defp mock_meta(:oauth_profile) do
-    unique_num = System.unique_integer([:positive, :monotonic])
-
-    %{
-      provider: "github",
-      provider_id: unique_num |> to_string,
-      login: "#{Faker.Person.first_name()}#{unique_num}",
-      bio: Faker.Lorem.Shakespeare.romeo_and_juliet(),
-      company: Faker.Company.name(),
-      country: "",
-      city: "",
-      email: Faker.Internet.email(),
-      nickname: "#{Faker.Person.first_name()}#{unique_num}",
-      avatar: Faker.Avatar.image_url()
-    }
-  end
-
   defp mock_meta(:bill) do
     %{
       payment_usage: "donate",
@@ -324,7 +151,10 @@ defmodule GroupherServer.Support.Factory do
   def mock_attrs(:article_tag, attrs), do: mock_meta(:article_tag) |> Map.merge(attrs)
   def mock_attrs(:category, attrs), do: mock_meta(:category) |> Map.merge(attrs)
   def mock_attrs(:github_profile, attrs), do: mock_meta(:github_profile) |> Map.merge(attrs)
-  def mock_attrs(:oauth_profile, attrs), do: mock_meta(:oauth_profile) |> Map.merge(attrs)
+  def mock_attrs(:oauth_profile, attrs) do
+    provider = Map.get(attrs, :provider) || Map.get(attrs, "provider") || "github"
+    mock_meta({:oauth_profile, provider}) |> Map.merge(attrs)
+  end
   def mock_attrs(:bill, attrs), do: mock_meta(:bill) |> Map.merge(attrs)
 
   def mock_attrs(thread, attrs), do: mock_meta(thread) |> Map.merge(attrs)

--- a/backend/main/lib/support/factory/oauth.ex
+++ b/backend/main/lib/support/factory/oauth.ex
@@ -1,0 +1,139 @@
+defmodule GroupherServer.Support.Factory.Oauth do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      defp mock_meta(:github_profile), do: unquote(__MODULE__).github_profile_meta()
+
+      defp mock_meta(:oauth_profile), do: unquote(__MODULE__).oauth_profile("github")
+
+      defp mock_meta({:oauth_profile, provider}) when is_binary(provider),
+        do: unquote(__MODULE__).oauth_profile(provider)
+    end
+  end
+
+  def github_profile_meta do
+    unique_num = System.unique_integer([:positive, :monotonic])
+
+    %{
+      id: "#{Faker.Person.first_name()} #{unique_num}",
+      login: "#{Faker.Person.first_name()}#{unique_num}",
+      github_id: "#{unique_num + 1000}",
+      node_id: "#{unique_num + 2000}",
+      access_token: "#{unique_num + 3000}",
+      bio: Faker.Lorem.Shakespeare.romeo_and_juliet(),
+      company: Faker.Company.name(),
+      location: "chengdu",
+      email: Faker.Internet.email(),
+      avatar_url: Faker.Avatar.image_url(),
+      html_url: Faker.Avatar.image_url(),
+      followers: unique_num * unique_num,
+      following: unique_num * unique_num * unique_num
+    }
+  end
+
+  def oauth_profile(provider \\ "github") when is_binary(provider) do
+    unique_num = System.unique_integer([:positive, :monotonic])
+
+    provider_id = unique_num |> to_string()
+    login = "#{Faker.Person.first_name()}#{unique_num}"
+    nickname = "#{Faker.Person.first_name()}#{unique_num}"
+    email = Faker.Internet.email()
+    avatar = Faker.Avatar.image_url()
+
+    %{
+      provider: provider,
+      provider_id: provider_id,
+      login: login,
+      bio: Faker.Lorem.Shakespeare.romeo_and_juliet(),
+      company: Faker.Company.name(),
+      country: "",
+      city: "",
+      email: email,
+      nickname: nickname,
+      avatar: avatar,
+      raw: oauth_raw(provider, provider_id, login, nickname, email, avatar)
+    }
+  end
+
+  # provider native profile mock (string keys only, so it matches JSON decode behavior)
+  defp oauth_raw("github", provider_id, login, nickname, email, avatar) do
+    %{
+      "id" => provider_id,
+      "login" => login,
+      "name" => nickname,
+      "email" => email,
+      "avatar_url" => avatar,
+      "html_url" => "https://github.com/#{login}"
+    }
+  end
+
+  defp oauth_raw("google", provider_id, _login, nickname, email, avatar) do
+    %{
+      "sub" => provider_id,
+      "name" => nickname,
+      "email" => email,
+      "email_verified" => true,
+      "picture" => avatar,
+      "locale" => "en"
+    }
+  end
+
+  defp oauth_raw("facebook", provider_id, _login, nickname, email, avatar) do
+    %{
+      "id" => provider_id,
+      "name" => nickname,
+      "email" => email,
+      "picture" => %{
+        "data" => %{
+          "url" => avatar,
+          "is_silhouette" => false
+        }
+      }
+    }
+  end
+
+  defp oauth_raw("twitter", provider_id, login, nickname, _email, avatar) do
+    %{
+      "id" => provider_id,
+      "username" => login,
+      "name" => nickname,
+      "profile_image_url" => avatar
+    }
+  end
+
+  defp oauth_raw("discord", provider_id, login, nickname, email, avatar) do
+    %{
+      "id" => provider_id,
+      "username" => login,
+      "global_name" => nickname,
+      "email" => email,
+      "avatar" => avatar
+    }
+  end
+
+  defp oauth_raw("notion", provider_id, _login, nickname, email, avatar) do
+    %{
+      "bot_id" => provider_id,
+      "owner" => %{
+        "type" => "user",
+        "user" => %{
+          "id" => provider_id,
+          "name" => nickname,
+          "person" => %{"email" => email},
+          "avatar_url" => avatar
+        }
+      }
+    }
+  end
+
+  defp oauth_raw(_provider, provider_id, login, nickname, email, avatar) do
+    %{
+      "id" => provider_id,
+      "login" => login,
+      "name" => nickname,
+      "email" => email,
+      "avatar" => avatar
+    }
+  end
+end

--- a/backend/main/priv/repo/migrations/20260124090000_fix_oauth_providers_unique_index_and_add_raw.exs
+++ b/backend/main/priv/repo/migrations/20260124090000_fix_oauth_providers_unique_index_and_add_raw.exs
@@ -1,0 +1,25 @@
+defmodule GroupherServer.Repo.Migrations.FixOauthProvidersUniqueIndexAndAddRaw do
+  use Ecto.Migration
+
+  def up do
+    alter table(:oauth_providers, prefix: "account") do
+      add(:raw, :map)
+    end
+
+    # previously: unique_index(:oauth_providers, [:user_id, :provider, :provider_id])
+    # the lookup in signin_oauth is by provider + provider_id, so we make it unique globally
+    create unique_index(:oauth_providers, [:provider, :provider_id], prefix: "account")
+
+    drop_if_exists(index(:oauth_providers, [:user_id, :provider, :provider_id], prefix: "account"))
+  end
+
+  def down do
+    drop_if_exists(index(:oauth_providers, [:provider, :provider_id], prefix: "account"))
+
+    create unique_index(:oauth_providers, [:user_id, :provider, :provider_id], prefix: "account")
+
+    alter table(:oauth_providers, prefix: "account") do
+      remove(:raw)
+    end
+  end
+end

--- a/backend/main/test/groupher_server/accounts/oauth_test.exs
+++ b/backend/main/test/groupher_server/accounts/oauth_test.exs
@@ -2,19 +2,17 @@ defmodule GroupherServer.Test.Accounts.Oauth do
   @moduledoc false
 
   use GroupherServer.TestTools
-  # TODO import Service.Utils move both helper and github
   import Helper.Utils
 
   alias Accounts.Model.OauthProvider
 
   # @valid_user mock_attrs(:user)
-  @valid_github_profile mock_attrs(:oauth_profile) |> map_key_stringify
-  @valid_twitter_profile mock_attrs(:oauth_profile)
-                         |> Map.merge(%{provider: "twitter"})
-                         |> map_key_stringify
+  @valid_github_profile mock_attrs(:oauth_profile, %{provider: "github"}) |> map_key_stringify
+  @valid_twitter_profile mock_attrs(:oauth_profile, %{provider: "twitter"}) |> map_key_stringify
 
   # link oauth
   describe "[oauth login]" do
+    @tag :wip
     test "can register new valid oauth github user" do
       assert {:error, _} =
                ORM.find_by(OauthProvider, %{
@@ -42,10 +40,14 @@ defmodule GroupherServer.Test.Accounts.Oauth do
       assert oauth_provider.login == @valid_github_profile["login"]
       assert oauth_provider.user_id == user.id
 
+      assert oauth_provider.raw["login"] == @valid_github_profile["login"]
+      assert oauth_provider.raw["avatar_url"] == @valid_github_profile["avatar"]
+
       assert signin_res |> Map.has_key?(:user)
       assert signin_res |> Map.has_key?(:token)
     end
 
+    @tag :wip
     test "existing user can signin" do
       {:ok, signin_res} = Accounts.signin_oauth(@valid_github_profile)
 
@@ -53,6 +55,7 @@ defmodule GroupherServer.Test.Accounts.Oauth do
       assert signin_res |> Map.has_key?(:token)
     end
 
+    @tag :wip
     test "existing user can signin multiple times" do
       {:ok, _} = Accounts.signin_oauth(@valid_github_profile)
       {:ok, _} = Accounts.signin_oauth(@valid_github_profile)
@@ -62,6 +65,7 @@ defmodule GroupherServer.Test.Accounts.Oauth do
       assert {:ok, 1} == ORM.count(OauthProvider)
     end
 
+    @tag :wip
     test "existing non-existing user fails" do
       {:ok, _signin_res} =
         Accounts.signin_oauth(@valid_github_profile)
@@ -70,6 +74,7 @@ defmodule GroupherServer.Test.Accounts.Oauth do
         Accounts.signin_oauth(%{@valid_github_profile | "provider_id" => "non-existing-id"})
     end
 
+    @tag :wip
     test "can link oauth provider to existing user" do
       user_login = @valid_twitter_profile["login"]
       github_provider = @valid_github_profile |> Map.put("login", user_login)
@@ -88,8 +93,11 @@ defmodule GroupherServer.Test.Accounts.Oauth do
       assert first.user_id == last.user_id
       assert first.provider == "github"
       assert last.provider == "twitter"
+
+      assert last.raw["username"] == @valid_twitter_profile["login"]
     end
 
+    @tag :wip
     test "can unlink oauth provider" do
       user_login = @valid_twitter_profile["login"]
       github_provider = @valid_github_profile |> Map.put("login", user_login)
@@ -108,6 +116,7 @@ defmodule GroupherServer.Test.Accounts.Oauth do
       assert after_delete.provider == "github"
     end
 
+    @tag :wip
     test "can not unlink oauth provider if there is only one" do
       user_login = @valid_twitter_profile["login"]
       github_provider = @valid_github_profile |> Map.put("login", user_login)

--- a/backend/main/test/groupher_server/cms/community/community_test.exs
+++ b/backend/main/test/groupher_server/cms/community/community_test.exs
@@ -4,9 +4,6 @@ defmodule GroupherServer.Test.CMS.Community do
 
   alias CMS.Model.CommunityThread
 
-  @community_normal Constant.CMS.pending(:normal)
-  @community_applying Constant.CMS.pending(:applying)
-
   setup do
     {:ok, user} = db_insert(:user)
     {:ok, community} = mock_community(user)

--- a/backend/main/test/groupher_server/cms/hooks/audit_post_test.exs
+++ b/backend/main/test/groupher_server/cms/hooks/audit_post_test.exs
@@ -5,10 +5,6 @@ defmodule GroupherServer.Test.CMS.Hooks.AuditPost do
 
   # alias CMS.Delegate.Hooks
 
-  @audit_legal Constant.CMS.pending(:legal)
-  @audit_illegal Constant.CMS.pending(:illegal)
-  @audit_failed Constant.CMS.pending(:audit_failed)
-
   setup do
     {:ok, user} = db_insert(:user)
     {:ok, post} = db_insert(:post)

--- a/backend/main/test/groupher_server/mailer/email_test.exs
+++ b/backend/main/test/groupher_server/mailer/email_test.exs
@@ -5,8 +5,6 @@ defmodule GroupherServer.Test.Mailer do
   use GroupherServer.TestTools
   use Bamboo.Test
 
-  @support_email get_config(:system_emails, :support_email)
-
   describe "basic email" do
     # test "send welcome email when user has email addr" do
     #   {:ok, user} = db_insert(:user, %{email: "fake@gmail.com"})

--- a/backend/main/test/groupher_server/seeds/clean_up_test.exs
+++ b/backend/main/test/groupher_server/seeds/clean_up_test.exs
@@ -14,7 +14,7 @@ defmodule GroupherServer.Test.Seeds.CleanUp do
   end
 
   describe "[community clean up]" do
-    test "can clean up a community", ~m(user post_attrs)a do
+    test "can clean up a community", _ do
       # {:ok, community} = CMS.seed_community(:home)
       # {:ok, _} = CMS.create_article(community, :post, post_attrs, user)
 

--- a/backend/main/test/groupher_server_web/mutation/accounts/oauth_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/accounts/oauth_test.exs
@@ -3,13 +3,14 @@ defmodule GroupherServer.Test.Mutation.Account.Oauth do
 
   use GroupherServer.TestTools
   import Helper.Utils
+  alias GroupherServer.Repo
+  alias GroupherServer.Accounts.Model.OauthProvider
 
   @oauth_trust_code get_config(:oauth, :oauth_trust_code)
 
-  @valid_github_profile mock_attrs(:oauth_profile)
-  @valid_twitter_profile mock_attrs(:oauth_profile)
-                         |> Map.merge(%{provider: "twitter"})
-                         |> map_key_stringify
+  @valid_github_profile mock_attrs(:oauth_profile, %{provider: "github"})
+  @valid_twitter_profile mock_attrs(:oauth_profile, %{provider: "twitter"})
+  @valid_google_profile mock_attrs(:oauth_profile, %{provider: "google"})
 
   setup do
     {:ok, user} = db_insert(:user)
@@ -31,20 +32,50 @@ defmodule GroupherServer.Test.Mutation.Account.Oauth do
       }
     }
     """
+    @tag :wip
     test "can signin oauth with github", ~m(guest_conn)a do
       variables = %{
-        provider: @valid_github_profile,
+        provider: gql_oauth_provider(@valid_github_profile),
         oauthTrustCode: @oauth_trust_code
       }
 
       ret = guest_conn |> gq_mutation(@query, variables)
 
       assert ret["user"]["login"] == @valid_github_profile.login
+
+      oauth_provider =
+        Repo.get_by(OauthProvider,
+          provider: @valid_github_profile.provider,
+          provider_id: @valid_github_profile.provider_id
+        )
+
+      assert oauth_provider.raw["login"] == @valid_github_profile.login
     end
 
+    @tag :wip
+    test "can signin oauth with google", ~m(guest_conn)a do
+      variables = %{
+        provider: gql_oauth_provider(@valid_google_profile),
+        oauthTrustCode: @oauth_trust_code
+      }
+
+      ret = guest_conn |> gq_mutation(@query, variables)
+
+      assert ret["user"]["login"] == @valid_google_profile.login
+
+      oauth_provider =
+        Repo.get_by(OauthProvider,
+          provider: @valid_google_profile.provider,
+          provider_id: @valid_google_profile.provider_id
+        )
+
+      assert oauth_provider.raw["sub"] == @valid_google_profile.provider_id
+    end
+
+    @tag :wip
     test "can not signin oauth with un-trust code", ~m(guest_conn)a do
       variables = %{
-        provider: @valid_github_profile,
+        provider: gql_oauth_provider(@valid_github_profile),
         oauthTrustCode: "whatever"
       }
 
@@ -61,35 +92,41 @@ defmodule GroupherServer.Test.Mutation.Account.Oauth do
       }
     }
     """
+    @tag :wip
     test "can link oauth with twitter", ~m(user_conn user)a do
-      github_provider = @valid_github_profile |> Map.put("login", user.login)
-
       variables = %{
-        provider: @valid_twitter_profile,
+        provider: gql_oauth_provider(@valid_twitter_profile),
         oauthTrustCode: @oauth_trust_code
       }
 
       ret = user_conn |> gq_mutation(@query, variables)
 
       assert ret["user"]["login"] == user.login
+
+      oauth_provider =
+        Repo.get_by(OauthProvider,
+          provider: @valid_twitter_profile.provider,
+          provider_id: @valid_twitter_profile.provider_id
+        )
+
+      assert oauth_provider.user_id == user.id
+      assert oauth_provider.raw["username"] == @valid_twitter_profile.login
     end
 
-    test "can not link oauth with twitter with unlogged", ~m(guest_conn user)a do
-      github_provider = @valid_github_profile |> Map.put("login", user.login)
-
+    @tag :wip
+    test "can not link oauth with twitter with unlogged", ~m(guest_conn)a do
       variables = %{
-        provider: @valid_twitter_profile,
+        provider: gql_oauth_provider(@valid_twitter_profile),
         oauthTrustCode: @oauth_trust_code
       }
 
       assert guest_conn |> mutation_error?(@query, variables, ecode(:account_login))
     end
 
-    test "can not link oauth with un-trust code", ~m(user_conn user)a do
-      github_provider = @valid_github_profile |> Map.put("login", user.login)
-
+    @tag :wip
+    test "can not link oauth with un-trust code", ~m(user_conn)a do
       variables = %{
-        provider: @valid_twitter_profile,
+        provider: gql_oauth_provider(@valid_twitter_profile),
         oauthTrustCode: "whatever"
       }
 
@@ -105,15 +142,16 @@ defmodule GroupherServer.Test.Mutation.Account.Oauth do
       }
     }
     """
+    @tag :wip
     test "can unlink oauth with provider", ~m(user_conn user)a do
-      github_provider = @valid_github_profile |> Map.put("login", user.login)
-      twitter_provider = @valid_twitter_profile |> Map.put("login", user.login)
+      github_provider = @valid_github_profile |> Map.put(:login, user.login)
+      twitter_provider = @valid_twitter_profile |> Map.put(:login, user.login)
 
       {:ok, _} = Accounts.link_oauth(user.login, github_provider)
       {:ok, _} = Accounts.link_oauth(user.login, twitter_provider)
 
       variables = %{
-        provider: @valid_twitter_profile,
+        provider: gql_oauth_provider(@valid_twitter_profile),
         oauthTrustCode: @oauth_trust_code
       }
 
@@ -122,19 +160,30 @@ defmodule GroupherServer.Test.Mutation.Account.Oauth do
       assert ret["login"] == user.login
     end
 
+    @tag :wip
     test "can not unlink oauth with provider when unlogged in", ~m(guest_conn user)a do
-      github_provider = @valid_github_profile |> Map.put("login", user.login)
-      twitter_provider = @valid_twitter_profile |> Map.put("login", user.login)
+      github_provider = @valid_github_profile |> Map.put(:login, user.login)
+      twitter_provider = @valid_twitter_profile |> Map.put(:login, user.login)
 
       {:ok, _} = Accounts.link_oauth(user.login, github_provider)
       {:ok, _} = Accounts.link_oauth(user.login, twitter_provider)
 
       variables = %{
-        provider: @valid_twitter_profile,
+        provider: gql_oauth_provider(@valid_twitter_profile),
         oauthTrustCode: @oauth_trust_code
       }
 
       assert guest_conn |> mutation_error?(@query, variables, ecode(:account_login))
     end
+  end
+
+  defp gql_oauth_provider(profile) do
+    profile =
+      case Map.get(profile, :raw) do
+        %{} = raw -> Map.put(profile, :raw, Jason.encode!(raw))
+        _ -> profile
+      end
+
+    map_key_stringify(profile)
   end
 end

--- a/backend/main/test/groupher_server_web/query/accounts/account_test.exs
+++ b/backend/main/test/groupher_server_web/query/accounts/account_test.exs
@@ -36,7 +36,7 @@ defmodule GroupherServer.Test.Query.Account.Basic do
     end
 
     @tag :wip
-    test "guest user can not get any profile", ~m(guest_conn user)a do
+    test "guest user can not get any profile", ~m(guest_conn)a do
       assert guest_conn |> query_error?(@query, %{}, ecode(:account_login))
     end
 

--- a/backend/main/test/groupher_server_web/query/cms/paged_articles/paged_kanban_posts_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/paged_articles/paged_kanban_posts_test.exs
@@ -6,8 +6,6 @@ defmodule GroupherServer.Test.Query.PagedArticles.PagedKanbanPosts do
   @article_cat Constant.CMS.article_cat()
   @article_state Constant.CMS.article_state()
 
-  @page_size get_config(:general, :page_size)
-
   setup do
     {community, _, post_attrs, user} = mock_article(:post)
 

--- a/backend/main/test/helper/audit_bot_test.exs
+++ b/backend/main/test/helper/audit_bot_test.exs
@@ -2,7 +2,6 @@ defmodule GroupherServer.Test.Helper.AuditBot do
   @moduledoc false
 
   use GroupherServerWeb.ConnCase, async: true
-  alias Helper.AuditBot
 
   describe "[general test]" do
     # test "illgal words should be detected" do

--- a/backend/main/test/helper/converter/editor_to_html_test/index_test.exs
+++ b/backend/main/test/helper/converter/editor_to_html_test/index_test.exs
@@ -11,19 +11,6 @@ defmodule GroupherServer.Test.Helper.Converter.EditorToHTML do
   #   "text" : "<script>evil scripts</script>"
   @root_class Class.article()
 
-  @real_editor_data ~S({
-    "time" : 1567250876713,
-    "blocks" : [
-        {
-            "type" : "paragraph",
-            "data" : {
-                "text": "content"
-            }
-        }
-    ],
-    "version" : "2.15.0"
-  })
-
   describe "[basic convert]" do
     @editor_json %{
       "time" => 1_567_250_876_713,

--- a/backend/main/test/helper/orm_test.exs
+++ b/backend/main/test/helper/orm_test.exs
@@ -173,7 +173,7 @@ defmodule GroupherServer.Test.Helper.ORM do
       assert not is_nil(user.meta)
     end
 
-    test "update meta should work with user", ~m(community user)a do
+    test "update meta should work with user", ~m(user)a do
       {:ok, ret} =
         ORM.update_meta(user, %{
           follower_user_ids: [2, 3, 5]

--- a/frontend/core/config/auth.handler.ts
+++ b/frontend/core/config/auth.handler.ts
@@ -50,6 +50,7 @@ export const config = {
           country: '',
           city: profile.location,
           company: profile.company,
+          raw: JSON.stringify(profile),
         }
 
         const params = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add raw JSON storage for OAuth provider profiles and enforce global uniqueness (provider + provider_id) for reliable sign-in and safe, idempotent multi-provider linking.

- **New Features**
  - Store provider-native profile data in oauth_providers.raw (GraphQL exposes raw as json).
  - Normalize provider params without atomizing nested keys; raw is kept as-is.
  - Improve link/unlink flow: upsert to avoid duplicates and block linking a provider tied to another user.
  - Frontend now sends raw as JSON string; tests updated with new factories and raw checks.

- **Migration**
  - Add raw column to account.oauth_providers.
  - Change unique index to [:provider, :provider_id] (global uniqueness).
  - Run the migration to apply these changes.

<sup>Written for commit f166fd6fa754064ffaced534b3c736ec422a66d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth flow now preserves raw provider profiles and upserts provider records to prevent duplicate linkages.
  * GraphQL inputs accept raw OAuth payloads for richer provider data.

* **Bug Fixes**
  * Removed stray debug output and fixed a typo in IP parsing helper.

* **Tests**
  * New test factories for OAuth and articles; OAuth tests add raw-field assertions and some WIP tags.

* **Chores**
  * Database migration to support raw provider data and adjust provider uniqueness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->