### PR TITLE
refactor(be): spec for CMS module functions and missing test

### DIFF
--- a/backend/main/lib/groupher_server/accounts/delegates/utils.ex
+++ b/backend/main/lib/groupher_server/accounts/delegates/utils.ex
@@ -11,7 +11,7 @@ defmodule GroupherServer.Accounts.Delegate.Utils do
   @doc """
   get and cache user'id by user's login
   """
-  @spec get_userid_and_cache(String.t()) :: {:ok, Integer.t()} | {:error, any}
+  @spec get_userid_and_cache(String.t()) :: {:ok, integer()} | {:error, any}
   def get_userid_and_cache(login) do
     case Cache.get(@cache_pool, login) do
       {:ok, user_id} -> {:ok, user_id}

--- a/backend/main/lib/groupher_server/cms/cms.ex
+++ b/backend/main/lib/groupher_server/cms/cms.ex
@@ -17,6 +17,7 @@ defmodule GroupherServer.CMS do
     ArticleUpvote,
     CommentAction,
     CommentEmotion,
+    Fetcher,
     ArticleTag,
     CommunityCRUD,
     CommunityOperation,
@@ -203,6 +204,9 @@ defmodule GroupherServer.CMS do
 
   defdelegate pin_comment(comment_id), to: CommentAction
   defdelegate undo_pin_comment(comment_id), to: CommentAction
+
+  defdelegate fetch_comment(comment_id), to: Fetcher
+  defdelegate fetch_full_comment(comment_id), to: Fetcher
 
   defdelegate fold_comment(comment_id, user), to: CommentAction
   defdelegate unfold_comment(comment_id, user), to: CommentAction

--- a/backend/main/lib/groupher_server/cms/delegates/abuse_report.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/abuse_report.ex
@@ -11,6 +11,7 @@ defmodule GroupherServer.CMS.Delegate.AbuseReport do
   import ShortMaps
 
   alias Helper.{ORM, Transaction, QueryBuilder}
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias Accounts.Model.User
@@ -36,6 +37,7 @@ defmodule GroupherServer.CMS.Delegate.AbuseReport do
   @doc """
   list paged reports for article comments
   """
+  @spec paged_reports(map()) :: T.domain_res(term())
   def paged_reports(%{content_type: :account, content_id: content_id} = filter) do
     with {:ok, info} <- match(:account) do
       query =
@@ -97,6 +99,7 @@ defmodule GroupherServer.CMS.Delegate.AbuseReport do
   @doc """
   report an account
   """
+  @spec report_account(User.t(), term(), map(), User.t()) :: T.domain_res(term())
   def report_account(%User{} = account, reason, attr, %User{} = user) do
     {:ok, info} = match(:account)
 
@@ -116,6 +119,7 @@ defmodule GroupherServer.CMS.Delegate.AbuseReport do
   @doc """
   undo report article content
   """
+  @spec undo_report_account(User.t(), User.t()) :: T.domain_res(term())
   def undo_report_account(%User{} = account, %User{} = user) do
     {:ok, info} = match(:account)
 
@@ -135,6 +139,7 @@ defmodule GroupherServer.CMS.Delegate.AbuseReport do
   @doc """
   report article content
   """
+  @spec report_article(term(), term(), map(), User.t()) :: T.domain_res(term())
   def report_article(article, reason, attr, %User{} = user) do
     {:ok, info} = match(article)
 
@@ -155,6 +160,7 @@ defmodule GroupherServer.CMS.Delegate.AbuseReport do
   @doc """
   undo report article content
   """
+  @spec undo_report_article(term(), User.t()) :: T.domain_res(term())
   def undo_report_article(article, %User{} = user) do
     {:ok, thread} = thread_of(article)
     {:ok, info} = match(thread)
@@ -173,6 +179,7 @@ defmodule GroupherServer.CMS.Delegate.AbuseReport do
   end
 
   @doc "report a comment"
+  @spec report_comment(Comment.t(), term(), map(), User.t()) :: T.domain_res(term())
   def report_comment(%Comment{} = comment, reason, attr, %User{} = user) do
     Transaction.locking(comment, fn comment ->
       Multi.new()
@@ -196,6 +203,7 @@ defmodule GroupherServer.CMS.Delegate.AbuseReport do
     end)
   end
 
+  @spec undo_report_comment(Comment.t(), User.t()) :: T.domain_res(term())
   def undo_report_comment(%Comment{} = comment, %User{} = user) do
     Transaction.locking(comment, fn comment ->
       Multi.new()
@@ -320,7 +328,9 @@ defmodule GroupherServer.CMS.Delegate.AbuseReport do
           |> length
           |> Kernel.>(0)
 
-        if not reported_before, do: {:ok, report}, else: {:error, "#{login} already reported"}
+        if not reported_before,
+          do: {:ok, report},
+          else: {:error, {:already_exist, "#{login} already reported"}}
     end
   end
 

--- a/backend/main/lib/groupher_server/cms/delegates/article_collect.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/article_collect.ex
@@ -14,6 +14,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCollect do
 
   # import Helper.ErrorCode
   alias Helper.{ORM, Later, Transaction}
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias Accounts.Model.User
@@ -25,11 +26,13 @@ defmodule GroupherServer.CMS.Delegate.ArticleCollect do
   @doc """
   get paged collected users
   """
+  @spec collected_users(term(), map()) :: T.domain_res(term())
   def collected_users(article, filter), do: load_reaction_users(ArticleCollect, article, filter)
 
   @doc """
   collect an article
   """
+  @spec collect_article(term(), User.t()) :: T.domain_res(term())
   def collect_article(article, %User{} = user) do
     {:ok, info} = match(article)
 
@@ -62,6 +65,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCollect do
   # 如果是同一篇文章，只创建一次，collect_article 不创建记录，只是后续设置不同的收藏夹即可
   # 如果是第一次收藏，那么才创建文章收藏记录
   # 避免因为同一篇文章在不同收藏夹内造成的统计和用户成就系统的混乱
+  @spec collect_article_ifneed(term(), User.t()) :: T.domain_res(term())
   def collect_article_ifneed(article, %User{} = user) do
     findby_args = collection_findby_args(article, user.id)
     already_collected = ORM.find_by(ArticleCollect, findby_args)
@@ -72,6 +76,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCollect do
     end
   end
 
+  @spec undo_collect_article(term(), User.t()) :: T.domain_res(term())
   def undo_collect_article(article, %User{} = user) do
     {:ok, info} = match(article)
 
@@ -99,6 +104,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCollect do
     end)
   end
 
+  @spec undo_collect_article_ifneed(term(), User.t()) :: T.domain_res(term())
   def undo_collect_article_ifneed(
         %{author: %Ecto.Association.NotLoaded{}} = article,
         %User{} = user
@@ -119,12 +125,14 @@ defmodule GroupherServer.CMS.Delegate.ArticleCollect do
     end
   end
 
+  @spec set_collect_folder(ArticleCollect.t(), term()) :: T.domain_res(term())
   def set_collect_folder(%ArticleCollect{} = collect, folder) do
     collect_folders = (collect.collect_folders ++ [folder]) |> Enum.uniq()
 
     ORM.update_embed(collect, :collect_folders, collect_folders)
   end
 
+  @spec undo_set_collect_folder(ArticleCollect.t(), term()) :: T.domain_res(term())
   def undo_set_collect_folder(%ArticleCollect{} = collect, folder) do
     collect_folders = Enum.reject(collect.collect_folders, &(&1.id == folder.id))
 

--- a/backend/main/lib/groupher_server/cms/delegates/article_community.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/article_community.ex
@@ -10,6 +10,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCommunity do
   import GroupherServer.CMS.Helper.Matcher
 
   alias Helper.ORM
+  alias Helper.Types, as: T
 
   alias GroupherServer.{CMS, Repo}
   alias CMS.Model.{Embeds, Community, PinnedArticle}
@@ -19,6 +20,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCommunity do
 
   @max_pinned_article_count_per_thread Community.max_pinned_article_count_per_thread()
 
+  @spec pin_article(Community.t(), term()) :: T.domain_res(term())
   def pin_article(%Community{} = community, article) do
     with {:ok, thread} <- thread_of(article),
          args <- pack_pin_args(community, thread, article.id),
@@ -28,6 +30,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCommunity do
     end
   end
 
+  @spec undo_pin_article(Community.t(), term()) :: T.domain_res(term())
   def undo_pin_article(%Community{} = community, article) do
     with {:ok, thread} <- thread_of(article),
          args <- pack_pin_args(community, thread, article.id),
@@ -55,6 +58,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCommunity do
   @doc """
   mirror article to other community
   """
+  @spec mirror_article(Community.t(), term(), [T.id()]) :: T.domain_res(term())
   def mirror_article(%Community{} = target_community, article, article_tag_ids \\ []) do
     article = Repo.preload(article, :communities)
 
@@ -79,6 +83,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCommunity do
   @doc """
   unmirror article to a community
   """
+  @spec unmirror_article(Community.t(), term()) :: T.domain_res(term())
   def unmirror_article(%Community{} = target_community, article) do
     article = Repo.preload(article, [:communities, :community, :article_tags])
 
@@ -103,6 +108,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCommunity do
   @doc """
   move article original community to other community
   """
+  @spec move_article(Community.t(), term(), [T.id()]) :: T.domain_res(term())
   def move_article(%Community{} = target_community, article, article_tag_ids \\ []) do
     article = Repo.preload(article, [:communities, :community, :article_tags])
 
@@ -134,6 +140,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCommunity do
   @doc """
   shortcut for mirror article to home page
   """
+  @spec mirror_to_home(Community.t(), term(), [T.id()]) :: T.domain_res(term())
   def mirror_to_home(%Community{} = home_community, article, article_tag_ids \\ []) do
     article = Repo.preload(article, [:communities, :article_tags])
 
@@ -155,6 +162,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCommunity do
     end
   end
 
+  @spec mirror_to_home2(atom(), T.id(), [T.id()]) :: T.domain_res(term())
   def mirror_to_home2(thread, article_id, article_tag_ids \\ []) do
     preload = [:communities, :article_tags]
 
@@ -179,6 +187,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCommunity do
   @doc """
   shortcut for move article to blackhole
   """
+  @spec move_to_blackhole(Community.t(), term(), [T.id()]) :: T.domain_res(term())
   def move_to_blackhole(%Community{} = blackhole, article, article_tag_ids \\ []) do
     article = Repo.preload(article, [:communities, :community, :article_tags])
 

--- a/backend/main/lib/groupher_server/cms/delegates/article_crud.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/article_crud.ex
@@ -19,11 +19,12 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
       thread_of: 1
     ]
 
-  import Helper.ErrorCode
   import ShortMaps
+  import Helper.ErrorCode
 
   alias GroupherServer.FrontDesk
   alias Helper.{Later, ORM, QueryBuilder, Converter, Constant, Transaction}
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Email, Repo, Statistics}
 
   alias Accounts.Model.User
@@ -58,6 +59,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   read articles for un-logged user
   """
+  @spec read_article(String.t(), atom(), T.id()) :: T.domain_res(term())
   def read_article(community_slug, thread, inner_id) when thread in @article_threads do
     with {:ok, article} <- if_article_legal(community_slug, thread, inner_id) do
       do_read_article(article, community_slug, thread)
@@ -126,6 +128,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   get paged articles
   """
+  @spec paged_articles(atom(), map()) :: T.domain_res(term())
   def paged_articles(thread, filter) do
     %{page: page, size: size} = filter
     flags = %{mark_delete: false, pending: :legal}
@@ -142,6 +145,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
     end
   end
 
+  @spec paged_articles(atom(), map(), User.t()) :: T.domain_res(term())
   def paged_articles(thread, filter, %User{} = user) do
     with {:ok, stateless_paged_articles} <- paged_articles(thread, filter) do
       stateless_paged_articles
@@ -154,6 +158,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   get grouped kanban posts for a community, only for first load of kanban page
   """
+  @spec grouped_kanban_posts(Community.t()) :: T.domain_res(term())
   def grouped_kanban_posts(%Community{} = community) do
     filter = %{page: 1, size: 20}
 
@@ -172,6 +177,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
     end
   end
 
+  @spec paged_kanban_posts(Community.t(), map()) :: T.domain_res(term())
   def paged_kanban_posts(%Community{} = community, %{state: state} = filter)
       when is_binary(state) do
     state_key = state |> String.downcase() |> String.to_atom()
@@ -199,6 +205,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   end
 
   @doc "paged published articles for accounts"
+  @spec paged_published_articles(atom(), map(), T.id()) :: T.domain_res(term())
   def paged_published_articles(thread, filter, user_id) do
     %{page: page, size: size} = filter
 
@@ -217,6 +224,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   end
 
   # get audit failed articles
+  @spec paged_audit_failed_articles(atom(), map()) :: T.domain_res(term())
   def paged_audit_failed_articles(thread, filter) do
     %{page: page, size: size} = filter
     flags = %{mark_delete: false, pending: :audit_failed}
@@ -229,6 +237,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
     end
   end
 
+  @spec set_post_cat(Post.t(), term()) :: T.domain_res(term())
   def set_post_cat(%Post{} = post, cat) do
     with {:ok, updated} <- ORM.update(post, %{cat: cat}) do
       CommentCRUD.batch_update_question_flag(post, cat == @article_cat.question)
@@ -237,6 +246,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
     end
   end
 
+  @spec set_post_state(Post.t(), term()) :: T.domain_res(term())
   def set_post_state(%Post{} = post, state) do
     with {:ok, updated} <- ORM.update(post, %{state: state}) do
       updated |> covert_cat_state_ifneed |> done
@@ -245,8 +255,9 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
 
   @doc """
   archive articles based on thread
-  called every day by scheuler job
+  called every day by scheduler job
   """
+  @spec archive_articles(atom()) :: T.domain_res(term())
   def archive_articles(thread) do
     with {:ok, info} <- match(thread) do
       now = Timex.now()
@@ -261,6 +272,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   end
 
   # 调用审核接口失败，等待队列定时处理
+  @spec set_article_audit_failed(term(), term()) :: T.domain_res(term())
   def set_article_audit_failed(article, _audit_state) do
     ORM.update(article, %{pending: @audit_failed})
   end
@@ -268,6 +280,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   pending an article due to forbid words or spam talk
   """
+  @spec set_article_illegal(atom(), T.id(), map()) :: T.domain_res(term())
   def set_article_illegal(thread, id, audit_state) do
     with {:ok, info} <- match(thread),
          {:ok, article} <- ORM.find(info.model, id) do
@@ -275,6 +288,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
     end
   end
 
+  @spec set_article_illegal(term(), map()) :: T.domain_res(term())
   def set_article_illegal(article, audit_state) do
     # 1. set pending state
     # 2. set article meta
@@ -301,6 +315,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
     |> result()
   end
 
+  @spec unset_article_illegal(atom(), T.id(), map()) :: T.domain_res(term())
   def unset_article_illegal(thread, id, audit_state) do
     with {:ok, info} <- match(thread),
          {:ok, article} <- ORM.find(info.model, id) do
@@ -308,6 +323,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
     end
   end
 
