### PR TITLE
refactor(fe): add s-full class

### DIFF
--- a/frontend/core/containers/editor/CommunityEditor/salon/banner/scale_selector.ts
+++ b/frontend/core/containers/editor/CommunityEditor/salon/banner/scale_selector.ts
@@ -32,7 +32,7 @@ export default () => {
     //
     gradientBar: 'absolute left-0 -top-px h-6 rounded-xl trans-all-200 overflow-hidden',
     gradientBg: cn(
-      'absolute top-0 left-0 w-full h-full',
+      'absolute top-0 left-0 s-full',
       'gradient-purple',
       isDarkTheme && 'rotate-180',
       vividDark(),

--- a/frontend/core/containers/editor/CommunityEditor/salon/banner/select_type/intro_images.ts
+++ b/frontend/core/containers/editor/CommunityEditor/salon/banner/select_type/intro_images.ts
@@ -24,11 +24,11 @@ export default () => {
     cinemaImage: cn('size-24 -rotate-3 left-10 bottom-12 z-30', boxBase),
     codeImage: cn('size-20 -rotate-6 left-2 bottom-3', boxBase),
     adminsImage: cn('w-28 h-24 rotate-2 right-3 bottom-1 z-20', boxBase),
-    image: 'rounded-lg w-full h-full object-cover',
+    image: 'rounded-lg s-full object-cover',
 
     //
     gameBox: 'size-20 absolute bg-transparent z-20',
-    gameImage: cn('w-full h-full object-cover', shadow('md')),
+    gameImage: cn('s-full object-cover', shadow('md')),
     gameBar: cn('w-32 h-3 rounded-md absolute -z-10', rainbow(COLOR.ORANGE, 'bg')),
     //
 
@@ -46,10 +46,10 @@ export default () => {
     ),
     pillHighlight: cn('h-36 mb-4 border-dashed', rainbow(COLOR.PURPLE, 'borderSoft')),
     pillNormal: 'gradient-black',
-    pillGadient: 'absolute w-full h-full rotate-180 gradient-purple',
-    pillGadient2: 'absolute w-full h-full rotate-180 gradient-orange',
-    pillGadient3: 'absolute w-full h-full gradient-red',
-    pillGadient4: 'absolute w-full h-full gradient-blue',
+    pillGadient: 'absolute s-full rotate-180 gradient-purple',
+    pillGadient2: 'absolute s-full rotate-180 gradient-orange',
+    pillGadient3: 'absolute s-full gradient-red',
+    pillGadient4: 'absolute s-full gradient-blue',
     pillIcon: cn('size-5 absolute bottom-2 left-3.5', fill('digest')),
     pillHighlighIcon: cn(rainbow(COLOR.PURPLE, 'fill')),
 

--- a/frontend/core/containers/editor/CommunityEditor/salon/index.ts
+++ b/frontend/core/containers/editor/CommunityEditor/salon/index.ts
@@ -4,7 +4,7 @@ export default () => {
   const { cn, container } = useTwBelt()
 
   return {
-    wrapper: cn('column-align-both w-full h-full', container()),
+    wrapper: cn('column-align-both s-full', container()),
     main: 'h-screen',
   }
 }

--- a/frontend/core/containers/editor/WallpaperEditor/salon/build_in/pictrue_group.ts
+++ b/frontend/core/containers/editor/WallpaperEditor/salon/build_in/pictrue_group.ts
@@ -10,7 +10,7 @@ export default ({ showMore }: TProps) => {
   const { cn, br, fill, primary } = useTwBelt()
 
   return {
-    wrapper: cn('row wrap w-full h-full gap-3 mt-2.5 relative', showMore && 'mb-14'),
+    wrapper: cn('row wrap s-full gap-3 mt-2.5 relative', showMore && 'mb-14'),
     block: cn(
       'w-44 h-28 rounded-md overflow-hidden relative border border-2 border-transparent pointer trans-all-200',
       `hover:${br('digest')}`,

--- a/frontend/core/containers/editor/WallpaperEditor/salon/footer.ts
+++ b/frontend/core/containers/editor/WallpaperEditor/salon/footer.ts
@@ -9,7 +9,7 @@ export default () => {
       bg('card'),
     ),
     divider: sexyBorder(),
-    inner: 'row-between w-full h-full pt-2',
+    inner: 'row-between s-full pt-2',
     blankIcon: cn('size-3.5 mr-2.5', fill('digest')),
   }
 }

--- a/frontend/core/containers/thread/DashboardThread/salon/basic_info/logos.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/basic_info/logos.ts
@@ -6,9 +6,9 @@ export default () => {
   return {
     wrapper: 'w-full pb-8 mb-5',
     faviconBox: cn('size-8 rounded', bg('hoverBg')),
-    favicon: 'w-full h-full',
+    favicon: 's-full',
     logoBox: cn('size-16', bg('hoverBg')),
-    logo: 'w-full h-full',
+    logo: 's-full',
 
     title: cn('text-sm mb-3', fg('title')),
     desc: cn('text-xs mt-2.5 mt-5 opacity-80', fg('digest')),

--- a/frontend/core/containers/thread/DashboardThread/salon/broadcast/templates/article/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/broadcast/templates/article/index.ts
@@ -6,7 +6,7 @@ export default () => {
   const { cn, primary, sexyBorder } = useTwBelt()
 
   return {
-    wrapper: 'column-align-both w-full h-full gap-4 pb-8',
+    wrapper: 'column-align-both s-full gap-4 pb-8',
     arrow: cn('size-3.5 ml-1', primary('fill')),
     divider: sexyBorder(),
   }

--- a/frontend/core/containers/thread/DashboardThread/salon/broadcast/templates/global/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/broadcast/templates/global/index.ts
@@ -6,7 +6,7 @@ export default () => {
   const { cn, primary, sexyBorder } = useTwBelt()
 
   return {
-    wrapper: 'column-align-both w-full h-full gap-4 pb-8',
+    wrapper: 'column-align-both s-full gap-4 pb-8',
     arrow: cn('size-3.5 ml-1', primary('fill')),
     divider: sexyBorder(),
   }

--- a/frontend/core/containers/thread/DashboardThread/salon/layout/doc_layout/faq_template.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/layout/doc_layout/faq_template.ts
@@ -9,7 +9,7 @@ export default () => {
   const base = useBase()
 
   return {
-    block: 'row-center row wrap relative w-full h-full',
+    block: 'row-center row wrap relative s-full',
     bar: cnMerge(base.bar, 'h-1.5 w-20 opacity-40'),
     icon: 'size-2.5',
     faqTitle: cn('text-xs absolute -ml-1', fg('title')),

--- a/frontend/core/containers/thread/DashboardThread/salon/layout/doc_layout/main_template.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/layout/doc_layout/main_template.ts
@@ -10,7 +10,7 @@ export default () => {
   const base = useBase()
 
   return {
-    block: 'row-center row wrap relative w-full h-full',
+    block: 'row-center row wrap relative s-full',
     bar: cnMerge(base.bar, 'h-1.5 w-20 opacity-40'),
     circle: cnMerge(base.circle, 'size-3.5 opacity-40'),
     iconBox: 'absolute align-both size-4 rounded mt-2 mr-5',

--- a/frontend/core/containers/thread/DashboardThread/salon/layout/glow_light.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/layout/glow_light.ts
@@ -22,7 +22,7 @@ export default () => {
     blockActive: cn(base.blockBaseActive),
     row: 'row-center wrap gap-x-5 gap-y-6 w-full',
 
-    bgWrapper: 'absolute w-full h-full top-0 left-0',
+    bgWrapper: 'absolute s-full top-0 left-0',
 
     bgStyle2: (glowType) => {
       return `

--- a/frontend/core/containers/thread/KanbanThread/salon/classic_layout/index.ts
+++ b/frontend/core/containers/thread/KanbanThread/salon/classic_layout/index.ts
@@ -6,7 +6,7 @@ export default () => {
   const isSidebarLayout = useIsSidebarLayout()
 
   return {
-    wrapper: cn('w-full h-full min-h-screen py-2.5', isSidebarLayout && 'pl-12'),
+    wrapper: cn('s-full min-h-screen py-2.5', isSidebarLayout && 'pl-12'),
     columns: 'row items-start justify-between min-h-96 mt-14',
   }
 }

--- a/frontend/core/containers/thread/KanbanThread/salon/index.ts
+++ b/frontend/core/containers/thread/KanbanThread/salon/index.ts
@@ -1,5 +1,5 @@
 export default () => {
   return {
-    wrapper: 'w-full h-full',
+    wrapper: 's-full',
   }
 }

--- a/frontend/core/containers/thread/KanbanThread/salon/waterfall_layout/index.ts
+++ b/frontend/core/containers/thread/KanbanThread/salon/waterfall_layout/index.ts
@@ -1,5 +1,5 @@
 export default () => {
   return {
-    wrapper: 'column items-start w-full h-full mt-10 gap-y-7',
+    wrapper: 'column items-start s-full mt-10 gap-y-7',
   }
 }

--- a/frontend/core/tailwind/common/utils.css
+++ b/frontend/core/tailwind/common/utils.css
@@ -111,6 +111,10 @@
     @apply text-left leading-none cursor-pointer;
   }
 
+  .s-full {
+    @apply w-full h-full;
+  }
+
   .text-shadow-none {
     text-shadow: none;
   }

--- a/frontend/core/widgets/AccountUnit/salon/loading.ts
+++ b/frontend/core/widgets/AccountUnit/salon/loading.ts
@@ -6,7 +6,7 @@ export default () => {
   const { cn, fg, bg, shadow } = useTwBelt()
 
   return {
-    wrapper: 'column-align-both absolute top-0 left-0 w-full h-full backdrop-blur-md z-50',
+    wrapper: 'column-align-both absolute top-0 left-0 s-full backdrop-blur-md z-50',
     iconWrapper: 'column-align-both mb-8 mt-10 relative',
     title: cn('row text-xl bold', fg('digest')),
     desc: cn('text-sm', fg('digest')),

--- a/frontend/core/widgets/Facepile/salon/real_avatar.ts
+++ b/frontend/core/widgets/Facepile/salon/real_avatar.ts
@@ -24,7 +24,7 @@ export default ({ size, isFirst, isLast }: TProps) => {
       br('divider'),
       avatar(),
     ),
-    avatar: 'text-xs w-full h-full text-center',
+    avatar: 'text-xs s-full text-center',
     avatarFallback: cn('border', br('divider')),
   }
 }

--- a/frontend/core/widgets/GlobalLayout/salon/main.ts
+++ b/frontend/core/widgets/GlobalLayout/salon/main.ts
@@ -11,7 +11,7 @@ export default () => {
   return {
     wrapper: cn(
       container(),
-      'column relative w-full h-full min-h-fit',
+      'column relative s-full min-h-fit',
       // NOTICE: this class will cause children's position fixed fail,
       'transition-transform transition-shadow backdrop-blur-2xl',
       hasShadow && 'shadow-lg',

--- a/frontend/core/widgets/HomeHeader/index.tsx
+++ b/frontend/core/widgets/HomeHeader/index.tsx
@@ -88,7 +88,7 @@ export default () => {
             <Link className={cn(s.requestDemoLink, 'scale-90')} href={`/${ROUTE.APPLY_COMMUNITY}`}>
               <Button space={3} className='bold-sm'>
                 <span className='relative flex size-3 mr-2.5 brightness-125 scale-75'>
-                  <span className='absolute inline-flex w-full h-full rounded-full opacity-80 animate-ping bg-rainbow-purpleSoft'></span>
+                  <span className='absolute inline-flex s-full rounded-full opacity-80 animate-ping bg-rainbow-purpleSoft'></span>
                   <span className='relative inline-flex rounded-full size-3 bg-rainbow-purple'></span>
                 </span>
                 开始使用

--- a/frontend/core/widgets/HomeHeader/salon/feature_intro.ts
+++ b/frontend/core/widgets/HomeHeader/salon/feature_intro.ts
@@ -7,7 +7,7 @@ export default () => {
   const { cn, fill, hover, bg, fg, menu, rainbow, rainbowSoft, vividDark } = useTwBelt()
 
   const blockBase = 'relative align-both size-12 min-w-12 mr-4 rounded-lg'
-  const blockBg = 'absolute top-0 left-0 w-full h-full rounded-lg trans-all-100'
+  const blockBg = 'absolute top-0 left-0 s-full rounded-lg trans-all-100'
   const blockColor = cn(blockBg, 'opacity-0 group-hover:opacity-100')
   const iconColor = 'group-hover:opacity-100 trans-all-100'
 

--- a/frontend/core/widgets/Img/salon/index.ts
+++ b/frontend/core/widgets/Img/salon/index.ts
@@ -4,11 +4,7 @@ export default () => {
   return {
     wrapper: 'relative z-10 inline-block p-0 border-0 bg-transparent align-middle shrink-0',
     notLoaded: '-z-10 opacity-0 absolute',
-
-    // 图片本体：自己决定 cover/contain、圆角等
-    img: 'absolute inset-0 z-0 block w-full h-full object-cover',
-
-    // fallback 覆盖层：默认居中（你不想居中就删掉 grid）
+    img: 'absolute inset-0 z-0 block s-full object-cover',
     fallbackOverlay: 'grid place-items-center absolute inset-0 z-10',
   }
 }

--- a/frontend/core/widgets/Img/salon/lazy_load_image.ts
+++ b/frontend/core/widgets/Img/salon/lazy_load_image.ts
@@ -3,8 +3,8 @@ export { cn, cnMerge } from '~/css'
 export default () => {
   return {
     normal: 'relative inline-flex p-0 border-0 bg-transparent',
-    fallbackInFlow: 'inline-flex w-full h-full',
+    fallbackInFlow: 'inline-flex s-full',
     fallbackHidden: 'opacity-0 pointer-events-none',
-    imgOverlay: 'absolute inset-0 z-10 block w-full h-full object-cover',
+    imgOverlay: 'absolute inset-0 z-10 block s-full object-cover',
   }
 }

--- a/frontend/core/widgets/ImgFallback/salon/avatar.ts
+++ b/frontend/core/widgets/ImgFallback/salon/avatar.ts
@@ -12,7 +12,7 @@ export default ({ size, ...spacing }: TProps) => {
   const { cn, rainbowSoft, margin, avatar, rainbow } = useTwBelt()
 
   return {
-    wrapper: cn('align-both border-none w-full h-full', margin(spacing), avatar()),
+    wrapper: cn('align-both border-none s-full', margin(spacing), avatar()),
     name: cn('bold leading-none', getFontSize(size)),
 
     rainbowSoft,

--- a/frontend/core/widgets/PriceWall/salon/index.ts
+++ b/frontend/core/widgets/PriceWall/salon/index.ts
@@ -8,7 +8,7 @@ export default () => {
   const { cn, fg, bg, rainbow, shadow, dimDark, linkable } = useTwBelt()
 
   return {
-    wrapper: 'column-align-both w-full h-full mb-14 overflow-hidden',
+    wrapper: 'column-align-both s-full mb-14 overflow-hidden',
     bannerTitle: cn('text-2xl bold-sm mt-5 mb-2', fg('title')),
     bannerDesc: cn('text-base mb-14', fg('digest')),
     bannerNote: cn('text-base mb-8', fg('title')),
@@ -22,13 +22,13 @@ export default () => {
     //
     column:
       'group w-80 h-[680px] relative px-6 pt-5 rounded-t-3xl rounded-b-xl border border-transparent overflow-hidden',
-    gradientGreen: cn('absolute top-0 left-0 w-full h-full opacity-40 -z-10', 'gradient-green'),
+    gradientGreen: cn('absolute top-0 left-0 s-full opacity-40 -z-10', 'gradient-green'),
     gradientOrange: cn(
-      'absolute top-0 left-0 w-full h-full opacity-80 rotate-180 border border-dotted border-transparent -z-10',
+      'absolute top-0 left-0 s-full opacity-80 rotate-180 border border-dotted border-transparent -z-10',
       'gradient-orange',
     ),
     gradientPurple: cn(
-      'absolute top-0 left-0 w-full h-full opacity-30 rotate-180 -z-10',
+      'absolute top-0 left-0 s-full opacity-30 rotate-180 -z-10',
       'gradient-purple',
     ),
     board: cn(

--- a/frontend/core/widgets/Switcher/salon/tabs/drawer_view.ts
+++ b/frontend/core/widgets/Switcher/salon/tabs/drawer_view.ts
@@ -7,7 +7,7 @@ export default () => {
 
   return {
     wrapper: cn('relative overflow-hidden w-full h-9 rounded-xl p-1', bg('hoverBg')),
-    tabsContainer: 'row-center w-full h-full relative z-10',
+    tabsContainer: 'row-center s-full relative z-10',
     tabItem: cn('align-both h-full grow rounded-md text-xs pointer', fg('digest')),
     activeTabItem: cn(fg('title')),
     slider: cn(

--- a/frontend/landing/app/pricing/salon/index.ts
+++ b/frontend/landing/app/pricing/salon/index.ts
@@ -1,5 +1,5 @@
 export default () => {
   return {
-    wrapper: 'column-align-both w-full h-full mb-20 overflow-hidden',
+    wrapper: 'column-align-both s-full mb-20 overflow-hidden',
   }
 }

--- a/frontend/landing/app/widgets/Landing/ArticlesIntroTabs/DiscussTab/DiscussDemo/CommentItem.tsx
+++ b/frontend/landing/app/widgets/Landing/ArticlesIntroTabs/DiscussTab/DiscussDemo/CommentItem.tsx
@@ -1,8 +1,6 @@
 import type { FC } from 'react'
-
-import type { TUser } from '~/spec'
-
 import Img from '~/Img'
+import type { TUser } from '~/spec'
 import ImgFallback from '~/widgets/ImgFallback'
 
 import useSalon, {
@@ -20,7 +18,7 @@ const CommentItem: FC<TProps> = ({ user, className = '' }) => {
 
   return (
     <div className={cn(s.wrapper, className)}>
-      <Img src={user.avatar} className={s.avatar} fallback={<ImgFallback size={6} user={user} />} />
+      <Img src={user.avatar} className={s.avatar} fallback={<ImgFallback user={user} />} />
       <div className={s.rightPart}>
         <div className={s.nickname}>{user.nickname}</div>
         <div className={s.bar} />

--- a/frontend/landing/app/widgets/Landing/salon/articles_intro_tabs/content.ts
+++ b/frontend/landing/app/widgets/Landing/salon/articles_intro_tabs/content.ts
@@ -11,9 +11,7 @@ type TProps = {
 export default ({ tab }: TProps) => {
   const { cn } = useTwBelt()
 
-  const bgGradient = cn(
-    'absolute top-0 left-0 w-full h-full opacity-0 transition-opacity duration-700',
-  )
+  const bgGradient = cn('absolute top-0 left-0 s-full opacity-0 transition-opacity duration-700')
 
   return {
     wrapper: 'column-align-both relative w-full',

--- a/frontend/landing/app/widgets/Landing/salon/articles_intro_tabs/help_tab/help_demo/article.ts
+++ b/frontend/landing/app/widgets/Landing/salon/articles_intro_tabs/help_tab/help_demo/article.ts
@@ -24,7 +24,7 @@ export default () => {
     //
     title: cn('row-center text-base', fg('title')),
     inner: cn(
-      'column-center w-full h-full z-10 px-4 py-8 pt-6 border rounded-md',
+      'column-center s-full z-10 px-4 py-8 pt-6 border rounded-md',
       br('rainbow.cyanSoft'),
       bg('card'),
     ),

--- a/frontend/landing/app/widgets/Landing/salon/battery_bento/design/panel.ts
+++ b/frontend/landing/app/widgets/Landing/salon/battery_bento/design/panel.ts
@@ -22,7 +22,7 @@ export default () => {
       fontSize: '42px',
     },
 
-    wrapper: 'relative p-4 pt-7 w-full h-full overflow-hidden',
+    wrapper: 'relative p-4 pt-7 s-full overflow-hidden',
     gridIcon: cn('absolute top-3 size-28', fill('digest')),
     mainCard: cn(
       'align-both absolute top-6 -right-5 rounded-xl border z-20',

--- a/frontend/landing/app/widgets/Landing/salon/battery_bento/integration/panel.ts
+++ b/frontend/landing/app/widgets/Landing/salon/battery_bento/integration/panel.ts
@@ -7,7 +7,7 @@ export default () => {
   const { cn, bg, shadow, rainbow } = useTwBelt()
 
   return {
-    wrapper: 'relative w-full h-full p-4 overflow-hidden',
+    wrapper: 'relative s-full p-4 overflow-hidden',
     block: cn(
       'align-both w-64 h-40 relative p-2.5 overflow-hidden rounded-md trans-all-200',
       bg('card'),

--- a/frontend/landing/app/widgets/Landing/salon/battery_bento/mobile_first/panel.ts
+++ b/frontend/landing/app/widgets/Landing/salon/battery_bento/mobile_first/panel.ts
@@ -10,7 +10,7 @@ export default () => {
   const { cn, fg, bg, br, rainbow, shadow } = useTwBelt()
 
   return {
-    wrapper: 'row-center w-full h-full overflow-hidden px-4 trans-all-200',
+    wrapper: 'row-center s-full overflow-hidden px-4 trans-all-200',
     phone: cn(
       'column w-28 min-w-28 h-44 pl-2.5 border-4 rounded-t-xl mt-2 gap-y-1.5',
       bg('card'),

--- a/frontend/landing/app/widgets/Landing/salon/battery_bento/security/panel.ts
+++ b/frontend/landing/app/widgets/Landing/salon/battery_bento/security/panel.ts
@@ -10,7 +10,7 @@ export default () => {
   const { cn, fg, bg, rainbow, shadow } = useTwBelt()
 
   return {
-    wrapper: 'w-full h-full p-4 pt-7 overflow-hidden relative',
+    wrapper: 's-full p-4 pt-7 overflow-hidden relative',
     nestIcon: cn(
       'absolute size-44 rotate-45 top-0 left-10 opacity-10 trans-all-200',
       rainbow(COLOR.GREEN, 'fill'),

--- a/frontend/landing/app/widgets/Landing/salon/battery_bento/statistics/panel.ts
+++ b/frontend/landing/app/widgets/Landing/salon/battery_bento/statistics/panel.ts
@@ -1,5 +1,5 @@
 export default () => {
   return {
-    wrapper: 'w-full h-full recursive p-4 pt-7',
+    wrapper: 's-full recursive p-4 pt-7',
   }
 }

--- a/frontend/landing/app/widgets/Landing/salon/compare_dev/bg_shapes/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/compare_dev/bg_shapes/index.ts
@@ -12,7 +12,7 @@ export default () => {
   const turnning = isLightTheme ? 'opacity-30 saturate-50' : 'opacity-15 saturate-100'
 
   return {
-    wrapper: 'absolute w-full h-full top-0 left-0',
+    wrapper: 'absolute s-full top-0 left-0',
     wipItem: cn('row-center absolute left-1/2 top-28 -ml-32 rotate-3', rainbow(COLOR.GREEN, 'fg')),
     wipText: cn('text-lg bold opacity-30 ml-1', rainbow(COLOR.GREEN, 'fg')),
     wipIcon: cn('size-4 opacity-50 -mt-0.5', rainbow(COLOR.GREEN, 'fill')),

--- a/frontend/landing/app/widgets/Landing/salon/compare_dev/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/compare_dev/index.ts
@@ -18,7 +18,7 @@ export default () => {
     //
     ourWall: 'relative column-align-both w-full h-auto pl-10 overflow-hidden',
     ourWallBg: cn(
-      'absolute top-0 left-0 w-full h-full rotate-180 gradient-green',
+      'absolute top-0 left-0 s-full rotate-180 gradient-green',
       isDarkTheme && 'opacity-30 rotate-180',
     ),
     greenDiffBar: 'diff-bar-green absolute left-0 top-0 w-7 h-full z-10 rounded-tr-lg',
@@ -31,7 +31,7 @@ export default () => {
 
     theirWall: 'relative column-align-both w-full h-auto diff-area-red-stripes',
     theirWallBg: cn(
-      'absolute top-0 left-0 w-full h-full',
+      'absolute top-0 left-0 s-full',
       rainbowSoft(COLOR.RED),
       isDarkTheme ? 'opacity-80' : 'opacity-40',
     ),

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/admins_tab/content_card.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/admins_tab/content_card.ts
@@ -14,7 +14,7 @@ export default () => {
       isLightTheme ? bg('card') : bg('hoverBg'),
       isLightTheme ? shadow('sm') : shadow('md'),
     ),
-    inner: 'w-full h-full rounded-xl relative gradient-red',
+    inner: 's-full rounded-xl relative gradient-red',
     bar: cn(
       'w-12 h-1.5 -ml-6 rounded-xl absolute top-4 left-1/2 opacity-15',
       rainbow(COLOR.RED, 'bg'),

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/cms_tab/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/cms_tab/index.ts
@@ -5,7 +5,7 @@ export default () => {
 
   return {
     wrapper: cn(
-      'row w-full h-full relative -ml-16 mb-20',
+      'row s-full relative -ml-16 mb-20',
       'animate-fade-up animate-duration-500 animate-ease-in-out',
     ),
   }

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/cms_tab/tabs.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/cms_tab/tabs.ts
@@ -31,10 +31,7 @@ export default () => {
       br('divider'),
       shadow('xl'),
     ),
-    bottomGradient: cn(
-      'absolute top-0 left-0 w-full h-full rotate-180 -z-10 opacity-50',
-      'gradient-blue',
-    ),
+    bottomGradient: cn('absolute top-0 left-0 s-full rotate-180 -z-10 opacity-50', 'gradient-blue'),
     icon: cn('size-3 mr-1', fill('digest')),
     title: cn('text-xs', fg('digest')),
   }

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/import_tab/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/import_tab/index.ts
@@ -5,7 +5,7 @@ export default () => {
 
   return {
     wrapper: cn(
-      'row w-full h-full relative mb-20',
+      'row s-full relative mb-20',
       'animate-fade-up animate-duration-500 animate-ease-in-out',
     ),
   }

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/index.ts
@@ -12,7 +12,7 @@ export default ({ tab }: TProps) => {
   const { cn, fg, landingTitle } = useTwBelt()
 
   const bgGradient = cn(
-    'absolute top-0 left-0 w-full h-full opacity-0 transition-opacity duration-500 -z-10',
+    'absolute top-0 left-0 s-full opacity-0 transition-opacity duration-500 -z-10',
   )
 
   return {

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/integrate_tab/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/integrate_tab/index.ts
@@ -1,5 +1,5 @@
 export default () => {
   return {
-    wrapper: 'row w-full h-full relative ml-12',
+    wrapper: 'row s-full relative ml-12',
   }
 }

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/layout_tab/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/layout_tab/index.ts
@@ -5,7 +5,7 @@ export default () => {
 
   return {
     wrapper: cn(
-      'row w-full h-full relative mb-16',
+      'row s-full relative mb-16',
       'animate-fade-up animate-duration-500 animate-ease-in-out',
     ),
   }

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/layout_tab/wallpaper_card.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/layout_tab/wallpaper_card.ts
@@ -10,7 +10,7 @@ export default () => {
       bg('card'),
       shadow('sm'),
     ),
-    background: cn('w-full h-full rounded-xl trans-all-200', dimDark()),
+    background: cn('s-full rounded-xl trans-all-200', dimDark()),
     edittool: 'absolute -bottom-3 left-28 z-30',
   }
 }

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/links_tab/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/links_tab/index.ts
@@ -5,7 +5,7 @@ export default () => {
 
   return {
     wrapper: cn(
-      'row w-full h-full relative mb-16 mr-5',
+      'row s-full relative mb-16 mr-5',
       'animate-fade-up animate-duration-500 animate-ease-in-out',
     ),
   }

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/tags_tab/content_card.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/tags_tab/content_card.ts
@@ -16,7 +16,7 @@ export default () => {
       shadow('md'),
       bg('card'),
     ),
-    inner: cn('relative border px-6 py-5 w-full h-full rounded-md', br('divider'), bg('card')),
+    inner: cn('relative border px-6 py-5 s-full rounded-md', br('divider'), bg('card')),
     bar: cn('absolute h-16 w-24 opacity-5 rounded-md', bg('text.digest')),
   }
 }

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/tags_tab/footer.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/tags_tab/footer.ts
@@ -11,7 +11,7 @@ export default () => {
       shadow('sm'),
       bg('card'),
     ),
-    inner: 'row w-full h-full rounded-xl py-4 px-6 gradient-green',
+    inner: 'row s-full rounded-xl py-4 px-6 gradient-green',
     left: 'w-1/2',
     right: 'w-1/2',
     item: 'row items-start h-8',

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/tags_tab/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/tags_tab/index.ts
@@ -5,7 +5,7 @@ export default () => {
 
   return {
     wrapper: cn(
-      'row w-full h-full relative mb-24',
+      'row s-full relative mb-24',
       'animate-fade-up animate-duration-500 animate-ease-in-out',
     ),
   }

--- a/frontend/landing/app/widgets/Landing/salon/dashboard_intros/trend_tab/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/dashboard_intros/trend_tab/index.ts
@@ -1,5 +1,5 @@
 export default () => {
   return {
-    wrapper: 'row w-full h-full relative ml-12',
+    wrapper: 'row s-full relative ml-12',
   }
 }

--- a/frontend/landing/app/widgets/Landing/salon/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/index.ts
@@ -18,7 +18,7 @@ export default () => {
 
   return {
     wrapper: cn('column-align-both relative h-full w-full overflow-hidden', container()),
-    inner: 'column-align-both relative w-full h-full',
+    inner: 'column-align-both relative s-full',
     banner: 'column-center relative w-full pt-16',
     githubInfo: cn('row-center mt-12 mb-3 hover:underline pointer', fg('digest')),
     githubIcon: 'size-4 mr-1.5',

--- a/frontend/landing/app/widgets/Landing/salon/tech_stacks/index.ts
+++ b/frontend/landing/app/widgets/Landing/salon/tech_stacks/index.ts
@@ -15,10 +15,10 @@ export default () => {
       isDarkTheme ? 'border-zinc-800 border-x-20' : 'border-zinc-200',
       'keyboard-wall',
     ),
-    inner: cn('align-both justify-between relative w-full h-full', 'pl-4', shadow('card')),
+    inner: cn('align-both justify-between relative s-full', 'pl-4', shadow('card')),
     mask: 'z-30 absolute w-3/4 h-full left-0 opacity-20 pointer-events-none blur-xl rounded-3xl',
     innerBgWrapper: cn(
-      'absolute top-0 left-0 w-full h-full overflow-hidden rounded-xl pointer-events-none',
+      'absolute top-0 left-0 s-full overflow-hidden rounded-xl pointer-events-none',
       isDarkTheme && 'invert',
     ),
     slogan: 'column-align-both',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a new s-full utility (w-full h-full) and refactor components to cut duplicate class strings with no visual changes. Also fix avatar fallback usage to match the current ImgFallback API.

- **Refactors**
  - Added .s-full in utils.css (applies w-full h-full).
  - Replaced w-full h-full in overlays, images, wrappers, and gradients across Editors, Threads, Widgets, and Landing.

<sup>Written for commit 9da7e2d7a4a8d6af63f2290d77eb9dc0d8cce842. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated styling implementation across interface components for enhanced consistency.
  * Simplified component property usage in avatar functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->