### PR TITLE
feat: float option workflow

### DIFF
--- a/backend/main/lib/groupher_server/cms/models/metrics/dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/models/metrics/dashboard.ex
@@ -1,10 +1,10 @@
 defmodule GroupherServer.CMS.Model.Metrics.Dashboard do
   @moduledoc """
-  KTV(key, type, value(default)) for dashbaord macro/schema/type etc
-  define once, we can get embed_schema fields/default_values/cast_values and GraphQL endpont arg ready
+  KTV(key, type, value(default)) for dashboard macro/schema/type etc
+  define once, we can get embed_schema fields/default_values/cast_values and GraphQL endpoint arg ready
 
   only general key/value like string/boolean are supported
-  int/array of type are not supported, cuz it's hard to leverage between GraphQL/Schama/Types ..
+  int/array of type are not supported, cuz it's hard to leverage between GraphQL/Schema/Types ..
   those cases need to manually add
   """
 

--- a/backend/main/lib/groupher_server/cms/models/metrics/dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/models/metrics/dashboard.ex
@@ -72,6 +72,7 @@ defmodule GroupherServer.CMS.Model.Metrics.Dashboard do
       [:glow_type, :string, ""],
       [:glow_fixed, :boolean, false],
       [:glow_opacity, :string, ""],
+      [:dark_float, :boolean, true],
 
       ## blur
       [:gauss_blur, :integer, 100],