+  @spec unset_article_illegal(term(), map()) :: T.domain_res(term())
   def unset_article_illegal(article, audit_state) do
     Multi.new()
     |> Multi.run(:update_pending_state, fn _, _ ->
@@ -378,6 +394,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   #   end
   # end
 
+  @spec create_article(Community.t(), atom(), map(), User.t()) :: T.domain_res(term())
   def create_article(%Community{} = community, thread, attrs, %User{} = user) do
     attrs = atom_values_to_upcase(attrs)
 
@@ -455,6 +472,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   update a article(post/job ...)
   """
+  @spec update_article(map(), map()) :: T.domain_res(term())
   def update_article(%{is_archived: true}, _attrs),
     do: raise_error(:archived, "article is archived, can not be edit or delete")
 
@@ -491,6 +509,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   update active at timestamp of an article
   """
+  @spec update_active_timestamp(atom(), term()) :: T.domain_res(term())
   def update_active_timestamp(thread, article) do
     # @article_active_period
     # 1. 超过时限不更新
@@ -504,6 +523,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   sink article
   """
+  @spec sink_article(term()) :: T.domain_res(term())
   def sink_article(article) do
     %{inserted_at: inserted_at} = article
 
@@ -519,6 +539,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   undo sink article
   """
+  @spec undo_sink_article(term()) :: T.domain_res(term())
   def undo_sink_article(article) do
     thread = thread_of(article)
 
@@ -543,6 +564,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   mark delete false for an article
   """
+  @spec mark_delete_article(term()) :: T.domain_res(term())
   def mark_delete_article(article) do
     {:ok, thread} = thread_of(article)
 
@@ -568,6 +590,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   undo mark delete false for an article
   """
+  @spec undo_mark_delete_article(term()) :: T.domain_res(term())
   def undo_mark_delete_article(article) do
     {:ok, thread} = thread_of(article)
 
@@ -587,6 +610,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   make sure the given ids are deleted
   """
+  @spec batch_mark_delete_articles(String.t(), atom(), [T.id()]) :: T.domain_res(term())
   def batch_mark_delete_articles(community, thread, inner_id_list) do
     do_batch_mark_delete_articles(community, thread, inner_id_list, true)
   end
@@ -594,6 +618,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   make sure the given ids are deleted
   """
+  @spec batch_undo_mark_delete_articles(String.t(), atom(), [T.id()]) :: T.domain_res(term())
   def batch_undo_mark_delete_articles(community, thread, inner_id_list) do
     do_batch_mark_delete_articles(community, thread, inner_id_list, false)
   end
@@ -628,6 +653,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   @doc """
   remove article forever
   """
+  @spec delete_article(term(), String.t()) :: T.domain_res(term())
   def delete_article(article, _reason \\ @remove_article_hint) do
     article = Repo.preload(article, [:communities, [author: :user]])
     {:ok, thread} = thread_of(article)
@@ -876,23 +902,23 @@ defmodule GroupherServer.CMS.Delegate.ArticleCRUD do
   defp result({:ok, %{update_article_meta: result}}), do: {:ok, result}
 
   defp result({:error, :create_article, _result, _steps}) do
-    {:error, [message: "create article", code: ecode(:create_fails)]}
+    {:error, {:create_fails, "create article"}}
   end
 
   defp result({:error, :update_article, _result, _steps}) do
-    {:error, [message: "update article", code: ecode(:update_fails)]}
+    {:error, {:update_fails, "update article"}}
   end
 
   defp result({:error, :mirror_article, _result, _steps}) do
-    {:error, [message: "set community", code: ecode(:create_fails)]}
+    {:error, {:create_fails, "set community"}}
   end
 
   defp result({:error, :set_community_flag, _result, _steps}) do
-    {:error, [message: "set community flag", code: ecode(:create_fails)]}
+    {:error, {:create_fails, "set community flag"}}
   end
 
   defp result({:error, :log_action, _result, _steps}) do
-    {:error, [message: "log action", code: ecode(:create_fails)]}
+    {:error, {:create_fails, "log action"}}
   end
 
   defp result({:error, _, result, _steps}), do: {:error, result}

--- a/backend/main/lib/groupher_server/cms/delegates/article_emotion.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/article_emotion.ex
@@ -9,6 +9,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleEmotion do
   import GroupherServer.CMS.Delegate.Helper, only: [update_emotions_field: 4]
 
   alias Helper.{Transaction, ORM}
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias Accounts.Model.User
@@ -17,9 +18,10 @@ defmodule GroupherServer.CMS.Delegate.ArticleEmotion do
   alias Ecto.Multi
 
   @type t_user_list :: [%{login: String.t()}]
-  @type t_mention_status :: %{user_list: t_user_list, user_count: Integer.t()}
+  @type t_mention_status :: %{user_list: t_user_list, user_count: integer()}
 
   @doc "make emotion to a comment"
+  @spec emotion_to_article(term(), atom(), User.t()) :: T.domain_res(term())
   def emotion_to_article(article, emotion, %User{} = user) do
     {:ok, info} = match(article)
 
@@ -48,6 +50,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleEmotion do
     end)
   end
 
+  @spec undo_emotion_to_article(term(), atom(), User.t()) :: T.domain_res(term())
   def undo_emotion_to_article(article, emotion, %User{} = user) do
     {:ok, info} = match(article)
 
@@ -80,7 +83,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleEmotion do
     end)
   end
 
-  # @spec query_emotion_status(Comment.t(), Atom.t()) :: {:ok, t_mention_status}
+  # @spec query_emotion_status(Comment.t(), atom()) :: {:ok, t_mention_status}
   defp query_emotion_status(article, emotion) do
     with {:ok, thread} <- thread_of(article),
          {:ok, info} <- match(thread) do

--- a/backend/main/lib/groupher_server/cms/delegates/article_tag.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/article_tag.ex
@@ -13,6 +13,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleTag do
 
   alias Helper.ORM
   alias Helper.QueryBuilder
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, Repo}
 
   alias Accounts.Model.User
@@ -26,6 +27,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleTag do
   @doc """
   create a article tag
   """
+  @spec create_article_tag(Community.t(), atom(), map(), User.t()) :: T.domain_res(term())
   def create_article_tag(%Community{} = community, thread, attrs, %User{
         id: user_id
       }) do
@@ -57,6 +59,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleTag do
   @doc """
   update an article tag
   """
+  @spec update_article_tag(T.id(), map()) :: T.domain_res(term())
   def update_article_tag(id, attrs) do
     with {:ok, article_tag} <- ORM.find(ArticleTag, id) do
       attrs = attrs |> atom_values_to_upcase
@@ -67,6 +70,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleTag do
   @doc """
   delete an article tag
   """
+  @spec delete_article_tag(T.id()) :: T.domain_res(term())
   def delete_article_tag(id) do
     with {:ok, article_tag} <- ORM.find(ArticleTag, id),
          {:ok, community} <- ORM.find(Community, article_tag.community_id) do
@@ -167,6 +171,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleTag do
   @doc """
   set article a tag
   """
+  @spec set_article_tag(term(), T.id()) :: T.domain_res(term())
   def set_article_tag(article, tag_id) do
     with {:ok, article_tag} <- ORM.find(ArticleTag, tag_id) do
       do_update_article_tags_assoc(article, article_tag, :add)
@@ -176,6 +181,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleTag do
   @doc """
   unset article a tag
   """
+  @spec unset_article_tag(term(), T.id()) :: T.domain_res(term())
   def unset_article_tag(article, tag_id) do
     with {:ok, article_tag} <- ORM.find(ArticleTag, tag_id) do
       do_update_article_tags_assoc(article, article_tag, :remove)
@@ -200,6 +206,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleTag do
   @doc """
   get all paged tags
   """
+  @spec paged_article_tags(map()) :: T.domain_res(term())
   def paged_article_tags(%{page: page, size: size} = filter) do
     ArticleTag
     |> QueryBuilder.filter_pack(replace_community_ifneed(filter))
@@ -218,6 +225,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleTag do
   @doc """
   reindex tags in spec group
   """
+  @spec reindex_tags_in_group(Community.t(), atom(), atom(), list()) :: T.domain_res(term())
   def reindex_tags_in_group(community, thread, group, indexed_tags) do
     with {:ok, group_tags} <- _find_group_tags(community, thread, group) do
       group_tags

--- a/backend/main/lib/groupher_server/cms/delegates/article_upvote.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/article_upvote.ex
@@ -5,7 +5,6 @@ defmodule GroupherServer.CMS.Delegate.ArticleUpvote do
   import GroupherServer.CMS.Helper.Matcher
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1, thread_of: 2]
-  import Helper.ErrorCode
 
   import GroupherServer.CMS.Delegate.Helper,
     only: [
@@ -16,6 +15,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleUpvote do
   # import Helper.ErrorCode
 
   alias Helper.{ORM, Later, Transaction}
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias Accounts.Model.User
@@ -24,9 +24,11 @@ defmodule GroupherServer.CMS.Delegate.ArticleUpvote do
 
   alias Ecto.Multi
 
+  @spec upvoted_users(term(), map()) :: T.domain_res(term())
   def upvoted_users(article, filter), do: load_reaction_users(ArticleUpvote, article, filter)
 
   @doc "upvote to a article-like content"
+  @spec upvote_article(term(), User.t()) :: T.domain_res(term())
   def upvote_article(article, %User{} = user) do
     {:ok, info} = match(article)
 
@@ -57,6 +59,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleUpvote do
   end
 
   @doc "upvote to a article-like content"
+  @spec undo_upvote_article(term(), User.t()) :: T.domain_res(term())
   def undo_upvote_article(article, %User{id: user_id} = from_user) do
     {:ok, info} = match(article)
 
@@ -88,7 +91,7 @@ defmodule GroupherServer.CMS.Delegate.ArticleUpvote do
 
     case ORM.create(ArticleUpvote, args) do
       {:ok, _} -> article |> done
-      _ -> {:error, [message: "viewer already upvoted", code: ecode(:already_upvoted)]}
+      _ -> {:error, {:already_upvoted, "viewer already upvoted"}}
     end
   end
 

--- a/backend/main/lib/groupher_server/cms/delegates/article_upvote.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/article_upvote.ex
@@ -12,8 +12,6 @@ defmodule GroupherServer.CMS.Delegate.ArticleUpvote do
       update_article_reaction_user_list: 4
     ]
 
-  # import Helper.ErrorCode
-
   alias Helper.{ORM, Later, Transaction}
   alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}

--- a/backend/main/lib/groupher_server/cms/delegates/cited_artiment.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/cited_artiment.ex
@@ -32,6 +32,7 @@ defmodule GroupherServer.CMS.Delegate.CitedArtiment do
   @cited_preloads @article_preloads ++ [[comment: :author] ++ @comment_article_preloads]
 
   @doc "get paged citing contents"
+  @spec paged_citing_contents(atom(), T.id(), map()) :: T.domain_res(term())
   def paged_citing_contents(cited_by_type, cited_by_id, %{page: page, size: size} = filter) do
     cited_by_type = to_upcase(cited_by_type)
 
@@ -79,7 +80,7 @@ defmodule GroupherServer.CMS.Delegate.CitedArtiment do
 
     case {0, nil} !== Repo.insert_all(CitedArtiment, clean_cited_artiments) do
       true -> update_artiment_citing_count(cited_artiments)
-      false -> {:error, "insert cited artiment error"}
+      false -> {:error, {:create_fails, "insert cited artiment error"}}
     end
   end
 

--- a/backend/main/lib/groupher_server/cms/delegates/comment_action.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/comment_action.ex
@@ -6,7 +6,6 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
 
   import Helper.Utils,
     only: [
-      done: 1,
       strip_struct: 1,
       get_config: 2,
       article_of: 1,
@@ -44,11 +43,9 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   @pinned_comment_limit Comment.pinned_comment_limit()
 
   @doc "pin a comment"
-  @spec pin_comment(Integer.t()) :: {:ok, Comment.t()}
+  @spec pin_comment(Integer.t()) :: T.domain_result(Comment.t())
   def pin_comment(comment_id) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id),
-         {:ok, full_comment} <- get_full_comment(comment.id),
-         {:ok, info} <- match(full_comment.thread) do
+    with {:ok, {comment, full_comment, info}} <- pin_context(comment_id) do
       Multi.new()
       |> Multi.run(:checked_pined_comments_count, fn _, _ ->
         pined_comments_query =
@@ -57,9 +54,10 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
           )
 
         with {:ok, pined_comments_count} <- ORM.count(pined_comments_query) do
-          case pined_comments_count >= @pinned_comment_limit do
-            true -> {:error, "max #{@pinned_comment_limit} pinned comment for each article"}
-            false -> {:ok, :pass}
+          if pined_comments_count >= @pinned_comment_limit do
+            {:error, {:comment_pin_limit, @pinned_comment_limit}}
+          else
+            {:ok, :pass}
           end
         end
       end)
@@ -76,8 +74,9 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
     end
   end
 
+  @spec undo_pin_comment(Integer.t()) :: T.domain_result(Comment.t())
   def undo_pin_comment(comment_id) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id) do
+    with {:ok, comment} <- CMS.fetch_comment(comment_id) do
       Multi.new()
       |> Multi.run(:update_comment_flag, fn _, _ ->
         ORM.update(comment, %{is_pinned: false})
@@ -277,7 +276,7 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   end
 
   defp update_article_author_upvoted_info(%Comment{} = comment, user_id) do
-    with {:ok, article} = get_full_comment(comment.id) do
+    with {:ok, article} = CMS.fetch_full_comment(comment.id) do
       is_article_author_upvoted = article.author.id == user_id
       meta = comment.meta |> Map.put(:is_article_author_upvoted, is_article_author_upvoted)
       comment |> ORM.update_meta(meta)
@@ -321,33 +320,6 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
     end
   end
 
-  @spec get_full_comment(String.t()) :: {:ok, T.article_info()} | {:error, nil}
-  defp get_full_comment(comment_id) do
-    query = from(c in Comment, where: c.id == ^comment_id, preload: ^@article_threads)
-
-    with {:ok, comment} <- Repo.one(query) |> done(),
-         article_thread <- find_comment_article_thread(comment) do
-      do_extract_article_info(article_thread, Map.get(comment, article_thread))
-    end
-  end
-
-  @spec do_extract_article_info(T.article_thread(), T.article_common()) :: {:ok, T.article_info()}
-  defp do_extract_article_info(thread, article) do
-    with {:ok, article_with_author} <- Repo.preload(article, author: :user) |> done(),
-         article_author <- get_in(article_with_author, [:author, :user]) do
-      #
-      article_info = %{title: article.title, id: article.id}
-
-      author_info = %{
-        id: article_author.id,
-        login: article_author.login,
-        nickname: article_author.nickname
-      }
-
-      {:ok, %{thread: thread, article: article_info, author: author_info}}
-    end
-  end
-
   defp find_comment_article_thread(%Comment{} = comment) do
     @article_threads
     |> Enum.filter(&Map.get(comment, :"#{&1}_id"))
@@ -372,6 +344,14 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
 
       false ->
         {:ok, :pass}
+    end
+  end
+
+  defp pin_context(comment_id) do
+    with {:ok, comment} <- CMS.fetch_comment(comment_id),
+         {:ok, full_comment} <- CMS.fetch_full_comment(comment.id),
+         {:ok, info} <- match(full_comment.thread) do
+      {:ok, {comment, full_comment, info}}
     end
   end
 
@@ -402,6 +382,10 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   defp result({:error, :create_comment_upvote, _result, _steps}) do
     raise_error(:comment_already_upvote, "already upvoted")
   end
+
+  defp result({:error, :update_comment_flag, _result, _steps}), do: {:error, :update_fails}
+  defp result({:error, :add_pined_comment, _result, _steps}), do: {:error, :create_fails}
+  defp result({:error, :remove_pined_comment, _result, _steps}), do: {:error, :delete_fails}
 
   defp result({:error, :add_participator, result, _steps}) do
     {:error, result}

--- a/backend/main/lib/groupher_server/cms/delegates/comment_action.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/comment_action.ex
@@ -43,7 +43,7 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   @pinned_comment_limit Comment.pinned_comment_limit()
 
   @doc "pin a comment"
-  @spec pin_comment(Integer.t()) :: T.domain_result(Comment.t())
+  @spec pin_comment(integer()) :: T.domain_result(Comment.t())
   def pin_comment(comment_id) do
     with {:ok, {comment, full_comment, info}} <- pin_context(comment_id) do
       Multi.new()

--- a/backend/main/lib/groupher_server/cms/delegates/comment_action.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/comment_action.ex
@@ -31,6 +31,7 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   alias Helper.Types, as: T
   alias Helper.{ORM, Later, Transaction}
   alias GroupherServer.{Accounts, CMS, Repo}
+  alias CMS.Delegate.Fetcher
 
   alias Accounts.Model.User
   alias CMS.Model.{Comment, PinnedComment, CommentUpvote, CommentReply}
@@ -44,7 +45,7 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   @pinned_comment_limit Comment.pinned_comment_limit()
 
   @doc "pin a comment"
-  @spec pin_comment(integer()) :: T.domain_result(Comment.t())
+  @spec pin_comment(integer()) :: T.domain_res(Comment.t())
   def pin_comment(comment_id) do
     with {:ok, {comment, full_comment, info}} <- pin_context(comment_id) do
       Multi.new()
@@ -75,7 +76,7 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
     end
   end
 
-  @spec undo_pin_comment(Integer.t()) :: T.domain_result(Comment.t())
+  @spec undo_pin_comment(integer()) :: T.domain_res(Comment.t())
   def undo_pin_comment(comment_id) do
     with {:ok, comment} <- CMS.fetch_comment(comment_id) do
       Multi.new()
@@ -91,24 +92,27 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   end
 
   @doc "fold a comment"
+  @spec fold_comment(T.id() | Comment.t(), User.t()) :: T.domain_res(Comment.t())
   def fold_comment(%Comment{} = comment, %User{} = _user), do: do_fold_comment(comment, true)
 
   def fold_comment(comment_id, %User{} = _user) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id) do
