### PR TITLE
feat: add darkFloat dashboard setting and apply to Tooltip

### DIFF
--- a/backend/main/lib/groupher_server/cms/models/metrics/dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/models/metrics/dashboard.ex
@@ -72,6 +72,7 @@ defmodule GroupherServer.CMS.Model.Metrics.Dashboard do
       [:glow_type, :string, ""],
       [:glow_fixed, :boolean, false],
       [:glow_opacity, :string, ""],
+      [:dark_float, :boolean, true],
 
       ## blur
       [:gauss_blur, :integer, 100],

--- a/backend/main/test/groupher_server_web/mutation/cms/dashboard_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/dashboard_test.exs
@@ -183,8 +183,8 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
     end
 
     @update_layout_query """
-    mutation($community: String!, $primaryColor: String $postLayout: String, $kanbanLayout: String, $kanbanCardLayout: String, $footerLayout: String, $broadcastEnable: Boolean, $kanbanBgColors: [String], $glowType: String, $glowFixed: Boolean, $glowOpacity: String, $tagLayout: String, $gaussBlur: Int, $gaussBlurDark: Int, $brandLayout: String) {
-      updateDashboardLayout(community: $community, primaryColor: $primaryColor, postLayout: $postLayout, kanbanLayout: $kanbanLayout, kanbanCardLayout: $kanbanCardLayout, footerLayout: $footerLayout, broadcastEnable: $broadcastEnable, kanbanBgColors: $kanbanBgColors, glowType: $glowType, glowFixed: $glowFixed, glowOpacity: $glowOpacity, tagLayout: $tagLayout, gaussBlur: $gaussBlur, gaussBlurDark: $gaussBlurDark, brandLayout: $brandLayout) {
+    mutation($community: String!, $primaryColor: String $postLayout: String, $kanbanLayout: String, $kanbanCardLayout: String, $footerLayout: String, $broadcastEnable: Boolean, $kanbanBgColors: [String], $glowType: String, $glowFixed: Boolean, $glowOpacity: String, $tagLayout: String, $gaussBlur: Int, $gaussBlurDark: Int, $brandLayout: String, $darkFloat: Boolean) {
+      updateDashboardLayout(community: $community, primaryColor: $primaryColor, postLayout: $postLayout, kanbanLayout: $kanbanLayout, kanbanCardLayout: $kanbanCardLayout, footerLayout: $footerLayout, broadcastEnable: $broadcastEnable, kanbanBgColors: $kanbanBgColors, glowType: $glowType, glowFixed: $glowFixed, glowOpacity: $glowOpacity, tagLayout: $tagLayout, gaussBlur: $gaussBlur, gaussBlurDark: $gaussBlurDark, brandLayout: $brandLayout, darkFloat: $darkFloat) {
         id
         title
         dashboard {
@@ -197,6 +197,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
             gaussBlur
             gaussBlurDark
             brandLayout
+            darkFloat
           }
         }
       }
@@ -220,7 +221,8 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
         tagLayout: "dot",
         gaussBlur: 80,
         gaussBlurDark: 60,
-        brandLayout: "LOGO"
+        brandLayout: "LOGO",
+        darkFloat: false
       }
 
       updated =
@@ -244,6 +246,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
       assert found.dashboard.layout.gauss_blur == 80
       assert found.dashboard.layout.gauss_blur_dark == 60
       assert found.dashboard.layout.brand_layout == "LOGO"
+      assert found.dashboard.layout.dark_float == false
     end
 
     test "update community dashboard layout should not overwrite existing settings",

--- a/frontend/core/containers/thread/DashboardThread/Layout/FloatBackground.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/FloatBackground.tsx
@@ -1,13 +1,13 @@
 import CheckLabel from '~/widgets/CheckLabel'
 import { FIELD } from '../constant'
-import usePrimaryColor from '../logic/usePrimaryColor'
+import useDarkFloat from '../logic/useDarkFloat'
 import SavingBar from '../SavingBar'
 import SectionLabel from '../SectionLabel'
 import useSalon, { cnMerge } from '../salon/layout/float_background'
 
 export default () => {
   const s = useSalon()
-  const { isTouched, saving } = usePrimaryColor()
+  const { darkFloat, edit, isTouched, saving } = useDarkFloat()
 
   return (
     <section className={s.wrapper}>
@@ -17,8 +17,8 @@ export default () => {
       />
 
       <div className={s.select}>
-        <button className={s.layout}>
-          <div className={cnMerge(s.block, s.blockActive)}>
+        <button className={s.layout} onClick={() => edit(true, FIELD.DARK_FLOAT)}>
+          <div className={cnMerge(s.block, darkFloat && s.blockActive)}>
             <div
               className={cnMerge(s.popover, 'left-20 top-12')}
               style={{ borderColor: 'dimgray' }}
@@ -47,10 +47,10 @@ export default () => {
             </div>
           </div>
 
-          <CheckLabel title='始终使用深色' active top={4} />
+          <CheckLabel title='始终使用深色' active={darkFloat} top={4} />
         </button>
-        <button className={s.layout}>
-          <div className={cnMerge(s.block)}>
+        <button className={s.layout} onClick={() => edit(false, FIELD.DARK_FLOAT)}>
+          <div className={cnMerge(s.block, !darkFloat && s.blockActive)}>
             <div
               className={cnMerge(s.popover, 'left-5 top-12 w-24 bg-white')}
               style={{ borderColor: 'dimgray' }}
@@ -89,13 +89,13 @@ export default () => {
             </div>
           </div>
 
-          <CheckLabel title='跟随主题' top={4} />
+          <CheckLabel title='跟随主题' active={!darkFloat} top={4} />
         </button>
       </div>
 
       <SavingBar
         isTouched={isTouched}
-        field={FIELD.PRIMARY_COLOR}
+        field={FIELD.DARK_FLOAT}
         loading={saving}
         width='w-11/12'
         top={6}

--- a/frontend/core/containers/thread/DashboardThread/constant.tsx
+++ b/frontend/core/containers/thread/DashboardThread/constant.tsx
@@ -33,6 +33,7 @@ export const LAYOUT_FIELD = {
   GLOW_TYPE: 'glowType',
   GLOW_FIXED: 'glowFixed',
   GLOW_OPACITY: 'glowOpacity',
+  DARK_FLOAT: 'darkFloat',
   GAUSS_BLUR: 'gaussBlur',
   GAUSS_BLUR_DARK: 'gaussBlurDark',
 }

--- a/frontend/core/containers/thread/DashboardThread/logic/useDarkFloat.ts
+++ b/frontend/core/containers/thread/DashboardThread/logic/useDarkFloat.ts
@@ -1,0 +1,25 @@
+import useDashboard from '~/hooks/useDashboard'
+import type { TEditFunc } from '~/spec'
+
+import useHelper from './useHelper'
+
+type TRet = {
+  darkFloat: boolean
+  saving: boolean
+  isTouched: boolean
+  edit: TEditFunc
+}
+
+export default (): TRet => {
+  const dsb$ = useDashboard()
+  const { edit, isChanged } = useHelper()
+
+  const { darkFloat, saving } = dsb$
+
+  return {
+    darkFloat,
+    saving,
+    edit,
+    isTouched: isChanged('darkFloat'),
+  }
+}

--- a/frontend/core/containers/thread/DashboardThread/schema.ts
+++ b/frontend/core/containers/thread/DashboardThread/schema.ts
@@ -175,6 +175,7 @@ const updateDashboardLayout = gql`
     $glowType: String
     $glowFixed: Boolean
     $glowOpacity: String
+    $darkFloat: Boolean
     $gaussBlur: Int
     $gaussBlurDark: Int
     $brandLayout: String
@@ -200,6 +201,7 @@ const updateDashboardLayout = gql`
       glowType: $glowType
       glowFixed: $glowFixed
       glowOpacity: $glowOpacity
+      darkFloat: $darkFloat
       gaussBlur: $gaussBlur
       gaussBlurDark: $gaussBlurDark
       brandLayout: $brandLayout

--- a/frontend/core/hooks/useDarkFloat/index.ts
+++ b/frontend/core/hooks/useDarkFloat/index.ts
@@ -1,0 +1,7 @@
+import useDashboard from '~/hooks/useDashboard'
+
+export default (): boolean => {
+  const { darkFloat } = useDashboard()
+
+  return darkFloat
+}

--- a/frontend/core/schemas/pages/community.ts
+++ b/frontend/core/schemas/pages/community.ts
@@ -102,6 +102,7 @@ export const community = `
           glowType
           glowFixed
           glowOpacity
+          darkFloat
           gaussBlur
           gaussBlurDark
           broadcastEnable

--- a/frontend/core/spec/dashboard.d.ts
+++ b/frontend/core/spec/dashboard.d.ts
@@ -72,6 +72,7 @@ export type TDsb = {
     glowType: string
     glowFixed: boolean
     glowOpacity: string
+    darkFloat: boolean
     docLayout: TDocLayout
     docFaqLayout: TDocFaqLayout
     postLayout: TPostLayout

--- a/frontend/core/stores/dashboard/constant.tsx
+++ b/frontend/core/stores/dashboard/constant.tsx
@@ -111,6 +111,8 @@ export const FIELDS: TDsbFieldMap = {
   glowFixed: true,
   glowOpacity: GLOW_OPACITY.NORMAL,
 
+  darkFloat: true,
+
   // gauss blur
   gaussBlur: 100,
   gaussBlurDark: 100,

--- a/frontend/core/stores/dashboard/spec.d.ts
+++ b/frontend/core/stores/dashboard/spec.d.ts
@@ -122,6 +122,8 @@ export type TDsbFieldMap = {
   glowFixed: boolean
   glowOpacity: string
 
+  darkFloat: boolean
+
   // gauss blur
   gaussBlur: int
   gaussBlurDark: int

--- a/frontend/core/widgets/Tooltip/index.tsx
+++ b/frontend/core/widgets/Tooltip/index.tsx
@@ -11,6 +11,7 @@ import type { Instance } from 'tippy.js'
 import { hideAll } from 'tippy.js'
 
 import useOutsideClick from '~/hooks/useOutsideClick'
+import useDarkFloat from '~/hooks/useDarkFloat'
 import type { TThemeName, TTooltipPlacement } from '~/spec'
 
 import ConfirmFooter from './ConfirmFooter'
@@ -84,6 +85,7 @@ const Tooltip: FC<TProps> = ({
   forceZIndex = false,
 }) => {
   const s = useSalon()
+  const darkFloat = useDarkFloat()
 
   const tooltipTheme = getCurrentTooltipTheme()
 
@@ -194,6 +196,7 @@ const Tooltip: FC<TProps> = ({
   ])
 
   const wrapperClass = !noPadding ? s.tooltip : cn(s.tooltip, 'p-0')
+  const themedWrapperClass = darkFloat ? cn(wrapperClass, 'dark') : wrapperClass
 
   /**
    * forceZIndex: only used in some special masking scenarios (IconSwitcher)
@@ -202,7 +205,7 @@ const Tooltip: FC<TProps> = ({
   const triggerWrapperClass = forceZIndex ? 'relative z-[1]' : undefined
 
   return (
-    <Tippy className={wrapperClass} {...tippyProps}>
+    <Tippy className={themedWrapperClass} {...tippyProps}>
       <div className={triggerWrapperClass}>{children}</div>
     </Tippy>
   )


### PR DESCRIPTION
### Motivation

- Provide a dashboard setting to force lightweight popovers/tooltip to always use a dark style (instead of following system/theme) so communities can opt into a consistent dark float UI.

### Description

- Added `:dark_float` boolean (default true) to the dashboard macro/schema in `backend/main/lib/groupher_server/cms/models/metrics/dashboard.ex` and extended the dashboard layout GraphQL mutation test to cover the new field in `backend/main/test/groupher_server_web/mutation/cms/dashboard_test.exs`.
- Exposed `darkFloat` in frontend GraphQL pages/schema (`frontend/core/schemas/pages/community.ts` and `frontend/core/containers/thread/DashboardThread/schema.ts`) and added `DARK_FLOAT`/`FIELD.DARK_FLOAT` to dashboard constants (`frontend/core/containers/thread/DashboardThread/constant.tsx`).
- Wire `darkFloat` into the dashboard store: added the field to `frontend/core/stores/dashboard/constant.tsx` and type specs `frontend/core/stores/dashboard/spec.d.ts` and `frontend/core/spec/dashboard.d.ts`.
- Added frontend UI and hooks to control/read the setting: created `useDarkFloat` hook (`frontend/core/hooks/useDarkFloat/index.ts`) and dashboard logic hook `useDarkFloat` (`frontend/core/containers/thread/DashboardThread/logic/useDarkFloat.ts`), integrated into the FloatBackground layout UI (`frontend/core/containers/thread/DashboardThread/Layout/FloatBackground.tsx`) to toggle/save the setting.
- Applied the `darkFloat` value to Tooltip theming by reading `useDarkFloat` and conditionally adding a `dark` class to the tooltip wrapper (`frontend/core/widgets/Tooltip/index.tsx`).
- No DB migration file was added because the dashboard layout is stored as an embedded schema and the macro default provides the new key and default value.

### Testing

- Ran TypeScript verification `tsc-files --noEmit --project ./tsconfig.app.json` as part of the pre-commit checks and it completed successfully.
- Backend GraphQL mutation test was updated to assert the new field but full Elixir test suite was not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698041c7f9048325bc43dbaa1b7833c5)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a darkFloat dashboard setting to force dark styling for popovers and tooltips. Tooltip now respects this setting; default is true and admins can toggle it in the dashboard.

- **New Features**
  - Added darkFloat boolean to dashboard layout (default true), exposed in GraphQL and covered by mutation test.
  - Added dashboard UI to toggle darkFloat in Float Background, with a new logic hook and store/type wiring.
  - Tooltip reads darkFloat via a hook and applies a dark class to force dark theme.
  - No DB migration needed; the embedded schema default supplies the new key.

<sup>Written for commit 00b155bdda8e0dfd70107b982ae9f5599a4a6de9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