--- a/backend/main/schema.graphql
+++ b/backend/main/schema.graphql
@@ -638,7 +638,7 @@ type RootMutationType {
 
   "update layout in dashboard"
   updateDashboardLayout(
-    community: String!, dashboardSection: DashboardSection, primaryColor: String, postLayout: String, kanbanLayout: String, kanbanCardLayout: String, docLayout: String, docFaqLayout: String, tagLayout: String, avatarLayout: String, brandLayout: String, bannerLayout: String, topbarLayout: String, topbarBg: String, broadcastLayout: String, broadcastBg: String, broadcastEnable: Boolean, broadcastArticleLayout: String, broadcastArticleBg: String, broadcastArticleEnable: Boolean, changelogLayout: String, footerLayout: String, headerLayout: String, glowType: String, glowFixed: Boolean, glowOpacity: String, gaussBlur: Int, gaussBlurDark: Int, kanbanBgColors: [String]
+    community: String!, dashboardSection: DashboardSection, primaryColor: String, postLayout: String, kanbanLayout: String, kanbanCardLayout: String, docLayout: String, docFaqLayout: String, tagLayout: String, avatarLayout: String, brandLayout: String, bannerLayout: String, topbarLayout: String, topbarBg: String, broadcastLayout: String, broadcastBg: String, broadcastEnable: Boolean, broadcastArticleLayout: String, broadcastArticleBg: String, broadcastArticleEnable: Boolean, changelogLayout: String, footerLayout: String, headerLayout: String, glowType: String, glowFixed: Boolean, glowOpacity: String, darkFloat: Boolean, gaussBlur: Int, gaussBlurDark: Int, kanbanBgColors: [String]
   ): Community
 
   "update rss in dashboard"
@@ -921,6 +921,7 @@ type DashboardLayout {
   glowType: String
   glowFixed: Boolean
   glowOpacity: String
+  darkFloat: Boolean
   gaussBlur: Int
   gaussBlurDark: Int
   kanbanBgColors: [String]

--- a/backend/main/test/groupher_server_web/mutation/cms/dashboard_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/dashboard_test.exs
@@ -183,8 +183,8 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
     end
 
     @update_layout_query """
-    mutation($community: String!, $primaryColor: String $postLayout: String, $kanbanLayout: String, $kanbanCardLayout: String, $footerLayout: String, $broadcastEnable: Boolean, $kanbanBgColors: [String], $glowType: String, $glowFixed: Boolean, $glowOpacity: String, $tagLayout: String, $gaussBlur: Int, $gaussBlurDark: Int, $brandLayout: String) {
-      updateDashboardLayout(community: $community, primaryColor: $primaryColor, postLayout: $postLayout, kanbanLayout: $kanbanLayout, kanbanCardLayout: $kanbanCardLayout, footerLayout: $footerLayout, broadcastEnable: $broadcastEnable, kanbanBgColors: $kanbanBgColors, glowType: $glowType, glowFixed: $glowFixed, glowOpacity: $glowOpacity, tagLayout: $tagLayout, gaussBlur: $gaussBlur, gaussBlurDark: $gaussBlurDark, brandLayout: $brandLayout) {
+    mutation($community: String!, $primaryColor: String $postLayout: String, $kanbanLayout: String, $kanbanCardLayout: String, $footerLayout: String, $broadcastEnable: Boolean, $kanbanBgColors: [String], $glowType: String, $glowFixed: Boolean, $glowOpacity: String, $tagLayout: String, $gaussBlur: Int, $gaussBlurDark: Int, $brandLayout: String, $darkFloat: Boolean) {
+      updateDashboardLayout(community: $community, primaryColor: $primaryColor, postLayout: $postLayout, kanbanLayout: $kanbanLayout, kanbanCardLayout: $kanbanCardLayout, footerLayout: $footerLayout, broadcastEnable: $broadcastEnable, kanbanBgColors: $kanbanBgColors, glowType: $glowType, glowFixed: $glowFixed, glowOpacity: $glowOpacity, tagLayout: $tagLayout, gaussBlur: $gaussBlur, gaussBlurDark: $gaussBlurDark, brandLayout: $brandLayout, darkFloat: $darkFloat) {
         id
         title
         dashboard {
@@ -197,6 +197,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
             gaussBlur
             gaussBlurDark
             brandLayout
+            darkFloat
           }
         }
       }
@@ -220,7 +221,8 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
         tagLayout: "dot",
         gaussBlur: 80,
         gaussBlurDark: 60,
-        brandLayout: "LOGO"
+        brandLayout: "LOGO",
+        darkFloat: false
       }
 
       updated =
@@ -244,6 +246,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
       assert found.dashboard.layout.gauss_blur == 80
       assert found.dashboard.layout.gauss_blur_dark == 60
       assert found.dashboard.layout.brand_layout == "LOGO"
+      assert found.dashboard.layout.dark_float == false
     end
 
     test "update community dashboard layout should not overwrite existing settings",

--- a/frontend/core/containers/thread/DashboardThread/Layout/FloatBackground.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/FloatBackground.tsx
@@ -93,13 +93,7 @@ export default () => {
         </button>
       </div>
 
-      <SavingBar
-        isTouched={isTouched}
-        field={FIELD.DARK_FLOAT}
-        loading={saving}
-        width='w-11/12'
-        top={6}
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.DARK_FLOAT} loading={saving} top={6} />
     </section>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/FloatBackground.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/FloatBackground.tsx
@@ -1,13 +1,13 @@
 import CheckLabel from '~/widgets/CheckLabel'
 import { FIELD } from '../constant'
-import usePrimaryColor from '../logic/usePrimaryColor'
+import useDarkFloat from '../logic/useDarkFloat'
 import SavingBar from '../SavingBar'
 import SectionLabel from '../SectionLabel'
 import useSalon, { cnMerge } from '../salon/layout/float_background'
 
 export default () => {
   const s = useSalon()
-  const { isTouched, saving } = usePrimaryColor()
+  const { darkFloat, edit, isTouched, saving } = useDarkFloat()
 
   return (
     <section className={s.wrapper}>
@@ -17,8 +17,8 @@ export default () => {
       />
 
       <div className={s.select}>
-        <button className={s.layout}>
-          <div className={cnMerge(s.block, s.blockActive)}>
+        <button className={s.layout} onClick={() => edit(true, FIELD.DARK_FLOAT)}>
+          <div className={cnMerge(s.block, darkFloat && s.blockActive)}>
             <div
               className={cnMerge(s.popover, 'left-20 top-12')}
               style={{ borderColor: 'dimgray' }}
@@ -47,10 +47,10 @@ export default () => {
             </div>
           </div>
 
-          <CheckLabel title='始终使用深色' active top={4} />
+          <CheckLabel title='始终使用深色' active={darkFloat} top={4} />
         </button>
-        <button className={s.layout}>
-          <div className={cnMerge(s.block)}>
+        <button className={s.layout} onClick={() => edit(false, FIELD.DARK_FLOAT)}>
+          <div className={cnMerge(s.block, !darkFloat && s.blockActive)}>
             <div
               className={cnMerge(s.popover, 'left-5 top-12 w-24 bg-white')}
               style={{ borderColor: 'dimgray' }}
@@ -89,13 +89,13 @@ export default () => {
             </div>
           </div>
 
-          <CheckLabel title='跟随主题' top={4} />
+          <CheckLabel title='跟随主题' active={!darkFloat} top={4} />
         </button>
       </div>
 
       <SavingBar
         isTouched={isTouched}
-        field={FIELD.PRIMARY_COLOR}
+        field={FIELD.DARK_FLOAT}
         loading={saving}
         width='w-11/12'
         top={6}

--- a/frontend/core/containers/thread/DashboardThread/Layout/GaussBlur/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/GaussBlur/index.tsx
@@ -1,10 +1,16 @@
 import THEME from '~/const/theme'
+import useDidMount from '~/hooks/useDidMount'
 import useTheme from '~/hooks/useTheme'
 import Dark from './Dark'
 import Light from './Light'
 
 export default () => {
   const { theme } = useTheme()
+  const mounted = useDidMount()
+
+  if (!mounted) {
+    return null
+  }
 
   return theme === THEME.LIGHT ? <Light /> : <Dark />
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/GlowLight.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/GlowLight.tsx
@@ -1,4 +1,5 @@
 import { GLOW_EFFECTS_KEYS, GLOW_OPACITY } from '~/const/glow_effect'
+import useDidMount from '~/hooks/useDidMount'
 import ClossSVG from '~/icons/CloseLight'
 
 import DLightSVG from '~/icons/DLight'
@@ -11,6 +12,8 @@ import useSalon, { cn } from '../salon/layout/glow_light'
 
 export default () => {
   const s = useSalon()
+
+  const mounted = useDidMount()
 
   const {
     glowType,
@@ -42,15 +45,16 @@ export default () => {
           </div>
         </button>
 
-        {GLOW_EFFECTS_KEYS.map((effect) => (
-          <button
-            key={effect}
-            className={cn(s.block, effect === glowType && s.blockActive)}
-            onClick={() => edit(effect, 'glowType')}
-          >
-            <div className={s.bgWrapper} style={{ background: `${s.bgStyle2(effect)}` }} />
-          </button>
-        ))}
+        {mounted &&
+          GLOW_EFFECTS_KEYS.map((effect) => (
+            <button
+              key={effect}
+              className={cn(s.block, effect === glowType && s.blockActive)}
+              onClick={() => edit(effect, 'glowType')}
+            >
+              <div className={s.bgWrapper} style={{ background: `${s.bgStyle2(effect)}` }} />
+            </button>
+          ))}
       </div>
 
       <SavingBar

--- a/frontend/core/containers/thread/DashboardThread/Layout/PageBackground.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/PageBackground.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react'
 import { getCSSVar } from '~/css'
 import { camelize, titleCaseHM, upperSnakeCase } from '~/fmt'
-import useMount from '~/hooks/useMount'
+import useDidMount from '~/hooks/useDidMount'
 import useTheme from '~/hooks/useTheme'
 import CheckSVG from '~/icons/Check'
 import { FIELD } from '../constant'
@@ -13,9 +12,7 @@ import useSalon, { cn } from '../salon/layout/page_background'
 export default () => {
   const { rawBg, edit, isTouched, isDarkTouched, saving } = usePageBg()
 
-  const [mounted, setMounted] = useState(false)
-
-  useMount(() => setMounted(true))
+  const mounted = useDidMount()
 
   const s = useSalon()
   const { isLightTheme } = useTheme()
@@ -24,36 +21,37 @@ export default () => {
     <section className={s.wrapper}>
       <SectionLabel
         title='页面背景色'
-        desc="设置主页面背景色。参考"
+        desc='设置主页面背景色。参考'
         classNames='pr-8'
         withThemeSelect
       />
 
       <div className={s.themeGroup}>
-        {s.bgColorNames.map((bg, index) => {
-          const bgTitle = titleCaseHM(bg)
-          const pageName = camelize(bg)
-          const bgVal = getCSSVar(`color-page-${pageName}`)
-          const active = rawBg === bgVal && !!rawBg
+        {mounted &&
+          s.bgColorNames.map((bg, index) => {
+            const bgTitle = titleCaseHM(bg)
+            const pageName = camelize(bg)
+            const bgVal = getCSSVar(`color-page-${pageName}`)
+            const active = rawBg === bgVal && !!rawBg
 
-          return (
-            <button
-              key={bg}
-              className={cn(s.block, `rotate-${s.rotateAngle[index]}`, active && s.blockActive)}
-              onClick={() => {
-                edit(upperSnakeCase(bg), isLightTheme ? FIELD.PAGE_BG : FIELD.PAGE_BG_DARK)
-              }}
-            >
-              <div className={cn(s.blockInner, s.getPageClass(pageName))}>
-                {active && <CheckSVG className={s.checker} />}
-              </div>
-              <div className={s.footer}>
-                <div className={s.colorTitle}>{bgTitle}</div>
-                <div className={s.hex}>{mounted && bgVal}</div>
-              </div>
-            </button>
-          )
-        })}
+            return (
+              <button
+                key={bg}
+                className={cn(s.block, `rotate-${s.rotateAngle[index]}`, active && s.blockActive)}
+                onClick={() => {
+                  edit(upperSnakeCase(bg), isLightTheme ? FIELD.PAGE_BG : FIELD.PAGE_BG_DARK)
+                }}
+              >
+                <div className={cn(s.blockInner, s.getPageClass(pageName))}>
+                  {active && <CheckSVG className={s.checker} />}
+                </div>
+                <div className={s.footer}>
+                  <div className={s.colorTitle}>{bgTitle}</div>
+                  <div className={s.hex}>{bgVal}</div>
+                </div>
+              </button>
+            )
+          })}
       </div>
 
       {isLightTheme ? (

--- a/frontend/core/containers/thread/DashboardThread/Layout/PrimaryColor.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/PrimaryColor.tsx
@@ -32,13 +32,7 @@ export default () => {
           </div>
           <p className={s.desc}>作用于各类功能按钮，Tab 高亮，菜单高亮等品牌颜色。</p>
 
-          <SavingBar
-            isTouched={isTouched}
-            field={FIELD.PRIMARY_COLOR}
-            loading={saving}
-            width='w-11/12'
-            top={6}
-          />
+          <SavingBar isTouched={isTouched} field={FIELD.PRIMARY_COLOR} loading={saving} top={6} />
         </div>
 
         <div className={s.block}>
@@ -59,13 +53,7 @@ export default () => {
         </div>
       </div>
 
-      <SavingBar
-        isTouched={isTouched}
-        field={FIELD.PRIMARY_COLOR}
-        loading={saving}
-        width='w-11/12'
-        top={6}
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.PRIMARY_COLOR} loading={saving} top={6} />
     </section>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/SectionLabel/ThemeSelect.tsx
+++ b/frontend/core/containers/thread/DashboardThread/SectionLabel/ThemeSelect.tsx
@@ -1,4 +1,5 @@
 import THEME from '~/const/theme'
+import useDidMount from '~/hooks/useDidMount'
 import useTheme from '~/hooks/useTheme'
 import MoonSVG from '~/icons/Moon'
 import SunSVG from '~/icons/Sun'
@@ -8,6 +9,12 @@ import useSalon, { cn } from '../salon/section_label/theme_select'
 export default () => {
   const s = useSalon()
   const { theme, changeMode } = useTheme()
+
+  const mounted = useDidMount()
+
+  if (!mounted) {
+    return null
+  }
 
   return (
     <div className={s.wrapper}>

--- a/frontend/core/containers/thread/DashboardThread/SectionLabel/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/SectionLabel/index.tsx
@@ -1,8 +1,7 @@
 import type { FC, ReactNode } from 'react'
-import ArrowButton from '~/widgets/Buttons/ArrowButton'
-
 import type { TSpace } from '~/spec'
-import useSalon, { cn } from '../salon/section_label'
+import ArrowButton from '~/widgets/Buttons/ArrowButton'
+import useSalon, { cnMerge } from '../salon/section_label'
 import ThemeSelect from './ThemeSelect'
 
 type TProps = {
@@ -23,7 +22,7 @@ const SectionLabel: FC<TProps> = ({
   addon = null,
   width = 'w-full',
   withThemeSelect = false,
-  detailText = "影响范围",
+  detailText = '影响范围',
   classNames = '',
   showMoreButton = true,
   onDetailClick = () => {},
@@ -32,7 +31,7 @@ const SectionLabel: FC<TProps> = ({
   const s = useSalon({ width, desc, ...spacing })
 
   return (
-    <div className={cn(s.wrapper, classNames)}>
+    <div className={cnMerge(s.wrapper, classNames)}>
       <div className={s.header}>
         <h3 className={s.title}>
           {title}
@@ -45,10 +44,16 @@ const SectionLabel: FC<TProps> = ({
         <div className='grow' />
         {addon}
       </div>
-      {desc && <div className={s.desc}>
-        {desc}
-        {showMoreButton && <ArrowButton left={0.5} onClick={onDetailClick}>{detailText}</ArrowButton>}
-        </div>}
+      {desc && (
+        <div className={s.desc}>
+          {desc}
+          {showMoreButton && (
+            <ArrowButton left={0.5} onClick={onDetailClick}>
+              {detailText}
+            </ArrowButton>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/constant.tsx
+++ b/frontend/core/containers/thread/DashboardThread/constant.tsx
@@ -33,6 +33,7 @@ export const LAYOUT_FIELD = {
   GLOW_TYPE: 'glowType',
   GLOW_FIXED: 'glowFixed',
   GLOW_OPACITY: 'glowOpacity',
+  DARK_FLOAT: 'darkFloat',
   GAUSS_BLUR: 'gaussBlur',
   GAUSS_BLUR_DARK: 'gaussBlurDark',
 }

--- a/frontend/core/containers/thread/DashboardThread/logic/useDarkFloat.ts
+++ b/frontend/core/containers/thread/DashboardThread/logic/useDarkFloat.ts
@@ -1,0 +1,25 @@
+import useDashboard from '~/hooks/useDashboard'
+import type { TEditFunc } from '~/spec'
+
+import useHelper from './useHelper'
+
+type TRet = {
+  darkFloat: boolean
+  saving: boolean
+  isTouched: boolean
+  edit: TEditFunc
+}
+
+export default (): TRet => {
+  const dsb$ = useDashboard()
+  const { edit, isChanged } = useHelper()
+
+  const { darkFloat, saving } = dsb$
+
+  return {
+    darkFloat,
+    saving,
+    edit,
+    isTouched: isChanged('darkFloat'),
+  }
+}

--- a/frontend/core/containers/thread/DashboardThread/salon/section_label/index.ts
+++ b/frontend/core/containers/thread/DashboardThread/salon/section_label/index.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import useTwBelt from '~/hooks/useTwBelt'
 import type { TSpace } from '~/spec'
 
-export { cn } from '~/css'
+export { cn, cnMerge } from '~/css'
 
 type TProps = {
   width: string

--- a/frontend/core/containers/thread/DashboardThread/schema.ts
+++ b/frontend/core/containers/thread/DashboardThread/schema.ts
@@ -175,6 +175,7 @@ const updateDashboardLayout = gql`
     $glowType: String
     $glowFixed: Boolean
     $glowOpacity: String
+    $darkFloat: Boolean
     $gaussBlur: Int
     $gaussBlurDark: Int
     $brandLayout: String
@@ -200,6 +201,7 @@ const updateDashboardLayout = gql`
       glowType: $glowType
       glowFixed: $glowFixed
       glowOpacity: $glowOpacity
+      darkFloat: $darkFloat
       gaussBlur: $gaussBlur
       gaussBlurDark: $gaussBlurDark
       brandLayout: $brandLayout

--- a/frontend/core/hooks/useDarkFloat/index.ts
+++ b/frontend/core/hooks/useDarkFloat/index.ts
@@ -1,0 +1,7 @@
+import useDashboard from '~/hooks/useDashboard'
+
+export default (): boolean => {
+  const { darkFloat } = useDashboard()
+
+  return darkFloat
+}

--- a/frontend/core/hooks/useDidMount/index.test.ts
+++ b/frontend/core/hooks/useDidMount/index.test.ts
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react'
+import useDidMount from '~/hooks/useDidMount'
+
+it('returns false on first render and true after mount', async () => {
+  const { result } = renderHook(() => useDidMount())
+
+  // hydration / first render
+  expect(result.current).toBe(false)
+
+  // effect runs after mount
+  await Promise.resolve()
+  expect(result.current).toBe(true)
+})

--- a/frontend/core/hooks/useDidMount/index.test.ts
+++ b/frontend/core/hooks/useDidMount/index.test.ts
@@ -1,13 +1,12 @@
-import { renderHook } from '@testing-library/react'
+import { renderHook, waitFor } from '@testing-library/react'
 import useDidMount from '~/hooks/useDidMount'
 
 it('returns false on first render and true after mount', async () => {
   const { result } = renderHook(() => useDidMount())
 
-  // hydration / first render
   expect(result.current).toBe(false)
 
-  // effect runs after mount
-  await Promise.resolve()
-  expect(result.current).toBe(true)
+  await waitFor(() => {
+    expect(result.current).toBe(true)
+  })
 })

--- a/frontend/core/hooks/useDidMount/index.ts
+++ b/frontend/core/hooks/useDidMount/index.ts
@@ -1,12 +1,12 @@
 // ~/hooks/useDidMount.ts
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 
 export default function useDidMount(): boolean {
-  const didMount = useRef(false)
+  const [didMount, setDidMount] = useState(false)
 
   useEffect(() => {
-    didMount.current = true
+    setDidMount(true)
   }, [])
 
-  return didMount.current
+  return didMount
 }

--- a/frontend/core/hooks/useDidMount/index.ts
+++ b/frontend/core/hooks/useDidMount/index.ts
@@ -1,0 +1,12 @@
+// ~/hooks/useDidMount.ts
+import { useEffect, useRef } from 'react'
+
+export default function useDidMount(): boolean {
+  const didMount = useRef(false)
+
+  useEffect(() => {
+    didMount.current = true
+  }, [])
+
+  return didMount.current
+}

--- a/frontend/core/schemas/pages/community.ts
+++ b/frontend/core/schemas/pages/community.ts
@@ -102,6 +102,7 @@ export const community = `
           glowType
           glowFixed
           glowOpacity
+          darkFloat
           gaussBlur
           gaussBlurDark
           broadcastEnable

--- a/frontend/core/spec/dashboard.d.ts
+++ b/frontend/core/spec/dashboard.d.ts
@@ -72,6 +72,7 @@ export type TDsb = {
     glowType: string
     glowFixed: boolean
     glowOpacity: string
+    darkFloat: boolean
     docLayout: TDocLayout
     docFaqLayout: TDocFaqLayout
     postLayout: TPostLayout

--- a/frontend/core/stores/dashboard/constant.tsx
+++ b/frontend/core/stores/dashboard/constant.tsx
@@ -111,6 +111,8 @@ export const FIELDS: TDsbFieldMap = {
   glowFixed: true,
   glowOpacity: GLOW_OPACITY.NORMAL,
 
+  darkFloat: true,
+
   // gauss blur
   gaussBlur: 100,
   gaussBlurDark: 100,

--- a/frontend/core/stores/dashboard/spec.d.ts
+++ b/frontend/core/stores/dashboard/spec.d.ts
@@ -122,6 +122,8 @@ export type TDsbFieldMap = {
   glowFixed: boolean
   glowOpacity: string
 
+  darkFloat: boolean
+
   // gauss blur
   gaussBlur: int
   gaussBlurDark: int

--- a/frontend/core/widgets/AccountUnit/LoggedInAccount.tsx
+++ b/frontend/core/widgets/AccountUnit/LoggedInAccount.tsx
@@ -31,6 +31,7 @@ const LoggedInAccount: FC<TProps> = ({ user }) => {
 
   return (
     <Tooltip
+      offset={[18, 5]}
       content={
         <div className={s.panel}>
           <div className={s.baseInfo}>

--- a/frontend/core/widgets/AccountUnit/salon/logged_in_account.ts
+++ b/frontend/core/widgets/AccountUnit/salon/logged_in_account.ts
@@ -6,7 +6,7 @@ export default () => {
   const { cn, avatar, fg, bg, fill, menu, sexyBorder, linkable } = useTwBelt()
 
   return {
-    panel: 'w-40 px-2 py-2',
+    panel: 'w-40 py-2',
     avatar: cn('size-5', avatar('sm')),
     baseInfo: 'ml-3 mb-4',
     userName: cn('text-sm bold-sm', fg('title')),

--- a/frontend/core/widgets/Buttons/salon/button/index.ts
+++ b/frontend/core/widgets/Buttons/salon/button/index.ts
@@ -83,7 +83,7 @@ export default function useButtonSalon({
   }
 
   const solidPrimaryFgOverride = () => {
-    if (!ghost && tone === 'primary') return fg('black')
+    if (!ghost && tone === 'primary') return 'dark:text-black'
     return ''
   }
 

--- a/frontend/core/widgets/Tooltip/index.tsx
+++ b/frontend/core/widgets/Tooltip/index.tsx
@@ -11,6 +11,7 @@ import type { Instance } from 'tippy.js'
 import { hideAll } from 'tippy.js'
 
 import useOutsideClick from '~/hooks/useOutsideClick'
+import useDarkFloat from '~/hooks/useDarkFloat'
 import type { TThemeName, TTooltipPlacement } from '~/spec'
 
 import ConfirmFooter from './ConfirmFooter'
@@ -84,6 +85,7 @@ const Tooltip: FC<TProps> = ({
   forceZIndex = false,
 }) => {
   const s = useSalon()
+  const darkFloat = useDarkFloat()
 
   const tooltipTheme = getCurrentTooltipTheme()
 
@@ -194,6 +196,7 @@ const Tooltip: FC<TProps> = ({
   ])
 
   const wrapperClass = !noPadding ? s.tooltip : cn(s.tooltip, 'p-0')
+  const themedWrapperClass = darkFloat ? cn(wrapperClass, 'dark') : wrapperClass
 
   /**
    * forceZIndex: only used in some special masking scenarios (IconSwitcher)
@@ -202,7 +205,7 @@ const Tooltip: FC<TProps> = ({
   const triggerWrapperClass = forceZIndex ? 'relative z-[1]' : undefined
 
   return (
-    <Tippy className={wrapperClass} {...tippyProps}>
+    <Tippy className={themedWrapperClass} {...tippyProps}>
       <div className={triggerWrapperClass}>{children}</div>
     </Tippy>
   )

--- a/frontend/core/widgets/Tooltip/index.tsx
+++ b/frontend/core/widgets/Tooltip/index.tsx
@@ -84,7 +84,10 @@ const Tooltip: FC<TProps> = ({
   const s = useSalon()
   const darkFloat = useDarkFloat()
 
-  const tooltipTheme = darkFloat ? THEME.DARK : THEME.LIGHT
+
+  const { theme } = useTheme()
+  const tooltipTheme = darkFloat ? THEME.DARK : theme
+
 
   const instanceRef = useRef<Instance | null>(null)
   const [active, setActive] = useState(false)

--- a/frontend/core/widgets/Tooltip/index.tsx
+++ b/frontend/core/widgets/Tooltip/index.tsx
@@ -12,6 +12,7 @@ import { hideAll } from 'tippy.js'
 import THEME from '~/const/theme'
 import useDarkFloat from '~/hooks/useDarkFloat'
 import useOutsideClick from '~/hooks/useOutsideClick'
+import useTheme from '~/hooks/useTheme'
 import type { TThemeName, TTooltipPlacement } from '~/spec'
 
 import ConfirmFooter from './ConfirmFooter'
@@ -84,10 +85,8 @@ const Tooltip: FC<TProps> = ({
   const s = useSalon()
   const darkFloat = useDarkFloat()
 
-
   const { theme } = useTheme()
   const tooltipTheme = darkFloat ? THEME.DARK : theme
-
 
   const instanceRef = useRef<Instance | null>(null)
   const [active, setActive] = useState(false)

--- a/frontend/core/widgets/Tooltip/index.tsx
+++ b/frontend/core/widgets/Tooltip/index.tsx
@@ -9,9 +9,9 @@ import Tippy from '@groupher/tooltip'
 import { type FC, memo, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import type { Instance } from 'tippy.js'
 import { hideAll } from 'tippy.js'
-
-import useOutsideClick from '~/hooks/useOutsideClick'
+import THEME from '~/const/theme'
 import useDarkFloat from '~/hooks/useDarkFloat'
+import useOutsideClick from '~/hooks/useOutsideClick'
 import type { TThemeName, TTooltipPlacement } from '~/spec'
 
 import ConfirmFooter from './ConfirmFooter'
@@ -21,10 +21,7 @@ import useSalon, { cn } from './salon'
 /**
  * Current tooltip theme.
  * For now it's hard-coded.
- * Later: replace this with "read from dashboard settings".
  */
-const getCurrentTooltipTheme = (): TThemeName => 'dark' // TODO: read from dashboard config
-
 export type TProps = {
   children: ReactNode
   content: string | ReactNode
@@ -87,7 +84,7 @@ const Tooltip: FC<TProps> = ({
   const s = useSalon()
   const darkFloat = useDarkFloat()
 
-  const tooltipTheme = getCurrentTooltipTheme()
+  const tooltipTheme = darkFloat ? THEME.DARK : THEME.LIGHT
 
   const instanceRef = useRef<Instance | null>(null)
   const [active, setActive] = useState(false)
@@ -196,7 +193,6 @@ const Tooltip: FC<TProps> = ({
   ])
 
   const wrapperClass = !noPadding ? s.tooltip : cn(s.tooltip, 'p-0')
-  const themedWrapperClass = darkFloat ? cn(wrapperClass, 'dark') : wrapperClass
 
   /**
    * forceZIndex: only used in some special masking scenarios (IconSwitcher)
@@ -205,7 +201,7 @@ const Tooltip: FC<TProps> = ({
   const triggerWrapperClass = forceZIndex ? 'relative z-[1]' : undefined
 
   return (
-    <Tippy className={themedWrapperClass} {...tippyProps}>
+    <Tippy className={wrapperClass} {...tippyProps}>
       <div className={triggerWrapperClass}>{children}</div>
     </Tippy>
   )

--- a/frontend/e2e/playwright.config.ts
+++ b/frontend/e2e/playwright.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { defineConfig, devices } from '@playwright/test'
 
 const app = process.env.E2E_APP ?? 'main'
@@ -6,17 +7,17 @@ const appConfig = {
   main: {
     cmd: 'cross-env PORT=3100 yarn workspace @groupher/frontend-main dev',
     url: 'http://localhost:3100',
-    testDir: './tests/main',
+    testDir: path.resolve('frontend/e2e/tests/main'),
   },
   dashboard: {
     cmd: 'cross-env PORT=3101 yarn workspace @groupher/frontend-dashboard dev',
     url: 'http://localhost:3101',
-    testDir: './tests/dashboard',
+    testDir: path.resolve('frontend/e2e/tests/dashboard'),
   },
   landing: {
     cmd: 'cross-env PORT=3102 yarn workspace @groupher/frontend-landing dev',
     url: 'http://localhost:3102',
-    testDir: './tests/landing',
+    testDir: path.resolve('frontend/e2e/tests/landing'),
   },
 } as const
 


### PR DESCRIPTION
- **chore: typo**
- **feat: add dark float dashboard setting (#418)**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “dark float” dashboard setting to control whether floating UI (like tooltips) always uses dark styling or follows the theme. Also fixes SSR hydration mismatches in theme-dependent dashboard controls to prevent flicker.

- **New Features**
  - Backend: added darkFloat (boolean, default true) to dashboard metrics; exposed in updateDashboardLayout and community queries; tests updated.
  - Dashboard UI: toggle in Float Background to choose “Always dark” or “Follow theme”; saved via DARK_FLOAT.
  - Hooks: added useDarkFloat for read-only access and logic/useDarkFloat for edit state.
  - Tooltip: theme now respects darkFloat.

- **Bug Fixes**
  - Prevent SSR mismatch by deferring render with useDidMount in GaussBlur, GlowLight, PageBackground, and ThemeSelect.

<sup>Written for commit 47671454fdd26afef876a3c4503a29baa477894e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a darkFloat toggle for dashboard layout customization; tooltips and layout APIs now honor this flag for dark/light float styling.
  * Components now delay certain UI renders until after mount to reduce flicker and improve hydration behavior.
* **UI**
  * Minor visual refinements: saving bar layout simplified, tooltip positioning adjusted, and panel spacing tweaked.
* **Tests**
  * Added/updated tests to cover the darkFloat layout update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->