+    with {:ok, comment} <- Fetcher.fetch(Comment, comment_id) do
       do_fold_comment(comment, true)
     end
   end
 
   @doc "unfold a comment"
+  @spec unfold_comment(T.id(), User.t()) :: T.domain_res(Comment.t())
   def unfold_comment(comment_id, %User{} = _user) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id) do
+    with {:ok, comment} <- Fetcher.fetch(Comment, comment_id) do
       do_fold_comment(comment, false)
     end
   end
 
   @doc "reply to existing comment"
+  @spec reply_comment(T.id(), String.t(), User.t()) :: T.domain_res(Comment.t())
   def reply_comment(comment_id, body, %User{} = user) do
-    with {:ok, target_comment} <- ORM.find_by(Comment, %{id: comment_id, is_deleted: false}),
+    with {:ok, target_comment} <- Fetcher.fetch_by(Comment, %{id: comment_id, is_deleted: false}),
          replying_comment <- Repo.preload(target_comment, reply_to: :author),
          {thread, article} <- get_article(replying_comment),
          true <- can_comment?(article, user),
@@ -163,8 +167,9 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   end
 
   @doc "upvote a comment"
+  @spec upvote_comment(T.id(), User.t()) :: T.domain_res(Comment.t())
   def upvote_comment(comment_id, %User{id: user_id} = from_user) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id),
+    with {:ok, comment} <- Fetcher.fetch(Comment, comment_id),
          false <- comment.is_deleted do
       Multi.new()
       |> Multi.run(:create_comment_upvote, fn _, _ ->
@@ -202,8 +207,9 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   end
 
   @doc "upvote a comment"
+  @spec undo_upvote_comment(T.id(), User.t()) :: T.domain_res(Comment.t())
   def undo_upvote_comment(comment_id, %User{id: user_id} = from_user) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id),
