### PR TITLE
refactor(fe): rm un-needed width on savingbar

### DIFF
--- a/frontend/core/containers/thread/DashboardThread/BasicInfo/OtherInfo/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/BasicInfo/OtherInfo/index.tsx
@@ -42,7 +42,7 @@ const OtherInfo: FC = () => {
         field={FIELD.MEDIA_REPORTS}
         isTouched={isMediaReportsTouched}
         loading={false}
-        top={30}
+        top={14}
         left={-1}
       />
     </div>

--- a/frontend/core/containers/thread/DashboardThread/BasicInfo/SocialInfo.tsx
+++ b/frontend/core/containers/thread/DashboardThread/BasicInfo/SocialInfo.tsx
@@ -23,7 +23,7 @@ export default () => {
         isTouched={isSocialLinksTouched}
         field={FIELD.SOCIAL_LINKS}
         loading={saving}
-        top={50}
+        top={10}
       />
     </div>
   )

--- a/frontend/core/containers/thread/DashboardThread/CMS/Docs/FAQ/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/CMS/Docs/FAQ/index.tsx
@@ -50,7 +50,7 @@ const FAQ: FC<TProps> = ({ sections, editingFAQIndex, editingFAQ, isTouched }) =
             field={FIELD.FAQ_SECTIONS}
             prefix='是否保存排序'
             isTouched={isTouched}
-            top={30}
+            top={12}
           />
         </div>
       </Markdown>

--- a/frontend/core/containers/thread/DashboardThread/Layout/AvatarLayout.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/AvatarLayout.tsx
@@ -46,13 +46,7 @@ export default () => {
           <CheckLabel title='圆形' active={layout === AVATAR_LAYOUT.CIRCLE} top={3} />
         </button>
       </div>
-      <SavingBar
-        isTouched={isTouched}
-        field={FIELD.AVATAR_LAYOUT}
-        loading={saving}
-        width='w-10/12'
-        top={8}
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.AVATAR_LAYOUT} loading={saving} top={8} />
     </div>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/BannerLayout.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/BannerLayout.tsx
@@ -25,8 +25,8 @@ export default () => {
 
       <SectionLabel
         title='整体布局'
-        desc="整体页面的 Header 布局，适用于除文章页的所有页面。"
-        detailText="查看示例"
+        desc='整体页面的 Header 布局，适用于除文章页的所有页面。'
+        detailText='查看示例'
       />
       <div className={s.select}>
         <button className={s.layout} onClick={() => edit(BANNER_LAYOUT.HEADER, 'bannerLayout')}>
@@ -139,13 +139,7 @@ export default () => {
           <CheckLabel title='左右分栏' active={layout === BANNER_LAYOUT.SIDEBAR} top={4} />
         </button>
       </div>
-      <SavingBar
-        isTouched={isTouched}
-        field={FIELD.BANNER_LAYOUT}
-        loading={saving}
-        top={10}
-        width='w-11/12'
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.BANNER_LAYOUT} loading={saving} top={10} />
     </div>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/BrandLayout.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/BrandLayout.tsx
@@ -56,7 +56,6 @@ export default () => {
         loading={saving}
         top={10}
         left={1}
-        width='w-11/12'
       />
     </div>
   )

--- a/frontend/core/containers/thread/DashboardThread/Layout/ChangelogLayout.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/ChangelogLayout.tsx
@@ -68,13 +68,7 @@ export default () => {
         </button>
       </div>
 
-      <SavingBar
-        isTouched={isTouched}
-        field={FIELD.CHANGELOG_LAYOUT}
-        loading={saving}
-        width='w-11/12'
-        top={12}
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.CHANGELOG_LAYOUT} loading={saving} top={12} />
     </div>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/DocLayout/index.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/DocLayout/index.tsx
@@ -17,11 +17,7 @@ export default () => {
 
   return (
     <div className={s.wrapper}>
-      <SectionLabel
-        title='封面目录布局'
-        desc="全部文档的目录布局。"
-        detailText="查看示例"
-      />
+      <SectionLabel title='封面目录布局' desc='全部文档的目录布局。' detailText='查看示例' />
       <div className={s.select}>
         <button className={s.layout} onClick={() => edit(DOC_LAYOUT.BLOCKS, 'docLayout')}>
           <div className={cn(s.block, docLayout === DOC_LAYOUT.BLOCKS && s.blockActive)}>
@@ -50,20 +46,14 @@ export default () => {
           <CheckLabel title='卡片排列' active={docLayout === DOC_LAYOUT.CARDS} top={4} />
         </button>
       </div>
-      <SavingBar
-        isTouched={isTouched}
-        field={FIELD.DOC_LAYOUT}
-        loading={saving}
-        width='w-11/12'
-        top={10}
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.DOC_LAYOUT} loading={saving} top={10} />
 
       <div className={s.divider} />
 
       <SectionLabel
         title='常见问题（FAQ）布局'
-        desc="当前设置仅针对常见问题的展示样式。"
-        detailText="查看示例"
+        desc='当前设置仅针对常见问题的展示样式。'
+        detailText='查看示例'
       />
       <div className={s.select}>
         <button className={s.layout} onClick={() => edit(DOC_FAQ_LAYOUT.COLLAPSE, 'docFaqLayout')}>
@@ -88,13 +78,7 @@ export default () => {
           <CheckLabel title='左右列' active={docFaqLayout === DOC_FAQ_LAYOUT.LEFT_RIGHT} top={4} />
         </button>
       </div>
-      <SavingBar
-        isTouched={isFaqTouched}
-        field={FIELD.DOC_FAQ_LAYOUT}
-        loading={saving}
-        width='w-11/12'
-        top={10}
-      />
+      <SavingBar isTouched={isFaqTouched} field={FIELD.DOC_FAQ_LAYOUT} loading={saving} top={10} />
     </div>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/GaussBlur/Dark.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/GaussBlur/Dark.tsx
@@ -67,19 +67,12 @@ export default () => {
             top={5}
             min={50}
             max={100}
-            width='w-10/12'
             unit='%'
           />
         </ul>
       </div>
 
-      <SavingBar
-        width='96%'
-        isTouched={isTouched}
-        field={FIELD.GAUSS_BLUR_DARK}
-        loading={saving}
-        top={20}
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.GAUSS_BLUR_DARK} loading={saving} top={20} />
     </div>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/GaussBlur/Light.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/GaussBlur/Light.tsx
@@ -68,19 +68,12 @@ export default () => {
             top={5}
             min={50}
             max={100}
-            width='w-10/12'
             unit='%'
           />
         </ul>
       </div>
 
-      <SavingBar
-        width='w-11/12'
-        isTouched={isTouched}
-        field={FIELD.GAUSS_BLUR}
-        loading={saving}
-        top={10}
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.GAUSS_BLUR} loading={saving} top={10} />
     </div>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/GlowLight.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/GlowLight.tsx
@@ -57,22 +57,11 @@ export default () => {
           ))}
       </div>
 
-      <SavingBar
-        isTouched={isTouched}
-        field={FIELD.GLOW_TYPE}
-        loading={saving}
-        top={10}
-        width='w-11/12'
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.GLOW_TYPE} loading={saving} top={10} />
 
       <div className='mb-10' />
 
-      <SavingBar
-        isTouched={isGrowFixedTouched}
-        field={FIELD.GLOW_FIXED}
-        loading={saving}
-        width='w-11/12'
-      >
+      <SavingBar isTouched={isGrowFixedTouched} field={FIELD.GLOW_FIXED} loading={saving}>
         <div className={s.settings}>
           <h3 className={s.title}>滑动跟随:</h3>
           <Radio
@@ -100,7 +89,6 @@ export default () => {
           isTouched={isGrowOpacityTouched}
           field={FIELD.GLOW_OPACITY}
           loading={saving}
-          width='88%'
           top={-8}
         >
           <div className={s.settings}>

--- a/frontend/core/containers/thread/DashboardThread/Layout/PostLayout.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/PostLayout.tsx
@@ -99,13 +99,7 @@ export default () => {
         </button>
       </div>
 
-      <SavingBar
-        width='w-11/12'
-        isTouched={isTouched}
-        field={FIELD.POST_LAYOUT}
-        loading={saving}
-        top={20}
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.POST_LAYOUT} loading={saving} top={20} />
     </div>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/TagLayout.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/TagLayout.tsx
@@ -42,13 +42,7 @@ export default () => {
           <CheckLabel title='圆点' active={tagLayout === TAG_LAYOUT.DOT} top={3} />
         </button>
       </div>
-      <SavingBar
-        isTouched={isTouched}
-        field={FIELD.TAG_LAYOUT}
-        loading={saving}
-        width='w-10/12'
-        top={10}
-      />
+      <SavingBar isTouched={isTouched} field={FIELD.TAG_LAYOUT} loading={saving} top={10} />
     </div>
   )
 }

--- a/frontend/core/containers/thread/DashboardThread/Layout/TopbarLayout.tsx
+++ b/frontend/core/containers/thread/DashboardThread/Layout/TopbarLayout.tsx
@@ -49,7 +49,6 @@ export default () => {
           loading={saving}
           left={-10}
           top={30}
-          width='89%'
         >
           <div className={s.bgWrapper}>
             <div>颜色:</div>

--- a/frontend/dashboard/src/app/[community]/dashboard/seo/layout.tsx
+++ b/frontend/dashboard/src/app/[community]/dashboard/seo/layout.tsx
@@ -46,7 +46,7 @@ export default ({ children }) => {
 
       {children}
 
-      <SavingBar field={FIELD.SEO} isTouched={isTouched} loading={saving} width='7/12' />
+      <SavingBar field={FIELD.SEO} isTouched={isTouched} loading={saving} />
     </div>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed custom width overrides from SavingBar and adjusted top offsets across dashboard layouts and the SEO page to use default responsive sizing and consistent spacing. No behavior changes; improves visual consistency and simplifies styling.

<sup>Written for commit 917f30cb7e9e13c0bc7bc9fc191c3c2ecd170218. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted vertical spacing and positioning of saving status indicators across dashboard sections.
  * Refined component sizing and layout spacing for improved visual consistency.
  * Consolidated code formatting for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->