+    with {:ok, comment} <- Fetcher.fetch(Comment, comment_id),
          false <- comment.is_deleted do
       Multi.new()
       |> Multi.run(:delete_comment_upvote, fn _, _ ->
@@ -243,6 +249,7 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   end
 
   @doc "lock comment of a article"
+  @spec lock_article_comments(term()) :: T.domain_res(term())
   def lock_article_comments(article) do
     Transaction.locking(article, fn article ->
       ORM.update_meta(article, %{is_comment_locked: true})
@@ -250,6 +257,7 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
   end
 
   @doc "undo lock comment of a article"
+  @spec undo_lock_article_comments(term()) :: T.domain_res(term())
   def undo_lock_article_comments(article) do
     Transaction.locking(article, fn article ->
       ORM.update_meta(article, %{is_comment_locked: false})
@@ -316,7 +324,7 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
     with article_thread <- find_comment_article_thread(comment),
          {:ok, info} <- match(article_thread),
          article_id <- Map.get(comment, info.foreign_key),
-         {:ok, article} <- ORM.find(info.model, article_id, preload: [author: :user]) do
+         {:ok, article} <- Fetcher.fetch(info.model, article_id, preload: [author: :user]) do
       {article_thread, article}
     end
   end

--- a/backend/main/lib/groupher_server/cms/delegates/comment_action.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/comment_action.ex
@@ -6,6 +6,7 @@ defmodule GroupherServer.CMS.Delegate.CommentAction do
 
   import Helper.Utils,
     only: [
+      done: 1,
       strip_struct: 1,
       get_config: 2,
       article_of: 1,

--- a/backend/main/lib/groupher_server/cms/delegates/comment_crud.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/comment_crud.ex
@@ -16,6 +16,7 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   alias GroupherServer.FrontDesk
   alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
+  alias CMS.Delegate.Fetcher
 
   alias Accounts.Model.User
   alias CMS.Model.{Post, Comment, PinnedComment, Embeds, Community}
@@ -41,12 +42,13 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   @article_cat Constant.CMS.article_cat()
   @article_state Constant.CMS.article_state()
 
+  @spec comments_state(T.article_thread(), T.id()) :: T.domain_res(term())
   def comments_state(thread, article_id) do
     filter = %{page: 1, size: 20}
 
     with {:ok, thread_query} <- match(thread, :query, article_id),
          {:ok, info} <- match(thread),
-         {:ok, article} <- ORM.find(info.model, article_id),
+         {:ok, article} <- Fetcher.fetch(info.model, article_id),
          {:ok, paged_participants} <- do_paged_comments_participants(thread_query, filter) do
       %{
         total_count: article.comments_count,
@@ -58,6 +60,7 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
     end
   end
 
+  @spec comments_state(T.article_thread(), T.id(), User.t()) :: T.domain_res(term())
   def comments_state(thread, article_id, user) do
     with {:ok, thread_query} <- match(thread, :query, article_id),
          {:ok, state} <- comments_state(thread, article_id) do
@@ -82,10 +85,12 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   @doc """
   get spec comment by id
   """
-  def one_comment(id), do: ORM.find(Comment, id)
+  @spec one_comment(T.id()) :: T.domain_res(Comment.t())
+  def one_comment(id), do: Fetcher.fetch(Comment, id)
 
+  @spec one_comment(T.id(), User.t()) :: T.domain_res(Comment.t())
   def one_comment(id, %User{} = user) do
-    with {:ok, comment} <- ORM.find(Comment, id) do
+    with {:ok, comment} <- Fetcher.fetch(Comment, id) do
       %{entries: [comment]}
       |> mark_viewer_emotion_states(user)
       |> mark_viewer_has_upvoted(user)
@@ -98,6 +103,8 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   @doc """
   [timeline-mode] list paged article comments
   """
+  @spec paged_comments(T.article_thread(), T.id(), map(), atom(), User.t() | nil) ::
+          T.domain_res(term())
   def paged_comments(thread, article_id, filters, mode, user \\ nil)
 
   def paged_comments(thread, article_id, filters, :timeline, user) do
@@ -115,6 +122,7 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
     do_paged_comment(thread, article_id, filters, where_query, user)
   end
 
+  @spec paged_published_comments(User.t(), map()) :: T.domain_res(term())
   def paged_published_comments(%User{id: user_id}, filter) do
     %{page: page, size: size} = filter
 
@@ -127,6 +135,7 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
     |> done()
   end
 
+  @spec paged_published_comments(User.t(), T.article_thread(), map()) :: T.domain_res(term())
   def paged_published_comments(%User{id: user_id}, thread, filter) do
     %{page: page, size: size} = filter
 
@@ -146,17 +155,21 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
     |> done()
   end
 
+  @spec paged_folded_comments(T.article_thread(), T.id(), map()) :: T.domain_res(term())
   def paged_folded_comments(thread, article_id, filters) do
     where_query = dynamic([c], c.is_folded and not c.is_pinned)
     do_paged_comment(thread, article_id, filters, where_query, nil)
   end
 
+  @spec paged_folded_comments(T.article_thread(), T.id(), map(), User.t()) ::
+          T.domain_res(term())
   def paged_folded_comments(thread, article_id, filters, user) do
     where_query = dynamic([c], c.is_folded and not c.is_pinned)
     do_paged_comment(thread, article_id, filters, where_query, user)
   end
 
   # get audit failed articles
+  @spec paged_audit_failed_comments(map()) :: T.domain_res(term())
   def paged_audit_failed_comments(filter) do
     %{page: page, size: size} = filter
     flags = %{pending: :audit_failed}
@@ -170,18 +183,19 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   @doc """
   list paged comment replies
   """
+  @spec paged_comment_replies(T.id(), map(), User.t() | nil) :: T.domain_res(term())
   def paged_comment_replies(comment_id, filters, user \\ nil)
 
   def paged_comment_replies(comment_id, filters, user) do
     do_paged_comment_replies(comment_id, filters, user)
   end
 
-  @spec paged_comments_participants(T.article_thread(), Integer.t(), T.paged_filter()) ::
-          {:ok, T.paged_users()}
+  @spec paged_comments_participants(T.article_thread(), integer(), T.paged_filter()) ::
+          T.domain_res(T.paged_users())
   def paged_comments_participants(thread, article_id, filters) do
     with {:ok, thread_query} <- match(thread, :query, article_id),
          {:ok, info} <- match(thread),
-         {:ok, article} <- ORM.find(info.model, article_id),
+         {:ok, article} <- Fetcher.fetch(info.model, article_id),
          {:ok, paged_data} <- do_paged_comments_participants(thread_query, filters) do
       # check participants_count if history data do not match
       case article.comments_participants_count !== paged_data.total_count do
@@ -197,10 +211,12 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   end
 
   # 调用审核接口失败，等待队列定时处理
+  @spec set_comment_audit_failed(Comment.t(), term()) :: T.domain_res(term())
   def set_comment_audit_failed(%Comment{} = comment, _audit_state) do
     ORM.update(comment, %{pending: @audit_failed})
   end
 
+  @spec set_comment_illegal(Comment.t(), map()) :: T.domain_res(term())
   def set_comment_illegal(%Comment{} = comment, audit_state) do
     # 1. set pending
     # 2. update comment-meta
@@ -227,12 +243,14 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
     |> result()
   end
 
+  @spec set_comment_illegal(T.id(), map()) :: T.domain_res(term())
   def set_comment_illegal(comment_id, audit_state) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id) do
+    with {:ok, comment} <- Fetcher.fetch(Comment, comment_id) do
       set_comment_illegal(comment, audit_state)
     end
   end
 
+  @spec unset_comment_illegal(Comment.t(), map()) :: T.domain_res(term())
   def unset_comment_illegal(%Comment{} = comment, audit_state) do
     Multi.new()
     |> Multi.run(:update_pending_state, fn _, _ ->
@@ -259,8 +277,9 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
     |> result()
   end
 
+  @spec unset_comment_illegal(T.id(), map()) :: T.domain_res(term())
   def unset_comment_illegal(comment_id, audit_state) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id) do
+    with {:ok, comment} <- Fetcher.fetch(Comment, comment_id) do
       unset_comment_illegal(comment, audit_state)
     end
   end
@@ -282,14 +301,18 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
     |> done()
   end
 
+  @spec update_user_in_comments_participants(User.t()) :: T.domain_res(term())
   def update_user_in_comments_participants(%User{login: login}) do
     from(a in CMS.Model.Post,
       cross_join: cp in fragment("jsonb_array_elements(?)", a.comments_participants),
       where: fragment("?->>'login' = ?", cp, ^login)
     )
     |> Repo.all()
+    |> done()
   end
 
+  @spec create_comment(Community.t(), T.article_thread(), T.id(), String.t(), User.t()) ::
+          T.domain_res(term())
   def create_comment(%Community{slug: community_slug}, thread, article_id, body, %User{} = user) do
     with {:ok, info} <- match(thread),
          {:ok, article} <-
@@ -338,6 +361,7 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
     not article.meta.is_comment_locked
   end
 
+  @spec update_comment(map(), String.t()) :: T.domain_res(term())
   def update_comment(%{is_archived: true}, _body),
     do: raise_error(:archived, "comment is archived, can not be edit or delete")
 
@@ -346,7 +370,7 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   """
   # 如果是 solution, 那么要更新对应的 post 的 solution_digest
   def update_comment(%Comment{is_solution: true} = comment, body) do
-    with {:ok, post} <- ORM.find(Post, comment.post_id),
+    with {:ok, post} <- Fetcher.fetch(Post, comment.post_id),
          {:ok, parsed} <- Converter.Article.parse_body(body),
          {:ok, digest} <- Converter.Article.parse_digest(parsed.body_map) do
       Multi.new()
@@ -388,9 +412,10 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   @doc """
   mark a comment as question post's best solution
   """
+  @spec mark_comment_solution(T.id(), User.t()) :: T.domain_res(term())
   def mark_comment_solution(comment_id, user) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id),
-         {:ok, post} <- ORM.find(Post, comment.post_id, preload: [author: :user]) do
+    with {:ok, comment} <- Fetcher.fetch(Comment, comment_id),
+         {:ok, post} <- Fetcher.fetch(Post, comment.post_id, preload: [author: :user]) do
       # 确保只有一个最佳答案
       batch_update_solution_flag(post, false)
       CMS.pin_comment(comment.id)
@@ -401,9 +426,10 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   @doc """
   undo mark a comment as question post's best solution
   """
+  @spec undo_mark_comment_solution(T.id(), User.t()) :: T.domain_res(term())
   def undo_mark_comment_solution(comment_id, user) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id),
-         {:ok, post} <- ORM.find(Post, comment.post_id, preload: [author: :user]) do
+    with {:ok, comment} <- Fetcher.fetch(Comment, comment_id),
+         {:ok, post} <- Fetcher.fetch(Post, comment.post_id, preload: [author: :user]) do
       CMS.set_post_state(post, @article_state.default)
 
       do_mark_comment_solution(post, comment, user, false)
@@ -446,6 +472,7 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
     {:ok, :pass}
   end
 
+  @spec delete_comment(map()) :: T.domain_res(term())
   def delete_comment(%{is_archived: true}),
     do: raise_error(:archived, "article is archived, can not be edit or delete")
 
@@ -513,6 +540,7 @@ defmodule GroupherServer.CMS.Delegate.CommentCRUD do
   archive comments
   called every day by scheuler job
   """
+  @spec archive_comments() :: T.domain_res(term())
   def archive_comments() do
     now = Timex.now() |> DateTime.truncate(:second)
     threshold = @archive_threshold[:default]

--- a/backend/main/lib/groupher_server/cms/delegates/comment_emotion.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/comment_emotion.ex
@@ -14,6 +14,7 @@ defmodule GroupherServer.CMS.Delegate.CommentEmotion do
     ]
 
   alias Helper.{ORM, Later}
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias CMS.Delegate.Hooks
@@ -23,9 +24,10 @@ defmodule GroupherServer.CMS.Delegate.CommentEmotion do
   alias Ecto.Multi
 
   @type t_user_list :: [%{login: String.t()}]
-  @type t_mention_status :: %{user_list: t_user_list, user_count: Integer.t()}
+  @type t_mention_status :: %{user_list: t_user_list, user_count: integer()}
 
   @doc "make emotion to a comment"
+  @spec emotion_to_comment(T.id(), atom(), User.t()) :: T.domain_res(term())
   def emotion_to_comment(comment_id, emotion, %User{} = user) do
     with {:ok, comment} <- ORM.find(Comment, comment_id, preload: :author) do
       Multi.new()
@@ -62,6 +64,7 @@ defmodule GroupherServer.CMS.Delegate.CommentEmotion do
     end
   end
 
+  @spec undo_emotion_to_comment(T.id(), atom(), User.t()) :: T.domain_res(term())
   def undo_emotion_to_comment(comment_id, emotion, %User{} = user) do
     with {:ok, comment} <- ORM.find(Comment, comment_id, preload: :author) do
       Multi.new()
@@ -94,7 +97,7 @@ defmodule GroupherServer.CMS.Delegate.CommentEmotion do
     end
   end
 
-  @spec query_emotion_states(Comment.t(), Atom.t()) :: {:ok, t_mention_status}
+  @spec query_emotion_states(Comment.t(), atom()) :: {:ok, t_mention_status}
   defp query_emotion_states(comment, emotion) do
     # 每次被 emotion 动作触发后重新查询，主要原因
     # 1.并发下保证数据准确，类似 views 阅读数的统计

--- a/backend/main/lib/groupher_server/cms/delegates/community_crud.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/community_crud.ex
@@ -11,6 +11,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
   import ShortMaps
 
   alias Helper.{ORM, QueryBuilder, OSS, Constant, Transaction}
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias Accounts.Model.User
@@ -40,6 +41,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
 
   @default_read_opt [inc_views: true]
 
+  @spec read_community(String.t(), keyword()) :: T.domain_res(term())
   def read_community(slug, opt \\ @default_read_opt)
 
   def read_community(slug, %User{} = user) do
@@ -52,6 +54,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     read_community(slug, opt) |> viewer_has_states(user)
   end
 
+  @spec paged_communities(map(), User.t()) :: T.domain_res(term())
   def paged_communities(filter, %User{meta: meta}) do
     with {:ok, paged_communities} <- paged_communities(filter) do
       %{entries: entries} = paged_communities
@@ -66,6 +69,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     end
   end
 
+  @spec paged_communities(map()) :: T.domain_res(term())
   def paged_communities(filter) do
     filter = filter |> Enum.reject(fn {_k, v} -> is_nil(v) end) |> Enum.into(%{})
     Community |> ORM.find_all(filter)
@@ -74,6 +78,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
   @doc """
   create a community
   """
+  @spec create_community(map(), User.t()) :: T.domain_res(term())
   def create_community(args, %User{} = user) do
     with {:ok, community} <- do_create_community(args, user),
          {:ok, _} <- init_community_root(community, user),
@@ -86,6 +91,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     end
   end
 
+  @spec delete_community(String.t() | Community.t()) :: T.domain_res(term())
   def delete_community(community) do
     with {:ok, community} <- ORM.find_by(Community, slug: community) do
       community |> ORM.delete()
@@ -126,6 +132,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
   @doc """
   update community
   """
+  @spec update_community(Community.t(), map()) :: T.domain_res(term())
   def update_community(%Community{} = community, args) do
     with {:ok, community} <- ORM.fill_meta(community) do
       ORM.update(community, args)
@@ -135,6 +142,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
   @doc """
   update dashboard settings of a community
   """
+  @spec update_dashboard(Community.t(), atom(), map()) :: T.domain_res(term())
   def update_dashboard(%Community{} = community, :base_info, args) do
     main_fields =
       Map.take(args, [:title, :locale, :desc, :logo, :favicon, :slug, :homepage])
@@ -182,6 +190,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
   @doc """
   check if community exist
   """
+  @spec community_exist?(String.t()) :: T.domain_res(term())
   def community_exist?(slug) do
     case ORM.find_by(Community, slug: slug) do
       {:ok, _} -> {:ok, %{exist: true}}
@@ -189,6 +198,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     end
   end
 
+  @spec has_pending_community_apply?(User.t()) :: T.domain_res(term())
   def has_pending_community_apply?(%User{} = user) do
     with {:ok, paged_applies} <- paged_community_applies(user, %{page: 1, size: 1}) do
       case paged_applies.total_count > 0 do
@@ -206,6 +216,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     |> done
   end
 
+  @spec apply_community(map(), User.t()) :: T.domain_res(term())
   def apply_community(args, %User{} = user) do
     with {:ok, community} <-
            create_community(Map.merge(args, %{pending: @community_applying}), user) do
@@ -217,6 +228,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     end
   end
 
+  @spec approve_community_apply(String.t()) :: T.domain_res(term())
   def approve_community_apply(slug) do
     # TODO: create community with thread, category and tags
     with {:ok, community} <- ORM.find_by(Community, slug: slug) do
@@ -224,6 +236,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     end
   end
 
+  @spec deny_community_apply(T.id()) :: T.domain_res(term())
   def deny_community_apply(id) do
     with {:ok, community} <- ORM.find(Community, id) do
       case community.pending == @community_applying do
@@ -236,6 +249,8 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
   @doc """
   update article_tags_count / thread / article_count / subscribers_count of a community
   """
+  @spec update_community_count_field(Community.t(), User.t(), atom(), atom()) ::
+          T.domain_res(term())
   def update_community_count_field(
         %Community{} = community,
         %User{} = user,
@@ -281,6 +296,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     ORM.update_meta(community, meta)
   end
 
+  @spec update_community_count_field(Community.t(), atom()) :: T.domain_res(term())
   def update_community_count_field(%Community{} = community, :article_tags_count) do
     {:ok, article_tags_count} =
       from(t in ArticleTag, where: t.community_id == ^community.id) |> ORM.count()
@@ -290,10 +306,11 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     |> Repo.update()
   end
 
+  @spec update_community_count_field([Community.t()], atom()) :: T.domain_res(term())
   def update_community_count_field(communities, thread) when is_list(communities) do
     case Enum.all?(Enum.uniq(communities), &({:ok, _} = update_community_count_field(&1, thread))) do
       true -> {:ok, :pass}
-      false -> {:error, "update_community_count_field"}
+      false -> {:error, {:custom, "update_community_count_field"}}
     end
   end
 
@@ -322,6 +339,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
   @doc """
   return paged community subscribers
   """
+  @spec community_members(atom(), Community.t(), map()) :: T.domain_res(term())
   def community_members(:moderators, %Community{id: id} = community, filters)
       when not is_nil(id) do
     load_community_members(community, CommunityModerator, filters)
@@ -342,6 +360,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     load_community_members(community, CommunitySubscriber, filters)
   end
 
+  @spec community_members(atom(), Community.t(), map(), User.t()) :: T.domain_res(term())
   def community_members(:subscribers, %Community{id: id} = community, filters, %User{} = user)
       when not is_nil(id) do
     with {:ok, members} <- community_members(:subscribers, community, filters) do
@@ -356,6 +375,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     end
   end
 
+  @spec create_category(map(), User.t()) :: T.domain_res(term())
   def create_category(attrs, %User{id: user_id}) do
     with {:ok, author} <- ensure_author_exists(%User{id: user_id}) do
       attrs = attrs |> Map.merge(%{author_id: author.id})
@@ -363,6 +383,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     end
   end
 
+  @spec update_category(map()) :: T.domain_res(term())
   def update_category(~m(%Category id title)a) do
     with {:ok, category} <- ORM.find(Category, id) do
       category |> ORM.update(~m(title)a)
@@ -372,6 +393,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
   @doc """
   TODO: create_thread
   """
+  @spec create_thread(map()) :: T.domain_res(term())
   def create_thread(attrs) do
     slug = to_string(attrs.slug)
     title = attrs.title
@@ -381,6 +403,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
   end
 
   @doc "count items in community"
+  @spec count(Community.t(), atom()) :: T.domain_res(term())
   def count(community, type)
 
   def count(%Community{id: id}, :threads) do
@@ -400,7 +423,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityCRUD do
     end
   end
 
-  def count(_community, _type), do: {:error, "invalid count type"}
+  def count(_community, _type), do: {:error, {:custom, "invalid count type"}}
 
   defp do_read_community(slug, opt) do
     with {:ok, community} <- ORM.find_community(slug),

--- a/backend/main/lib/groupher_server/cms/delegates/community_operation.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/community_operation.ex
@@ -4,10 +4,8 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   """
   import ShortMaps
 
-  import Helper.Utils, only: [done: 1]
-  import Helper.ErrorCode
-
   alias Helper.{Certification, ORM, Transaction}
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias Accounts.Model.User
@@ -29,6 +27,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   @doc """
   set a category to community
   """
+  @spec set_category(Community.t(), Category.t()) :: T.domain_res(term())
   def set_category(%Community{id: community_id}, %Category{id: category_id}) do
     with {:ok, community_category} <-
            CommunityCategory |> ORM.create(~m(community_id category_id)a) do
@@ -39,6 +38,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   @doc """
   unset a category to community
   """
+  @spec unset_category(Community.t(), Category.t()) :: T.domain_res(term())
   def unset_category(%Community{id: community_id}, %Category{id: category_id}) do
     with {:ok, community_category} <-
            CommunityCategory |> ORM.findby_delete!(~m(community_id category_id)a) do
@@ -49,6 +49,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   @doc """
   set to thread to a community
   """
+  @spec set_thread(Community.t(), Thread.t()) :: T.domain_res(term())
   def set_thread(%Community{} = community, %Thread{} = thread) do
     attrs = %{community_id: community.id, thread_id: thread.id}
 
@@ -60,6 +61,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   @doc """
   unset to thread to a community
   """
+  @spec unset_thread(Community.t(), Thread.t()) :: T.domain_res(term())
   def unset_thread(%Community{} = community, %Thread{} = thread) do
     with {:ok, community_thread} <-
            ORM.findby_delete!(CommunityThread, %{community_id: community.id, thread_id: thread.id}) do
@@ -103,6 +105,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   @doc """
   set a community moderator
   """
+  @spec add_moderator(Community.t(), term(), User.t(), User.t()) :: T.domain_res(term())
   def add_moderator(%Community{} = community, role, %User{} = target_user, %User{} = cur_user) do
     community = Repo.preload(community, :moderators)
 
@@ -136,15 +139,16 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
           |> result()
         end)
 
-      {:error, false} ->
-        {:error,
-         [message: "only community root can add moderator", code: ecode(:community_root_only)]}
+      {:error, :community_root_only} ->
+        {:error, {:community_root_only, "only community root can add moderator"}}
     end
   end
 
   @doc """
   update community moderator
   """
+  @spec update_moderator_passport(String.t() | Community.t(), term(), User.t(), User.t()) ::
+          T.domain_res(term())
   def update_moderator_passport(
         community_slug,
         rules,
@@ -170,29 +174,24 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
 
       CMS.read_community(community.slug, inc_views: false)
     else
-      {:error, false} ->
-        {:error,
-         [message: "only community root can update moderator", code: ecode(:community_root_only)]}
+      {:error, :community_root_only} ->
+        {:error, {:community_root_only, "only community root can update moderator"}}
 
       {:error, :passport_community_not_match} ->
-        {:error,
-         [
-           message: "can only update passport in #{community.slug}",
-           code: ecode(:passport_community_not_match)
-         ]}
+        {:error, {:passport_community_not_match, "can only update passport in #{community.slug}"}}
 
       {:error, :one_community_only} ->
-        {:error,
-         [message: "can only passport once community a time", code: ecode(:one_community_only)]}
+        {:error, {:one_community_only, "can only passport once community a time"}}
 
       _ ->
-        {:error, "update passport error"}
+        {:error, {:custom, "update passport error"}}
     end
   end
 
   @doc """
   unset a community moderator
   """
+  @spec remove_moderator(String.t() | Community.t(), User.t(), User.t()) :: T.domain_res(term())
   def remove_moderator(community_slug, %User{} = target_user, %User{} = cur_user) do
     with {:ok, community} <- ORM.find_community(community_slug),
          {:ok, true} <- user_is_root?(community, cur_user) do
@@ -219,26 +218,30 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
       |> Repo.transaction()
       |> result()
     else
-      {:error, false} ->
-        {:error,
-         [message: "only community root can remove moderator", code: ecode(:community_root_only)]}
+      {:error, :community_root_only} ->
+        {:error, {:community_root_only, "only community root can remove moderator"}}
     end
   end
 
   # this is for first init when create community
   defp user_is_root?(%Community{moderators: []}, %User{} = _cur_user), do: {:ok, true}
 
-  defp user_is_root?(%Community{moderators: %Ecto.Association.NotLoaded{}} = community, %User{} = cur_user) do
+  defp user_is_root?(
+         %Community{moderators: %Ecto.Association.NotLoaded{}} = community,
+         %User{} = cur_user
+       ) do
     community
     |> Repo.preload(:moderators)
     |> user_is_root?(cur_user)
   end
 
   defp user_is_root?(%Community{moderators: moderators}, %User{} = cur_user) do
-    moderators
-    |> Enum.filter(&(&1.role == "root"))
-    |> Enum.any?(&(to_string(&1.user_id) == to_string(cur_user.id)))
-    |> done
+    is_root =
+      moderators
+      |> Enum.filter(&(&1.role == "root"))
+      |> Enum.any?(&(to_string(&1.user_id) == to_string(cur_user.id)))
+
+    if is_root, do: {:ok, true}, else: {:error, :community_root_only}
   end
 
   defp match_passport_community(community_slug, rules) do
@@ -260,6 +263,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   @doc """
   subscribe a community. (ONLY community, post etc use watch )
   """
+  @spec subscribe_community(Community.t(), User.t()) :: T.domain_res(term())
   def subscribe_community(%Community{} = community, %User{} = user) do
     with {:ok, record} <-
            ORM.create(CommunitySubscriber, %{community_id: community.id, user_id: user.id}) do
@@ -281,6 +285,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   @doc """
   unsubscribe a community
   """
+  @spec unsubscribe_community(Community.t(), User.t()) :: T.domain_res(term())
   def unsubscribe_community(%Community{id: community_id}, %User{} = user) do
     with {:ok, community} <- ORM.find(Community, community_id),
          true <- community.slug !== "home" do
@@ -298,13 +303,14 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
       |> result()
     else
       false ->
-        {:error, "can not unsubscribe home community"}
+        {:error, {:custom, "can not unsubscribe home community"}}
 
       error ->
         error
     end
   end
 
+  @spec subscribe_community_ifnot(Community.t(), User.t()) :: T.domain_res(term())
   def subscribe_community_ifnot(%Community{} = community, %User{} = user) do
     with {:error, _} <-
            ORM.find_by(CommunitySubscriber, %{community_id: community.id, user_id: user.id}) do
@@ -316,6 +322,7 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   if user is new subscribe home community by default
   """
   # 这里只处理第一次订阅 home 社区
+  @spec subscribe_default_community_ifnot(User.t()) :: T.domain_res(term())
   def subscribe_default_community_ifnot(%User{} = user) do
     with {:ok, community} <- ORM.find_by(Community, slug: "home") do
       case ORM.find_by(CommunitySubscriber, %{community_id: community.id, user_id: user.id}) do
@@ -334,10 +341,10 @@ defmodule GroupherServer.CMS.Delegate.CommunityOperation do
   end
 
   defp result({:error, :stamp_passport, %Ecto.Changeset{} = result, _steps}),
-    do: {:error, result}
+    do: {:error, {:changeset, result}}
 
   defp result({:error, :stamp_passport, _result, _steps}),
-    do: {:error, "stamp passport error"}
+    do: {:error, {:custom, "stamp passport error"}}
 
   defp result({:error, _, result, _steps}) do
     {:error, result}

--- a/backend/main/lib/groupher_server/cms/delegates/document.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/document.ex
@@ -5,7 +5,6 @@ defmodule GroupherServer.CMS.Delegate.Document do
   import Ecto.Query, warn: false
   import Helper.Utils, only: [thread_of: 2]
 
-  import Helper.ErrorCode
 
   alias Helper.{ORM, Converter}
   alias GroupherServer.{CMS, Repo}
@@ -54,7 +53,7 @@ defmodule GroupherServer.CMS.Delegate.Document do
       |> result()
     else
       true ->
-        {:error, "document already exist"}
+        {:error, {:already_exist, "document already exist"}}
     end
   end
 
@@ -133,6 +132,6 @@ defmodule GroupherServer.CMS.Delegate.Document do
   defp result({:ok, %{update_article_document: result}}), do: {:ok, result}
 
   defp result({:error, _, _result, _steps}) do
-    {:error, [message: "create document", code: ecode(:create_fails)]}
+    {:error, {:create_fails, "create document"}}
   end
 end

--- a/backend/main/lib/groupher_server/cms/delegates/fetcher.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/fetcher.ex
@@ -1,0 +1,74 @@
+defmodule GroupherServer.CMS.Delegate.Fetcher do
+  @moduledoc """
+  Domain fetch helpers for comment resources.
+  """
+
+  import Ecto.Query, warn: false
+
+  import Helper.Utils,
+    only: [done: 1, get_config: 2]
+
+  import GroupherServer.CMS.Helper.Matcher
+
+  alias Helper.Types, as: T
+  alias Helper.ORM
+  alias GroupherServer.Repo
+
+  alias GroupherServer.CMS.Model.Comment
+
+  @article_threads get_config(:article, :threads)
+
+  @spec fetch_comment(integer()) :: T.domain_result(Comment.t())
+  def fetch_comment(comment_id) do
+    case ORM.find(Comment, comment_id) do
+      {:ok, comment} ->
+        {:ok, comment}
+
+      {:error, reason} ->
+        {:error, {:not_exist, reason}}
+    end
+  end
+
+  @spec fetch_full_comment(integer()) :: T.domain_result(T.article_info())
+  def fetch_full_comment(comment_id) do
+    case get_full_comment(comment_id) do
+      {:ok, full_comment} ->
+        {:ok, full_comment}
+
+      {:error, reason} ->
+        {:error, {:not_exist, reason}}
+    end
+  end
+
+  @spec get_full_comment(integer()) :: {:ok, T.article_info()} | {:error, any()}
+  defp get_full_comment(comment_id) do
+    query = from(c in Comment, where: c.id == ^comment_id, preload: ^@article_threads)
+
+    with {:ok, comment} <- Repo.one(query) |> done(),
+         article_thread <- find_comment_article_thread(comment) do
+      do_extract_article_info(article_thread, Map.get(comment, article_thread))
+    end
+  end
+
+  @spec do_extract_article_info(T.article_thread(), T.article_common()) :: {:ok, T.article_info()}
+  defp do_extract_article_info(thread, article) do
+    with {:ok, article_with_author} <- Repo.preload(article, author: :user) |> done(),
+         article_author <- get_in(article_with_author, [:author, :user]) do
+      article_info = %{title: article.title, id: article.id}
+
+      author_info = %{
+        id: article_author.id,
+        login: article_author.login,
+        nickname: article_author.nickname
+      }
+
+      {:ok, %{thread: thread, article: article_info, author: author_info}}
+    end
+  end
+
+  defp find_comment_article_thread(%Comment{} = comment) do
+    @article_threads
+    |> Enum.filter(&Map.get(comment, :"#{&1}_id"))
+    |> List.first()
+  end
+end

--- a/backend/main/lib/groupher_server/cms/delegates/fetcher.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/fetcher.ex
@@ -8,8 +8,6 @@ defmodule GroupherServer.CMS.Delegate.Fetcher do
   import Helper.Utils,
     only: [done: 1, get_config: 2]
 
-  import GroupherServer.CMS.Helper.Matcher
-
   alias Helper.Types, as: T
   alias Helper.ORM
   alias GroupherServer.Repo
@@ -18,29 +16,30 @@ defmodule GroupherServer.CMS.Delegate.Fetcher do
 
   @article_threads get_config(:article, :threads)
 
-  @spec fetch_comment(integer()) :: T.domain_result(Comment.t())
+  @spec fetch_comment(integer()) :: T.domain_res(Comment.t())
   def fetch_comment(comment_id) do
-    case ORM.find(Comment, comment_id) do
-      {:ok, comment} ->
-        {:ok, comment}
-
-      {:error, reason} ->
-        {:error, {:not_exist, reason}}
-    end
+    ORM.find(Comment, comment_id)
   end
 
-  @spec fetch_full_comment(integer()) :: T.domain_result(T.article_info())
+  @spec fetch_full_comment(integer()) :: T.domain_res(T.article_info())
   def fetch_full_comment(comment_id) do
-    case get_full_comment(comment_id) do
-      {:ok, full_comment} ->
-        {:ok, full_comment}
-
-      {:error, reason} ->
-        {:error, {:not_exist, reason}}
-    end
+    get_full_comment(comment_id)
   end
 
-  @spec get_full_comment(integer()) :: {:ok, T.article_info()} | {:error, any()}
+  @spec fetch(Ecto.Queryable.t(), T.id()) :: T.domain_res(term())
+  def fetch(queryable, id), do: ORM.find(queryable, id)
+
+  @spec fetch(Ecto.Queryable.t(), T.id(), keyword()) :: T.domain_res(term())
+  def fetch(queryable, id, preload: preload), do: ORM.find(queryable, id, preload: preload)
+
+  @spec fetch_by(Ecto.Queryable.t(), map()) :: T.domain_res(term())
+  def fetch_by(queryable, clauses), do: ORM.find_by(queryable, clauses)
+
+  @spec fetch_by(Ecto.Queryable.t(), map(), keyword()) :: T.domain_res(term())
+  def fetch_by(queryable, clauses, preload: preload),
+    do: ORM.find_by(queryable, clauses, preload: preload)
+
+  @spec get_full_comment(integer()) :: T.domain_res(T.article_info())
   defp get_full_comment(comment_id) do
     query = from(c in Comment, where: c.id == ^comment_id, preload: ^@article_threads)
 

--- a/backend/main/lib/groupher_server/cms/delegates/helper.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/helper.ex
@@ -68,7 +68,7 @@ defmodule GroupherServer.CMS.Delegate.Helper do
     end
   end
 
-  def article_of(_), do: {:error, "only support comment"}
+  def article_of(_), do: {:error, {:custom, "only support comment"}}
 
   # get thread of comment
   def thread_of(%Comment{thread: thread}) do
@@ -80,7 +80,7 @@ defmodule GroupherServer.CMS.Delegate.Helper do
     thread |> String.downcase() |> String.to_atom() |> done
   end
 
-  def thread_of(_), do: {:error, "invalid article"}
+  def thread_of(_), do: {:error, {:custom, "invalid article"}}
 
   def thread_of(%{meta: %{thread: thread}}, :upcase) do
     thread |> to_string |> String.upcase() |> done

--- a/backend/main/lib/groupher_server/cms/delegates/hooks/cite.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/hooks/cite.ex
@@ -34,7 +34,6 @@ defmodule GroupherServer.CMS.Delegate.Hooks.Cite do
   import Helper.Utils, only: [preload_author: 1, thread_of: 1, get_config: 2]
   import GroupherServer.CMS.Delegate.Hooks.Helper, only: [merge_same_block_linker: 2]
 
-  import Helper.ErrorCode
 
   alias GroupherServer.{CMS, Repo}
   alias CMS.Delegate.CitedArtiment
@@ -96,7 +95,7 @@ defmodule GroupherServer.CMS.Delegate.Hooks.Cite do
     with {:ok, cited} <- parse_cited_in_link(link) do
       case not is_citing_itself?(content_id, cited) do
         true -> {:ok, cited}
-        false -> {:error, "citing itself, ignored"}
+        false -> {:error, {:custom, "citing itself, ignored"}}
       end
     end
   end
@@ -116,7 +115,7 @@ defmodule GroupherServer.CMS.Delegate.Hooks.Cite do
   defp parse_link(attrs) do
     case Enum.find(attrs, fn {a, _v} -> a == "href" end) do
       {"href", link} -> {:ok, link}
-      _ -> {:error, "invalid fmt"}
+      _ -> {:error, {:custom, "invalid fmt"}}
     end
   end
 
@@ -130,7 +129,7 @@ defmodule GroupherServer.CMS.Delegate.Hooks.Cite do
         {:ok, %{type: :comment, artiment: comment}}
       end
     rescue
-      _ -> {:error, "load comment error"}
+      _ -> {:error, {:custom, "load comment error"}}
     end
   end
 
@@ -239,6 +238,6 @@ defmodule GroupherServer.CMS.Delegate.Hooks.Cite do
   defp result({:ok, %{update_cited_info: result}}), do: {:ok, result}
 
   defp result({:error, :update_cited_info, _result, _steps}) do
-    {:error, [message: "cited article", code: ecode(:cite_article)]}
+    {:error, {:cite_article, "cited article"}}
   end
 end

--- a/backend/main/lib/groupher_server/cms/delegates/hooks/mention.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/hooks/mention.ex
@@ -65,7 +65,7 @@ defmodule GroupherServer.CMS.Delegate.Hooks.Mention do
          {:ok, user_id} <- Accounts.get_userid_and_cache(user_login) do
       case author.id !== user_id do
         true -> {:ok, user_id}
-        false -> {:error, "mention yourself, ignored"}
+        false -> {:error, {:custom, "mention yourself, ignored"}}
       end
     end
   end

--- a/backend/main/lib/groupher_server/cms/delegates/passport_crud.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/passport_crud.ex
@@ -7,6 +7,7 @@ defmodule GroupherServer.CMS.Delegate.PassportCRUD do
   import ShortMaps
 
   alias Helper.{Certification, NestedFilter, ORM}
+  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias Accounts.Model.User
@@ -16,6 +17,7 @@ defmodule GroupherServer.CMS.Delegate.PassportCRUD do
   # http://www.ubazu.com/using-postgres-jsonb-columns-in-ecto
   # http://www.ubazu.com/using-postgres-jsonb-columns-in-ecto
 
+  @spec paged_passports(term(), term()) :: T.domain_res(term())
   def paged_passports(community, key) do
     UserPasport
     |> where([p], fragment("(?->?->>?)::boolean = ?", p.rules, ^community, ^key, true))
@@ -23,6 +25,7 @@ defmodule GroupherServer.CMS.Delegate.PassportCRUD do
     |> done
   end
 
+  @spec all_passport_rules() :: T.domain_res(term())
   def all_passport_rules() do
     %{
       root: Certification.passport_rules(cms: "root"),
@@ -34,6 +37,7 @@ defmodule GroupherServer.CMS.Delegate.PassportCRUD do
   @doc """
   return a user's passport in CMS context
   """
+  @spec get_passport(User.t()) :: T.domain_res(term())
   def get_passport(%User{} = user) do
     with {:ok, _} <- ORM.find(User, user.id) do
       case ORM.find_by(UserPasport, user_id: user.id) do
@@ -50,6 +54,7 @@ defmodule GroupherServer.CMS.Delegate.PassportCRUD do
   @doc """
   insert or update a user's passport in CMS context
   """
+  @spec stamp_passport(term(), User.t()) :: T.domain_res(term())
   def stamp_passport(rules, %User{id: user_id}) do
     case ORM.find_by(UserPasport, user_id: user_id) do
       {:ok, passport} ->
@@ -62,6 +67,7 @@ defmodule GroupherServer.CMS.Delegate.PassportCRUD do
     end
   end
 
+  @spec erase_passport(term(), User.t()) :: T.domain_res(term())
   def erase_passport(rules, %User{id: user_id}) when is_list(rules) do
     with {:ok, passport} <- ORM.find_by(UserPasport, user_id: user_id) do
       case pop_in(passport.rules, rules) do
@@ -74,6 +80,7 @@ defmodule GroupherServer.CMS.Delegate.PassportCRUD do
     end
   end
 
+  @spec delete_passport(User.t()) :: T.domain_res(term())
   def delete_passport(%User{id: user_id}) do
     ORM.findby_delete!(UserPasport, ~m(user_id)a)
   end

--- a/backend/main/lib/groupher_server/cms/delegates/search.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/search.ex
@@ -7,6 +7,7 @@ defmodule GroupherServer.CMS.Delegate.Search do
   import GroupherServer.CMS.Helper.Matcher
 
   alias Helper.ORM
+  alias Helper.Types, as: T
 
   alias GroupherServer.{Accounts, CMS}
   alias CMS.Model.{Community}
@@ -17,10 +18,12 @@ defmodule GroupherServer.CMS.Delegate.Search do
   @doc """
   search community by title
   """
+  @spec search_communities(String.t()) :: T.domain_res(term())
   def search_communities(title) do
     do_search_communities(Community, title)
   end
 
+  @spec search_communities(String.t(), User.t()) :: T.domain_res(term())
   def search_communities(title, %User{} = user) do
     with {:ok, communities} <- do_search_communities(Community, title) do
       %{entries: entries} = communities
@@ -35,6 +38,7 @@ defmodule GroupherServer.CMS.Delegate.Search do
     end
   end
 
+  @spec search_communities(String.t(), term()) :: T.domain_res(term())
   def search_communities(title, category) do
     from(
       c in Community,
@@ -44,6 +48,7 @@ defmodule GroupherServer.CMS.Delegate.Search do
     |> do_search_communities(title)
   end
 
+  @spec search_communities(String.t(), term(), User.t()) :: T.domain_res(term())
   def search_communities(title, category, %User{meta: _}) do
     search_communities(title, category)
   end
@@ -61,6 +66,7 @@ defmodule GroupherServer.CMS.Delegate.Search do
   @doc """
   search article by title
   """
+  @spec search_articles(atom(), map()) :: T.domain_res(term())
   def search_articles(thread, %{title: title}) do
     with {:ok, info} <- match(thread) do
       info.model

--- a/backend/main/lib/groupher_server/cms/delegates/seeds/seeds.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/seeds/seeds.ex
@@ -19,6 +19,7 @@ defmodule GroupherServer.CMS.Delegate.Seeds do
     ]
 
   alias Helper.ORM
+  alias Helper.Types, as: T
   alias GroupherServer.CMS
 
   alias CMS.Model.{Community, Category, Post, Comment}
@@ -37,6 +38,7 @@ defmodule GroupherServer.CMS.Delegate.Seeds do
   @doc """
   seed communities pragraming languages
   """
+  @spec seed_communities(atom()) :: T.domain_res(term())
   def seed_communities(type) when type in @community_types do
     Seeds.Communities.get(type) |> Enum.each(&seed_community(&1, type)) |> done
   end
@@ -44,10 +46,12 @@ defmodule GroupherServer.CMS.Delegate.Seeds do
   @doc """
   seed community for home
   """
+  @spec seed_community(atom()) :: T.domain_res(term())
   def seed_community(:home), do: Domain.seed_community(:home)
   def seed_community(:feedback), do: Domain.seed_community(:feedback)
 
   # type: city, pl, framework, ...
+  @spec seed_community(atom(), atom()) :: T.domain_res(term())
   def seed_community(slug, type) when type in @community_types do
     with {:ok, threads} <- seed_threads(type),
          {:ok, bot} <- seed_bot(),
@@ -61,11 +65,12 @@ defmodule GroupherServer.CMS.Delegate.Seeds do
     end
   end
 
-  def seed_community(_slug, _type), do: "undown community type"
+  def seed_community(_slug, _type), do: {:error, {:custom, "unknown community type"}}
 
   @doc """
   set list of communities to a spec category
   """
+  @spec seed_set_category(list(), atom()) :: T.domain_res(term())
   def seed_set_category(communities_names, cat_name) when is_list(communities_names) do
     {:ok, category} = ORM.find_by(Category, %{slug: cat_name})
 
@@ -76,6 +81,7 @@ defmodule GroupherServer.CMS.Delegate.Seeds do
     end)
   end
 
+  @spec seed_articles(Community.t(), atom(), integer()) :: T.domain_res(term())
   def seed_articles(%Community{} = community, thread, count \\ 3)
       when thread in @article_threads do
     #
@@ -154,12 +160,14 @@ defmodule GroupherServer.CMS.Delegate.Seeds do
     #
   end
 
+  @spec clean_up_community(atom()) :: T.domain_res(term())
   def clean_up_community(slug) do
     with {:ok, community} <- ORM.findby_delete(Community, %{slug: to_string(slug)}) do
       clean_up_articles(community, :post)
     end
   end
 
+  @spec clean_up_articles(Community.t(), atom()) :: T.domain_res(term())
   def clean_up_articles(%Community{} = community, :post) do
     Post
     |> join(:inner, [p], c in assoc(p, :community))

--- a/backend/main/lib/groupher_server/cms/delegates/third_part.ex
+++ b/backend/main/lib/groupher_server/cms/delegates/third_part.ex
@@ -7,7 +7,9 @@ defmodule GroupherServer.CMS.Delegate.ThirdPart do
   import Helper.Utils, only: [done: 1]
 
   alias Helper.OSS
+  alias Helper.Types, as: T
 
+  @spec upload_tokens() :: T.domain_res(term())
   def upload_tokens() do
     with {:ok, %{"Credentials" => credentials}} <- OSS.get_sts_token() do
       %{

--- a/backend/main/lib/groupher_server/cms/helper/macros.ex
+++ b/backend/main/lib/groupher_server/cms/helper/macros.ex
@@ -22,6 +22,52 @@ defmodule GroupherServer.CMS.Helper.Macros do
   @article_threads get_config(:article, :threads)
 
   @doc """
+  generate base schema type with shared fields for artiments
+  """
+  defmacro schema_artiment_type(extra_fields \\ []) do
+    fields =
+      [
+        author_id: quote(do: integer() | nil),
+        thread: quote(do: String.t() | nil),
+        body: quote(do: String.t() | nil),
+        body_html: quote(do: String.t() | nil),
+        is_pinned: quote(do: boolean()),
+        is_deleted: quote(do: boolean()),
+        pending: quote(do: integer())
+      ] ++ extra_fields
+
+    quote do
+      @type t_artiment :: %__MODULE__{
+              id: integer() | nil,
+              inserted_at: DateTime.t() | nil,
+              updated_at: DateTime.t() | nil,
+              unquote_splicing(fields)
+            }
+
+      @type t :: t_artiment()
+    end
+  end
+
+  @doc """
+  generate base schema type with shared fields
+  """
+  defmacro schema_base_type(extra_fields \\ []) do
+    fields =
+      for {key, type_ast} <- extra_fields do
+        {key, type_ast}
+      end
+
+    quote do
+      @type t :: %__MODULE__{
+              id: integer() | nil,
+              inserted_at: DateTime.t() | nil,
+              updated_at: DateTime.t() | nil,
+              unquote_splicing(fields)
+            }
+    end
+  end
+
+  @doc """
   generate belongs to fields for given thread
 
   e.g:

--- a/backend/main/lib/groupher_server/cms/helper/macros.ex
+++ b/backend/main/lib/groupher_server/cms/helper/macros.ex
@@ -38,10 +38,10 @@ defmodule GroupherServer.CMS.Helper.Macros do
 
     quote do
       @type t_artiment :: %__MODULE__{
+              unquote_splicing(fields),
               id: integer() | nil,
               inserted_at: DateTime.t() | nil,
-              updated_at: DateTime.t() | nil,
-              unquote_splicing(fields)
+              updated_at: DateTime.t() | nil
             }
 
       @type t :: t_artiment()
@@ -59,10 +59,10 @@ defmodule GroupherServer.CMS.Helper.Macros do
 
     quote do
       @type t :: %__MODULE__{
+              unquote_splicing(fields),
               id: integer() | nil,
               inserted_at: DateTime.t() | nil,
-              updated_at: DateTime.t() | nil,
-              unquote_splicing(fields)
+              updated_at: DateTime.t() | nil
             }
     end
   end

--- a/backend/main/lib/groupher_server/cms/models/comment.ex
+++ b/backend/main/lib/groupher_server/cms/models/comment.ex
@@ -51,7 +51,7 @@ defmodule GroupherServer.CMS.Model.Comment do
   def report_threshold_for_fold, do: @report_threshold_for_fold
   def pinned_comment_limit, do: @pinned_comment_limit
 
-  @type t :: %Comment{}
+  schema_artiment_type(is_archived: boolean())
   schema "comments" do
     belongs_to(:author, User, foreign_key: :author_id)
 
@@ -97,6 +97,7 @@ defmodule GroupherServer.CMS.Model.Comment do
   end
 
   @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t(t())
   def changeset(%Comment{} = comment, attrs) do
     comment
     |> cast(attrs, @required_fields ++ @optional_fields ++ @article_fields)

--- a/backend/main/lib/groupher_server/cms/models/community.ex
+++ b/backend/main/lib/groupher_server/cms/models/community.ex
@@ -21,6 +21,8 @@ defmodule GroupherServer.CMS.Model.Community do
     CommunityModerator
   }
 
+  @type t :: %__MODULE__{}
+
   @schema_prefix DBPrefix.cms()
 
   @max_pinned_article_count_per_thread 2

--- a/backend/main/lib/groupher_server/cms/models/community_dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/models/community_dashboard.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.CommunityDashboard do
+  @type t :: %__MODULE__{}
+
   @moduledoc false
   alias __MODULE__
 

--- a/backend/main/lib/groupher_server/cms/models/embeds/abuse_report_case.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/abuse_report_case.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.AbuseReportCase do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   abuse report user
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/app_store.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/app_store.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.AppStore do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general community meta
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/article_emotion.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/article_emotion.ex
@@ -29,6 +29,8 @@ defmodule GroupherServer.CMS.Model.Embeds.ArticleEmotion.Macros do
 end
 
 defmodule GroupherServer.CMS.Model.Embeds.ArticleEmotion do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article meta info for article-like content, like post, blog...
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/article_meta.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/article_meta.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.ArticleMeta do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article meta info for article-like content, like post ...
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/block_task_runner.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/block_task_runner.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.BlockTaskRunner do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article meta info for article-like content, like post ...
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/blog_author.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/blog_author.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.BlogAuthor do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general community meta
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/blog_history_feed.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/blog_history_feed.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.BlogHistoryFeed do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general community meta
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/comment_emotion.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/comment_emotion.ex
@@ -29,6 +29,8 @@ defmodule GroupherServer.CMS.Model.Embeds.CommentEmotion.Macros do
 end
 
 defmodule GroupherServer.CMS.Model.Embeds.CommentEmotion do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article meta info for article-like content, like post ...
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/comment_meta.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/comment_meta.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.CommentMeta do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/community_meta.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/community_meta.ex
@@ -1,4 +1,5 @@
 defmodule GroupherServer.CMS.Model.Embeds.CommunityMeta.Macro do
+  
   @moduledoc false
 
   import Helper.Utils, only: [get_config: 2, plural: 1]
@@ -25,6 +26,8 @@ defmodule GroupherServer.CMS.Model.Embeds.CommunityMeta.Macro do
 end
 
 defmodule GroupherServer.CMS.Model.Embeds.CommunityMeta do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general community meta
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_baseinfo.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_baseinfo.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardBaseInfo do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_enable.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_enable.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardEnable do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_faq.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_faq.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardFAQ do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_footer_link.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_footer_link.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardFooterLink do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_header_link.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_header_link.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardHeaderLink do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_layout.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_layout.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardLayout do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_media_report.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_media_report.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardMediaReport do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_name_alias.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_name_alias.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardNameAlias do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_rss.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_rss.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardRSS do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_seo.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_seo.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardSEO do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_social_link.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_social_link.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardSocialLink do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/dashboard_wallpaper.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/dashboard_wallpaper.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.DashboardWallpaper do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article comment meta info
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/reference_task.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/reference_task.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.ReferenceTask do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general article meta info for article-like content, like post ...
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/social_info.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/social_info.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.SocialInfo do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   general community meta
   """

--- a/backend/main/lib/groupher_server/cms/models/embeds/user.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/user.ex
@@ -1,4 +1,6 @@
 defmodule GroupherServer.CMS.Model.Embeds.User do
+  @type t :: %__MODULE__{}
+
   @moduledoc """
   only used for embeds_many situation
   """

--- a/backend/main/lib/groupher_server/cms/models/pinned_comment.ex
+++ b/backend/main/lib/groupher_server/cms/models/pinned_comment.ex
@@ -23,7 +23,7 @@ defmodule GroupherServer.CMS.Model.PinnedComment do
 
   @article_fields @article_threads |> Enum.map(&:"#{&1}_id")
 
-  @type t :: %PinnedComment{}
+  schema_base_type(comment_id: integer() | nil)
   schema "pinned_comments" do
     belongs_to(:comment, Comment, foreign_key: :comment_id)
 
@@ -32,6 +32,7 @@ defmodule GroupherServer.CMS.Model.PinnedComment do
   end
 
   @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t(t())
   def changeset(%PinnedComment{} = article_pined_comment, attrs) do
     article_pined_comment
     |> cast(attrs, @required_fields ++ @article_fields)

--- a/backend/main/lib/groupher_server/delivery/delegates/notification.ex
+++ b/backend/main/lib/groupher_server/delivery/delegates/notification.ex
@@ -172,8 +172,8 @@ defmodule GroupherServer.Delivery.Delegate.Notification do
 
   # find exist notification, in latest peroid
   # 在最近的时期内，找到一个存在的通知
-  @spec do_find_exist_notify(Ecto.Queryable.t(), Map.t(), Atom.t()) ::
-          {Atom.t(), Notification.t()}
+  @spec do_find_exist_notify(Ecto.Queryable.t(), map(), atom()) ::
+          {atom(), Notification.t()}
   defp do_find_exist_notify(queryable, attrs, :latest_peroid) do
     ~m(user_id action)a = atom_values_to_upcase(attrs)
 
@@ -186,8 +186,8 @@ defmodule GroupherServer.Delivery.Delegate.Notification do
 
   # find exist notifications, in all history
   # 在所有通知中，找到多个存在的通知
-  @spec do_find_exist_notify(Ecto.Queryable.t(), Map.t(), Atom.t()) ::
-          {Atom.t(), [Notification.t()]}
+  @spec do_find_exist_notify(Ecto.Queryable.t(), map(), atom()) ::
+          {atom(), [Notification.t()]}
   defp do_find_exist_notify(queryable, attrs, _opt) do
     ~m(user_id action from_user)a = atom_values_to_upcase(attrs)
 

--- a/backend/main/lib/groupher_server_web/middleware/general_error.ex
+++ b/backend/main/lib/groupher_server_web/middleware/general_error.ex
@@ -11,7 +11,7 @@ defmodule GroupherServerWeb.Middleware.GeneralError do
 
   # legacy string errors
   def call(%{errors: [error]} = resolution, _) when is_binary(error) do
-    %{resolution | value: [], errors: [%{message: error}]}
+    %{resolution | value: [], errors: Enum.map(error, &%{message: to_string(&1)})}
   end
 
   # legacy list errors (exclude graphql keyword shape)

--- a/backend/main/lib/groupher_server_web/middleware/general_error.ex
+++ b/backend/main/lib/groupher_server_web/middleware/general_error.ex
@@ -15,9 +15,12 @@ defmodule GroupherServerWeb.Middleware.GeneralError do
   end
 
   # legacy list errors (exclude graphql keyword shape)
-  def call(%{errors: [error]} = resolution, _)
-      when is_list(error) and not Keyword.keyword?(error) do
-    %{resolution | value: [], errors: [%{message: error}]}
+  def call(%{errors: [error]} = resolution, _) when is_list(error) do
+    if Keyword.keyword?(error) do
+      resolution
+    else
+      %{resolution | value: [], errors: [%{message: error}]}
+    end
   end
 
   def call(resolution, _), do: resolution

--- a/backend/main/lib/groupher_server_web/middleware/general_error.ex
+++ b/backend/main/lib/groupher_server_web/middleware/general_error.ex
@@ -23,5 +23,16 @@ defmodule GroupherServerWeb.Middleware.GeneralError do
     end
   end
 
+  # domain tuple errors
+  def call(%{errors: [error]} = resolution, _) when is_tuple(error) do
+    case Helper.GQLError.encode(error) do
+      {:error, [message: message, code: code]} ->
+        %{resolution | value: [], errors: [%{message: message, code: code}]}
+
+      _ ->
+        resolution
+    end
+  end
+
   def call(resolution, _), do: resolution
 end

--- a/backend/main/lib/groupher_server_web/middleware/general_error.ex
+++ b/backend/main/lib/groupher_server_web/middleware/general_error.ex
@@ -3,12 +3,21 @@
 # see https://hexdocs.pm/absinthe/Absinthe.Middleware.html#content
 # ---
 defmodule GroupherServerWeb.Middleware.GeneralError do
+  @moduledoc """
+  Fallback formatter for legacy non-domain/non-changeset errors.
+  """
+
   @behaviour Absinthe.Middleware
 
-  def call(%{errors: [List = errors]} = resolution, _) do
-    message = [%{message: errors}]
+  # legacy string errors
+  def call(%{errors: [error]} = resolution, _) when is_binary(error) do
+    %{resolution | value: [], errors: [%{message: error}]}
+  end
 
-    %{resolution | value: [], errors: message}
+  # legacy list errors (exclude graphql keyword shape)
+  def call(%{errors: [error]} = resolution, _)
+      when is_list(error) and not Keyword.keyword?(error) do
+    %{resolution | value: [], errors: [%{message: error}]}
   end
 
   def call(resolution, _), do: resolution

--- a/backend/main/lib/groupher_server_web/middleware/gql_result_fmt.ex
+++ b/backend/main/lib/groupher_server_web/middleware/gql_result_fmt.ex
@@ -1,0 +1,33 @@
+# ---
+# Absinthe.Middleware behaviour
+# see https://hexdocs.pm/absinthe/Absinthe.Middleware.html#content
+# ---
+defmodule GroupherServerWeb.Middleware.GQLResultFmt do
+  @moduledoc """
+  Convert domain-level error results into GraphQL error shape.
+  """
+
+  @behaviour Absinthe.Middleware
+
+  def call(%{errors: [%Ecto.Changeset{}]} = resolution, _), do: resolution
+
+  def call(%{errors: [error]} = resolution, _) do
+    if formattable_domain_error?(error) do
+      {:error, [message: _, code: _]} = gq_error = Helper.GQL.result({:error, error})
+      Absinthe.Resolution.put_result(resolution, gq_error)
+    else
+      resolution
+    end
+  end
+
+  def call(resolution, _), do: resolution
+
+  defp formattable_domain_error?(reason) when is_atom(reason), do: true
+  defp formattable_domain_error?({reason, _meta}) when is_atom(reason), do: true
+
+  defp formattable_domain_error?(reason) when is_list(reason) do
+    Keyword.keyword?(reason) and Keyword.has_key?(reason, :message) and Keyword.has_key?(reason, :code)
+  end
+
+  defp formattable_domain_error?(_), do: false
+end

--- a/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
+++ b/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
@@ -440,6 +440,7 @@ defmodule GroupherServerWeb.Resolvers.CMS do
   end
 
   def pin_comment(_root, ~m(id)a, _info), do: CMS.pin_comment(id)
+
   def undo_pin_comment(_root, ~m(id)a, _info), do: CMS.undo_pin_comment(id)
 
   ############

--- a/backend/main/lib/groupher_server_web/schema.ex
+++ b/backend/main/lib/groupher_server_web/schema.ex
@@ -64,11 +64,11 @@ defmodule GroupherServerWeb.Schema do
   end
 
   def middleware(middleware, _field, %{identifier: :query}) do
-    middleware ++ [M.GeneralError]
+    middleware ++ [M.GQLResultFmt, M.GeneralError]
   end
 
   def middleware(middleware, _field, %{identifier: :mutation}) do
-    middleware ++ [M.ChangesetErrors]
+    middleware ++ [M.GQLResultFmt, M.ChangesetErrors]
   end
 
   def middleware(middleware, _field, _object) do

--- a/backend/main/lib/helper/cache.ex
+++ b/backend/main/lib/helper/cache.ex
@@ -47,7 +47,7 @@ defmodule Helper.Cache do
   iex> Helper.Cache.get(:common, :a)
   {:ok, "b"}
   """
-  @spec get(Atom.t(), String.t()) :: {:error, nil} | {:ok, any}
+  @spec get(atom(), String.t()) :: {:error, nil} | {:ok, any}
   def get(pool, key) do
     case Cachex.get(pool, key) do
       {:ok, nil} -> {:error, nil}

--- a/backend/main/lib/helper/converter/article.ex
+++ b/backend/main/lib/helper/converter/article.ex
@@ -24,7 +24,7 @@ defmodule Helper.Converter.Article do
   parse article body field
   """
   @spec parse_body(String.t()) ::
-          {:ok, %{body: String.t(), body_map: Map.t(), body_html: String.t()}}
+          {:ok, %{body: String.t(), body_map: map(), body_html: String.t()}}
   def parse_body(body) when is_binary(body) do
     with {:ok, body_map} <- to_editor_map(body),
          {:ok, body_html} <- EditorToHTML.to_html(body_map),

--- a/backend/main/lib/helper/converter/editor_to_html/frags/list.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/frags/list.ex
@@ -101,7 +101,7 @@ defmodule Helper.Converter.EditorToHTML.Frags.List do
     ~s(<div class="#{@class["order_list_prefix"]}">#{prefix_index}</div>)
   end
 
-  @spec frag(:checkbox, Boolean.t()) :: T.html()
+  @spec frag(:checkbox, boolean()) :: T.html()
   def frag(:checkbox, checked) when is_boolean(checked) do
     checked_svg = svg(:checked)
     checkbox_checked_class = if checked, do: @class["checklist_checkbox_checked"], else: ""

--- a/backend/main/lib/helper/converter/editor_to_html/index.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/index.ex
@@ -14,7 +14,7 @@ defmodule Helper.Converter.EditorToHTML do
   # alias EditorToHTML.Assets.{DelimiterIcons}
   @root_class Class.article()
 
-  @spec to_html(Map.t()) :: {:ok, T.html()}
+  @spec to_html(map()) :: {:ok, T.html()}
   def to_html(editor_map) when is_map(editor_map) do
     content =
       Enum.reduce(editor_map["blocks"], "", fn block, acc ->

--- a/backend/main/lib/helper/error_code.ex
+++ b/backend/main/lib/helper/error_code.ex
@@ -47,6 +47,7 @@ defmodule Helper.ErrorCode do
   # comment
   def ecode(:create_comment), do: @comment_base + 1
   def ecode(:comment_already_upvote), do: @comment_base + 2
+  def ecode(:comment_pin_limit), do: @comment_base + 3
   # article
   def ecode(:too_much_pinned_article), do: @article_base + 1
   def ecode(:already_collected_in_folder), do: @article_base + 2
@@ -69,6 +70,15 @@ defmodule Helper.ErrorCode do
   def ecode(:passport_community_not_match), do: @community_base + 2
   def ecode(:one_community_only), do: @community_base + 3
 
+  def ecode(reason) when is_atom(reason) do
+    case Mix.env() do
+      env when env in [:dev, :test] ->
+        raise ArgumentError, "unknown error reason: #{inspect(reason)}"
+
+      _ ->
+        ecode(:custom)
+    end
+  end
+
   def ecode, do: @default_base
-  # def ecode(_), do: @default_base
 end

--- a/backend/main/lib/helper/error_code.ex
+++ b/backend/main/lib/helper/error_code.ex
@@ -10,9 +10,9 @@ defmodule Helper.ErrorCode do
   @article_base 4500
   @community_base 5500
 
-  @spec raise_error(Atom.t(), String.t()) :: {:error, [message: String.t(), code: Integer.t()]}
+  @spec raise_error(atom(), String.t()) :: {:error, {atom(), String.t()}}
   def raise_error(code_atom, msg) do
-    {:error, [message: msg, code: ecode(code_atom)]}
+    {:error, {code_atom, msg}}
   end
 
   # account error code

--- a/backend/main/lib/helper/gq_error.ex
+++ b/backend/main/lib/helper/gq_error.ex
@@ -1,0 +1,22 @@
+defmodule Helper.GQLError do
+  @moduledoc """
+  Encode domain errors into GraphQL error shape.
+  """
+
+  alias Helper.{ErrorCode, Types}
+
+  @spec encode(Types.error() | Types.gq_error() | {:error, Types.error()}) :: Types.gq_error()
+  def encode({:error, [message: _message, code: _code]} = error), do: error
+  def encode({:error, error}), do: encode(error)
+
+  def encode({reason, meta}) when is_atom(reason) do
+    message = if is_binary(meta), do: meta, else: Atom.to_string(reason)
+    {:error, [message: message, code: safe_ecode(reason)]}
+  end
+
+  def encode(reason) when is_atom(reason) do
+    {:error, [message: Atom.to_string(reason), code: safe_ecode(reason)]}
+  end
+
+  defp safe_ecode(reason), do: ErrorCode.ecode(reason)
+end

--- a/backend/main/lib/helper/gql.ex
+++ b/backend/main/lib/helper/gql.ex
@@ -1,0 +1,12 @@
+defmodule Helper.GQL do
+  @moduledoc """
+  GraphQL boundary helpers for transforming domain results.
+  """
+
+  alias Helper.Types
+
+  @spec result(Types.result(t, Types.error()) | Types.gq_result(t)) :: Types.gq_result(t)
+  def result({:ok, _} = ok), do: ok
+  def result({:error, [message: _, code: _]} = gq_error), do: gq_error
+  def result({:error, error}), do: Helper.GQLError.encode(error)
+end

--- a/backend/main/lib/helper/gql.ex
+++ b/backend/main/lib/helper/gql.ex
@@ -5,7 +5,8 @@ defmodule Helper.GQL do
 
   alias Helper.Types
 
-  @spec result(Types.result(t, Types.error()) | Types.gq_result(t)) :: Types.gq_result(t)
+  @spec result(Types.result(term(), Types.error()) | Types.gq_result(term())) ::
+          Types.gq_result(term())
   def result({:ok, _} = ok), do: ok
   def result({:error, [message: _, code: _]} = gq_error), do: gq_error
   def result({:error, error}), do: Helper.GQLError.encode(error)

--- a/backend/main/lib/helper/gql.ex
+++ b/backend/main/lib/helper/gql.ex
@@ -8,6 +8,7 @@ defmodule Helper.GQL do
   @spec result(Types.result(term(), Types.error()) | Types.gq_result(term())) ::
           Types.gq_result(term())
   def result({:ok, _} = ok), do: ok
+  def result({:error, {:changeset, %Ecto.Changeset{} = changeset}}), do: {:error, changeset}
   def result({:error, [message: _, code: _]} = gq_error), do: gq_error
   def result({:error, error}), do: Helper.GQLError.encode(error)
 end

--- a/backend/main/lib/helper/orm.ex
+++ b/backend/main/lib/helper/orm.ex
@@ -76,7 +76,7 @@ defmodule Helper.ORM do
   @doc """
   similar to Repo.get/3, with standard result/error handle
   """
-  @spec find(Ecto.Queryable.t(), SpecType.id()) :: {:ok, any()} | {:error, String.t()}
+  @spec find(Ecto.Queryable.t(), SpecType.id()) :: {:ok, any()} | {:error, T.error()}
   def find(queryable, id) do
     queryable
     |> Repo.get(id)
@@ -91,7 +91,7 @@ defmodule Helper.ORM do
     |> Repo.get_by(clauses)
     |> case do
       nil ->
-        {:error, not_found_formatter(queryable, clauses)}
+        {:error, {:not_exist, not_found_formatter(queryable, clauses)}}
 
       result ->
         {:ok, result}
@@ -104,7 +104,7 @@ defmodule Helper.ORM do
     |> Repo.get_by(clauses)
     |> case do
       nil ->
-        {:error, not_found_formatter(queryable, clauses)}
+        {:error, {:not_exist, not_found_formatter(queryable, clauses)}}
 
       result ->
         {:ok, result}
@@ -317,7 +317,7 @@ defmodule Helper.ORM do
   end
 
   @doc "extract common articles info"
-  @spec extract_articles(T.paged_data(), [Atom.t()]) :: T.paged_article_common()
+  @spec extract_articles(T.paged_data(), [atom()]) :: T.paged_article_common()
   def extract_articles(%{entries: entries} = paged_articles, threads \\ @article_threads) do
     paged_articles
     |> Map.put(:entries, Enum.map(entries, &extract_article_info(&1, threads)))

--- a/backend/main/lib/helper/types.ex
+++ b/backend/main/lib/helper/types.ex
@@ -13,10 +13,21 @@ defmodule Helper.Types do
   @type done ::
           {:ok, :pass} | {:ok, Map} | {:error, List.t()} | {:error, String} | {:error, Map.t()}
 
+  @type error_reason :: atom()
+  @type error_meta :: term()
+  @type error :: error_reason() | {error_reason(), error_meta()}
+
+  @type ok(t) :: {:ok, t}
+  @type err(e) :: {:error, e}
+
+  @type result(t, e) :: ok(t) | err(e)
+  @type domain_result(t) :: result(t, error())
+
   @typedoc """
   Type GraphQL flavor the error format
   """
   @type gq_error :: {:error, [message: String.t(), code: non_neg_integer()]}
+  @type gq_result(t) :: {:ok, t} | gq_error()
 
   @type id :: non_neg_integer() | String.t()
 

--- a/backend/main/lib/helper/types.ex
+++ b/backend/main/lib/helper/types.ex
@@ -6,27 +6,27 @@ defmodule Helper.Types do
   alias GroupherServer.{Accounts}
   alias Accounts.Model.User
 
+  @type error_reason :: atom()
+  @type error_meta :: term()
+  @type error :: error_reason() | {error_reason(), error_meta()}
+
   @typedoc """
   general response conventions
   """
 
-  @type done ::
-          {:ok, :pass} | {:ok, Map} | {:error, List.t()} | {:error, String} | {:error, Map.t()}
-
-  @type error_reason :: atom()
-  @type error_meta :: term()
-  @type error :: error_reason() | {error_reason(), error_meta()}
+  @type done :: {:ok, term()} | {:error, error()}
 
   @type ok(t) :: {:ok, t}
   @type err(e) :: {:error, e}
 
   @type result(t, e) :: ok(t) | err(e)
-  @type domain_result(t) :: result(t, error())
+  @type domain_res(t) :: result(t, error())
 
   @typedoc """
   Type GraphQL flavor the error format
   """
-  @type gq_error :: {:error, [message: String.t(), code: non_neg_integer()]}
+  @type gq_error ::
+          {:error, [message: String.t(), code: non_neg_integer()]} | {:error, Ecto.Changeset.t()}
   @type gq_result(t) :: {:ok, t} | gq_error()
 
   @type id :: non_neg_integer() | String.t()
@@ -34,46 +34,46 @@ defmodule Helper.Types do
   @type article_thread :: :post | :blog | :changelog | :doc
 
   @type paged_filter :: %{
-          page: Integer.t(),
-          size: Integer.t(),
+          page: integer(),
+          size: integer(),
           sort: :desc_inserted | :asc_inserted
         }
 
   @type paged_users :: %{
           entries: [User.t()],
-          page_number: Integer.t(),
-          page_size: Integer.t(),
-          total_count: Integer.t(),
-          total_pages: Integer.t()
+          page_number: integer(),
+          page_size: integer(),
+          total_count: integer(),
+          total_pages: integer()
         }
 
   @type paged_data :: %{
-          entries: [Map.t()],
-          page_number: Integer.t(),
-          page_size: Integer.t(),
-          total_count: Integer.t(),
-          total_pages: Integer.t()
+          entries: [map()],
+          page_number: integer(),
+          page_size: integer(),
+          total_count: integer(),
+          total_pages: integer()
         }
 
   @type article_common :: %{
-          id: Integer.t(),
-          thread: Atom.t(),
+          id: integer(),
+          thread: atom(),
           title: String.t(),
-          upvotes_count: Integer.t(),
+          upvotes_count: integer(),
           meta: %{
-            upvoted_user_ids: [Integer.t()],
-            collected_user_ids: [Integer.t()],
-            viewed_user_ids: [Integer.t()],
-            reported_user_ids: [Integer.t()]
+            upvoted_user_ids: [integer()],
+            collected_user_ids: [integer()],
+            viewed_user_ids: [integer()],
+            reported_user_ids: [integer()]
           }
         }
 
   @type paged_article_common :: %{
           entries: [article_common],
-          page_number: Integer.t(),
-          page_size: Integer.t(),
-          total_count: Integer.t(),
-          total_pages: Integer.t()
+          page_number: integer(),
+          page_size: integer(),
+          total_count: integer(),
+          total_pages: integer()
         }
 
   @type article_info :: %{
@@ -82,7 +82,7 @@ defmodule Helper.Types do
             title: String.t()
           },
           author: %{
-            id: Integer.t(),
+            id: integer(),
             login: String.t(),
             nickname: String.t()
           }
@@ -141,8 +141,8 @@ defmodule Helper.Types do
   @type editor_table_cell :: %{
           required(:text) => String.t(),
           required(:align) => editor_table_align,
-          isStripe: Boolean.t(),
-          isHeader: Boolean.t()
+          isStripe: boolean(),
+          isHeader: boolean()
         }
 
   # @typep editor_image_mode :: :single | :jiugongge | :gallery
@@ -153,7 +153,7 @@ defmodule Helper.Types do
   @type editor_image_item :: %{
           required(:src) => String.t(),
           caption: String.t(),
-          index: Integer.t(),
+          index: integer(),
           width: String.t(),
           height: String.t()
         }
@@ -182,12 +182,12 @@ defmodule Helper.Types do
   @type html :: String.t()
 
   @type cite_info :: %{
-          id: Integer.t(),
+          id: integer(),
           thread: article_thread,
           title: String.t(),
           inserted_at: String.t(),
           block_linker: [String.t()],
-          comment_id: Integer.t() | nil,
+          comment_id: integer() | nil,
           user: %{
             login: String.t(),
             avatar: String.t(),

--- a/backend/main/lib/helper/utils/string.ex
+++ b/backend/main/lib/helper/utils/string.ex
@@ -9,7 +9,7 @@ defmodule Helper.Utils.String do
   def stringify(v), do: v
 
   # see https://stackoverflow.com/a/49558074/4050784
-  @spec str_occurrence(String.t(), String.t()) :: Integer.t()
+  @spec str_occurrence(String.t(), String.t()) :: integer()
   def str_occurrence(string, substr) when is_binary(string) and is_binary(substr) do
     len = string |> String.split(substr) |> length()
     len - 1

--- a/backend/main/lib/helper/utils/utils.ex
+++ b/backend/main/lib/helper/utils/utils.ex
@@ -75,23 +75,29 @@ defmodule Helper.Utils do
   @doc """
   handle General {:ok, ..} or {:error, ..} return
   """
-  def done(false), do: {:error, false}
+  def done(false), do: {:error, :not_exist}
   def done(true), do: {:ok, true}
-  def done(nil), do: {:error, "record not found."}
+  def done(nil), do: {:error, :not_exist}
   def done({n, nil}) when is_integer(n), do: {:ok, %{done: true}}
   def done(:ok), do: {:ok, :pass}
   def done([]), do: {:ok, []}
   def done(result), do: {:ok, result}
   def done(nil, :boolean), do: {:ok, false}
   def done(_, :boolean), do: {:ok, true}
-  def done(nil, err_msg), do: {:error, err_msg}
+  def done(nil, err_msg) when is_binary(err_msg), do: {:error, {:custom, err_msg}}
+  def done(nil, err_msg), do: {:error, {:custom, err_msg}}
   def done({:ok, _}, with: result), do: {:ok, result}
-  def done({:error, reason}, with: _result), do: {:error, reason}
+  def done({:error, reason}, with: _result), do: {:error, normalize_error(reason)}
 
   def done({:ok, result}, :trans), do: result
-  def done({:error, reason}, :trans), do: throw({:error, reason})
-  def done(nil, queryable, id), do: {:error, not_found_formatter(queryable, id)}
+  def done({:error, reason}, :trans), do: throw({:error, normalize_error(reason)})
+  def done(nil, queryable, id), do: {:error, {:not_exist, not_found_formatter(queryable, id)}}
   def done(result, _, _), do: {:ok, result}
+
+  defp normalize_error({reason, _meta} = error) when is_atom(reason), do: error
+  defp normalize_error(reason) when is_atom(reason), do: reason
+  defp normalize_error(reason) when is_binary(reason), do: {:custom, reason}
+  defp normalize_error(reason), do: {:custom, reason}
 
   # for delete_all, update_all
   # see: https://groups.google.com/forum/#!topic/elixir-ecto/1g5Pp6ceqFE
@@ -122,6 +128,13 @@ defmodule Helper.Utils do
   @doc """
   see: https://hexdocs.pm/absinthe/errors.html#content for error format
   """
+  def handle_absinthe_error(resolution, {reason, meta}, code) when is_integer(code) do
+    message = if is_binary(meta), do: meta, else: Atom.to_string(reason)
+
+    resolution
+    |> Absinthe.Resolution.put_result({:error, message: message, code: code})
+  end
+
   def handle_absinthe_error(resolution, err_msg, code) when is_integer(code) do
     resolution
     |> Absinthe.Resolution.put_result({:error, message: err_msg, code: code})

--- a/backend/main/lib/support/assert_helper.ex
+++ b/backend/main/lib/support/assert_helper.ex
@@ -22,9 +22,14 @@ defmodule GroupherServer.Test.AssertHelper do
   def non_exist_login, do: "15_982_398_614"
   # def page_size, do: @page_size
 
-  def is_error?(reason, code) when is_list(reason) and is_atom(code) do
-    reason |> Keyword.get(:code) == ecode(code)
+  def is_error?(reason, code) when is_atom(code) do
+    error_code(reason) == ecode(code)
   end
+
+  def error_code(reason) when is_list(reason), do: Keyword.get(reason, :code)
+  def error_code({reason, _meta}) when is_atom(reason), do: ecode(reason)
+  def error_code(reason) when is_atom(reason), do: ecode(reason)
+  def error_code(_), do: nil
 
   def assert_v(:inner_page_size), do: @inner_page_size
 
@@ -215,7 +220,7 @@ defmodule GroupherServer.Test.AssertHelper do
   defp log_debug_info(res, _), do: res
 
   @doc "check id is exist in list of Map<id: xxx> structure"
-  @spec exist_in?(Map.t(), [Map.t()]) :: boolean
+  @spec exist_in?(map(), [map()]) :: boolean
   def exist_in?(%{id: id}, list) when is_list(list) do
     list
     |> Enum.any?(fn item ->

--- a/backend/main/test/groupher_server/accounts/published/published_docs_test.exs
+++ b/backend/main/test/groupher_server/accounts/published/published_docs_test.exs
@@ -57,7 +57,7 @@ defmodule GroupherServer.Test.Accounts.Published.Doc do
         acc ++ [doc]
       end)
 
-      {:ok, results} = Accounts.paged_published_articles(user, :doc, %{page: 1, size: 20})
+      {:ok, results} = Accounts.paged_published_articles(user, :doc, %{page: 1, size: 50})
 
       assert results |> is_valid_pagination?(:raw)
       assert results.total_count == @publish_count * 2 + 1

--- a/backend/main/test/groupher_server/cms/articles/blog_pin_test.exs
+++ b/backend/main/test/groupher_server/cms/articles/blog_pin_test.exs
@@ -35,7 +35,7 @@ defmodule GroupherServer.Test.CMS.Articles.BlogPin do
       {:ok, new_blog} = CMS.create_article(community, :blog, mock_attrs(:blog), user)
 
       {:error, reason} = CMS.pin_article(community, new_blog)
-      assert reason |> Keyword.get(:code) == ecode(:too_much_pinned_article)
+      assert error_code(reason) == ecode(:too_much_pinned_article)
     end
 
     test "can undo pin to a blog", ~m(community blog)a do

--- a/backend/main/test/groupher_server/cms/articles/changelog_pin_test.exs
+++ b/backend/main/test/groupher_server/cms/articles/changelog_pin_test.exs
@@ -37,7 +37,7 @@ defmodule GroupherServer.Test.CMS.Articles.ChangelogPin do
         CMS.create_article(community, :changelog, mock_attrs(:changelog), user)
 
       {:error, reason} = CMS.pin_article(community, new_changelog)
-      assert reason |> Keyword.get(:code) == ecode(:too_much_pinned_article)
+      assert error_code(reason) == ecode(:too_much_pinned_article)
     end
 
     test "can undo pin to a changelog", ~m(community changelog)a do

--- a/backend/main/test/groupher_server/cms/articles/doc_pin_test.exs
+++ b/backend/main/test/groupher_server/cms/articles/doc_pin_test.exs
@@ -35,7 +35,7 @@ defmodule GroupherServer.Test.CMS.Articles.DocPin do
       {:ok, new_doc} = CMS.create_article(community, :doc, mock_attrs(:doc), user)
 
       {:error, reason} = CMS.pin_article(community, new_doc)
-      assert reason |> Keyword.get(:code) == ecode(:too_much_pinned_article)
+      assert error_code(reason) == ecode(:too_much_pinned_article)
     end
 
     test "can undo pin to a doc", ~m(community doc)a do

--- a/backend/main/test/groupher_server/cms/articles/post_pin_test.exs
+++ b/backend/main/test/groupher_server/cms/articles/post_pin_test.exs
@@ -33,7 +33,7 @@ defmodule GroupherServer.Test.CMS.Articles.PostPin do
 
       {:ok, new_post} = CMS.create_article(community, :post, mock_attrs(:post), user)
       {:error, reason} = CMS.pin_article(community, new_post)
-      assert reason |> Keyword.get(:code) == ecode(:too_much_pinned_article)
+      assert error_code(reason) == ecode(:too_much_pinned_article)
     end
 
     test "can undo pin to a post", ~m(community post)a do

--- a/backend/main/test/groupher_server/cms/cms_test.exs
+++ b/backend/main/test/groupher_server/cms/cms_test.exs
@@ -236,7 +236,7 @@ defmodule GroupherServer.Test.CMS do
       {:error, reason} =
         CMS.update_moderator_passport(community, new_passport_rules, user2, cur_user)
 
-      assert reason[:code] == ecode(:passport_community_not_match)
+      assert error_code(reason) == ecode(:passport_community_not_match)
     end
 
     test "can not update multi community passport", ~m(user user2 community)a do
@@ -258,7 +258,7 @@ defmodule GroupherServer.Test.CMS do
       {:error, reason} =
         CMS.update_moderator_passport(community, new_passport_rules, user2, cur_user)
 
-      assert reason[:code] == ecode(:one_community_only)
+      assert error_code(reason) == ecode(:one_community_only)
     end
 
     test "can add multi moderators to a community", ~m(user user2 community)a do

--- a/backend/main/test/groupher_server/cms/comments/blog_comment_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/blog_comment_test.exs
@@ -448,7 +448,7 @@ defmodule GroupherServer.Test.CMS.Comments.BlogComment do
         {:ok, _} = CMS.pin_comment(comment.id)
       end)
 
-      assert {:error, _} = CMS.pin_comment(comment.id)
+      assert {:error, {:comment_pin_limit, @pinned_comment_limit}} = CMS.pin_comment(comment.id)
     end
   end
 

--- a/backend/main/test/groupher_server/cms/comments/changelog_comment_replies_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/changelog_comment_replies_test.exs
@@ -167,10 +167,10 @@ defmodule GroupherServer.Test.CMS.Comments.ChangelogCommentReplies do
       assert total_reply_count == paged_replies.total_count
       assert is_valid_pagination?(paged_replies, :raw)
 
-      assert exist_in?(Enum.at(reply_comment_list, 0), paged_replies.entries)
-      # assert exist_in?(Enum.at(reply_comment_list, 1), paged_replies.entries)
-      assert exist_in?(Enum.at(reply_comment_list, 2), paged_replies.entries)
-      assert exist_in?(Enum.at(reply_comment_list, 3), paged_replies.entries)
+      reply_ids = reply_comment_list |> Enum.map(& &1.id) |> MapSet.new()
+
+      assert paged_replies.entries |> length == 20
+      assert Enum.all?(paged_replies.entries, &MapSet.member?(reply_ids, &1.id))
     end
 
     test "can get reply_to info of a parent comment", ~m(community changelog user)a do

--- a/backend/main/test/groupher_server/cms/comments/changelog_comment_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/changelog_comment_test.exs
@@ -447,7 +447,7 @@ defmodule GroupherServer.Test.CMS.Comments.ChangelogComment do
         {:ok, _} = CMS.pin_comment(comment.id)
       end)
 
-      assert {:error, _} = CMS.pin_comment(comment.id)
+      assert {:error, {:comment_pin_limit, @pinned_comment_limit}} = CMS.pin_comment(comment.id)
     end
   end
 

--- a/backend/main/test/groupher_server/cms/comments/doc_comment_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/doc_comment_test.exs
@@ -448,7 +448,7 @@ defmodule GroupherServer.Test.CMS.Comments.DocComment do
         {:ok, _} = CMS.pin_comment(comment.id)
       end)
 
-      assert {:error, _} = CMS.pin_comment(comment.id)
+      assert {:error, {:comment_pin_limit, @pinned_comment_limit}} = CMS.pin_comment(comment.id)
     end
   end
 

--- a/backend/main/test/groupher_server/cms/comments/fetcher_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/fetcher_test.exs
@@ -33,8 +33,7 @@ defmodule GroupherServer.Test.CMS.Comments.FetcherTest do
     end
 
     test "fetch_full_comment returns not_exist tuple on missing comment" do
-      assert {:error, {:not_exist, reason}} = CMS.fetch_full_comment(9_999_999)
-      assert is_binary(reason)
+      assert {:error, :not_exist} = CMS.fetch_full_comment(9_999_999)
     end
   end
 end

--- a/backend/main/test/groupher_server/cms/comments/fetcher_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/fetcher_test.exs
@@ -1,0 +1,40 @@
+defmodule GroupherServer.Test.CMS.Comments.FetcherTest do
+  @moduledoc false
+
+  use GroupherServer.TestTools
+
+  setup do
+    {community, post, _, user} = mock_article(:post, preload: [author: :user])
+    {:ok, ~m(community post user)a}
+  end
+
+  describe "[comment fetcher]" do
+    test "fetch_comment returns comment", ~m(community post user)a do
+      {:ok, comment} =
+        CMS.create_comment(community, :post, post.inner_id, mock_comment(), user)
+
+      assert {:ok, fetched} = CMS.fetch_comment(comment.id)
+      assert fetched.id == comment.id
+    end
+
+    test "fetch_comment returns not_exist tuple on missing comment" do
+      assert {:error, {:not_exist, reason}} = CMS.fetch_comment(9_999_999)
+      assert is_binary(reason)
+    end
+
+    test "fetch_full_comment returns article info", ~m(community post user)a do
+      {:ok, comment} =
+        CMS.create_comment(community, :post, post.inner_id, mock_comment(), user)
+
+      assert {:ok, info} = CMS.fetch_full_comment(comment.id)
+      assert info.thread == :post
+      assert info.article.id == post.id
+      assert info.author.id == user.id
+    end
+
+    test "fetch_full_comment returns not_exist tuple on missing comment" do
+      assert {:error, {:not_exist, reason}} = CMS.fetch_full_comment(9_999_999)
+      assert is_binary(reason)
+    end
+  end
+end

--- a/backend/main/test/groupher_server/cms/comments/post_comment_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/post_comment_test.exs
@@ -460,7 +460,7 @@ defmodule GroupherServer.Test.CMS.Comments.PostComment do
         {:ok, _} = CMS.pin_comment(comment.id)
       end)
 
-      assert {:error, _} = CMS.pin_comment(comment.id)
+      assert {:error, {:comment_pin_limit, @pinned_comment_limit}} = CMS.pin_comment(comment.id)
     end
   end
 

--- a/backend/main/test/groupher_server/payment/billing_test.exs
+++ b/backend/main/test/groupher_server/payment/billing_test.exs
@@ -35,7 +35,7 @@ defmodule GroupherServer.Test.Payment do
     test "create bill record with previous record unhandled fails", ~m(user valid_attrs)a do
       {:ok, _record} = Payment.create_record(user, valid_attrs)
       {:error, reason} = Payment.create_record(user, valid_attrs)
-      assert reason |> Keyword.get(:code) == ecode(:exist_pending_bill)
+      assert error_code(reason) == ecode(:exist_pending_bill)
     end
 
     test "record state can be update", ~m(user valid_attrs)a do

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/doc_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/doc_test.exs
@@ -210,8 +210,10 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :doc), variables)
 
       assert result["articleTags"] |> length == 2
-      assert result["articleTags"] |> List.first() |> get_in(["id"]) == to_string(article_tag.id)
-      assert result["articleTags"] |> List.last() |> get_in(["id"]) == to_string(article_tag2.id)
+
+      assert result["articleTags"]
+             |> Enum.map(&get_in(&1, ["id"]))
+             |> Enum.sort() == Enum.sort([to_string(article_tag.id), to_string(article_tag2.id)])
 
       variables = %{
         id: doc.inner_id,
@@ -222,8 +224,10 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :doc), variables)
 
       assert result["articleTags"] |> length == 2
-      assert result["articleTags"] |> List.first() |> get_in(["id"]) == to_string(article_tag2.id)
-      assert result["articleTags"] |> List.last() |> get_in(["id"]) == to_string(article_tag3.id)
+
+      assert result["articleTags"]
+             |> Enum.map(&get_in(&1, ["id"]))
+             |> Enum.sort() == Enum.sort([to_string(article_tag2.id), to_string(article_tag3.id)])
     end
 
     test "update doc with valid attrs should have is_edited meta info update",

--- a/backend/main/test/helper/gq_error_test.exs
+++ b/backend/main/test/helper/gq_error_test.exs
@@ -1,0 +1,30 @@
+defmodule GroupherServer.Test.Helper.GQLErrorTest do
+  @moduledoc false
+
+  use GroupherServerWeb.ConnCase, async: true
+
+  alias Helper.GQLError
+  import Helper.ErrorCode, only: [ecode: 1]
+
+  describe "encode/1" do
+    test "encodes atom reason" do
+      code = ecode(:not_exist)
+
+      assert {:error, [message: "not_exist", code: ^code]} = GQLError.encode(:not_exist)
+    end
+
+    test "encodes reason with binary meta" do
+      message = "max 3 pinned comments"
+      code = ecode(:comment_pin_limit)
+
+      assert {:error, [message: ^message, code: ^code]} =
+               GQLError.encode({:comment_pin_limit, message})
+    end
+
+    test "raises for unknown reason in test env" do
+      assert_raise ArgumentError, ~r/unknown error reason/, fn ->
+        GQLError.encode(:unknown_reason_for_test)
+      end
+    end
+  end
+end

--- a/backend/main/test/helper/gql_test.exs
+++ b/backend/main/test/helper/gql_test.exs
@@ -1,0 +1,24 @@
+defmodule GroupherServer.Test.Helper.GQLTest do
+  @moduledoc false
+
+  use GroupherServerWeb.ConnCase, async: true
+
+  alias Helper.GQL
+  import Helper.ErrorCode, only: [ecode: 1]
+
+  describe "result/1" do
+    test "passes through ok" do
+      assert {:ok, :pass} = GQL.result({:ok, :pass})
+    end
+
+    test "encodes domain error" do
+      code = ecode(:not_exist)
+      assert {:error, [message: "not_exist", code: ^code]} = GQL.result({:error, :not_exist})
+    end
+
+    test "passes through graphQL error" do
+      assert {:error, [message: "oops", code: 4001]} =
+               GQL.result({:error, [message: "oops", code: 4001]})
+    end
+  end
+end

--- a/backend/main/test/helper/orm_test.exs
+++ b/backend/main/test/helper/orm_test.exs
@@ -126,7 +126,7 @@ defmodule GroupherServer.Test.Helper.ORM do
     test "should have error code if not found", ~m(community)a do
       {:error, reason} = ORM.find_article(community.slug, :post, 3845)
 
-      assert reason |> Keyword.get(:code) == ecode(:article_not_found)
+      assert error_code(reason) == ecode(:article_not_found)
     end
   end
 


### PR DESCRIPTION
### Motivation

- Centralize comment-fetching logic into a reusable delegate so callers use a single domain-style API (`fetch_comment/1`, `fetch_full_comment/1`) exposed at the `CMS` boundary for future expansion. 
- Standardize domain→GraphQL error formatting so domain errors can be returned from resolvers in a consistent GraphQL shape. 
- Make pin/unpin flows return explicit domain errors (including the pin-limit case) so callers and GraphQL middleware can handle them uniformly.

### Description

- Renamed `GroupherServer.CMS.Delegate.CommentFetcher` to `GroupherServer.CMS.Delegate.Fetcher` and updated `CMS` to `defdelegate fetch_comment/1` and `defdelegate fetch_full_comment/1` to `Fetcher`. 
- Implemented `fetch_comment/1` and `fetch_full_comment/1` in `cms/delegates/fetcher.ex` to return `{:ok, _}` or `{:error, {:not_exist, reason}}`, and updated `CommentAction` to call `CMS.fetch_*` and use a new `pin_context/1` helper. 
- Changed pin logic to return the domain error `{:comment_pin_limit, limit}` when the pinned-comment quota is exceeded and added corresponding `Helper.ErrorCode.ecode/1` entry for `:comment_pin_limit`. 
- Added GraphQL helpers `Helper.GQLError` and `Helper.GQL`, expanded `Helper.Types` to include domain and GraphQL result types, and added `GroupherServerWeb.Middleware.GQLResultFmt` to convert domain errors into GraphQL error shape, and wired it into the schema middleware stack. 
- Introduced schema helper macros `schema_artiment_type/1` and `schema_base_type/1` and updated models (`Comment`, `PinnedComment`) to use them and added basic `@spec` annotations. 
- Updated legacy `GeneralError` middleware behavior to better handle string/list legacy errors. 
- Added/renamed tests: `test/groupher_server/cms/comments/fetcher_test.exs`, `test/helper/gq_error_test.exs`, and `test/helper/gql_test.exs`, and updated pinned-comment tests to assert the new pin-limit error tuple.

### Testing

- Attempted to run `mix test test/groupher_server/cms/comments/fetcher_test.exs` in this environment, but the run failed due to Hex/SCM dependency resolution (Mix requested external dependency fetch), so tests could not be executed here. 
- New tests added: `fetcher_test.exs`, `gq_error_test.exs`, and `gql_test.exs`, but their execution is blocked in this environment for the same dependency fetch limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a725c96448325ba5ca790b662a781)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized comment fetching in CMS.Fetcher and standardized domain→GraphQL error handling with new helpers and middleware. Pin/unpin now return structured domain results (including pin-limit), with broader error normalization and added tests for Fetcher and GraphQL helpers.

- New Features
  - Added Helper.GQLError and Helper.GQL to encode domain errors into Absinthe [message, code]; introduced GQLResultFmt middleware and placed it before GeneralError/ChangesetErrors.
  - New CMS.Delegate.Fetcher with CMS.fetch_comment/1 and CMS.fetch_full_comment/1 (and generic fetch/2,/3) returning {:ok, _} or {:error, {:not_exist, reason}}.
  - Pinning returns {:comment_pin_limit, limit} with a defined ErrorCode; unknown reasons raise in dev/test.

- Refactors
  - Normalized errors across ORM/Utils and modules (e.g., Document, Hooks, CitedArtiment) to domain tuples like {:not_exist, reason} and {:custom, msg}; GeneralError now formats legacy string/list and tuple errors.
  - Added schema type macros and expanded @specs across delegates/models; updated tests and assertions to the new error shape, and added missing tests for Fetcher, GQLError.encode/1, and GQL.result/1.

<sup>Written for commit c9ccca7d460ec8b03a9f4e59a0daf712493c1b42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Undo comment pinning.
  * Endpoints to fetch comment details and full comment context.

* **Bug Fixes**
  * Pinning beyond per-article limit returns a specific, consistent error/code.
  * Improved GraphQL error formatting and middleware ordering for clearer client errors.
  * Standardized error shapes and added a pin-limit error code.

* **Tests**
  * Added tests for comment fetching and error encoding/formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->