### PR TITLE
refactor(fe): extract common store creator

### DIFF
--- a/frontend/core/containers/thread/DashboardThread/logic/useBaseInfo/useMediaReports.ts
+++ b/frontend/core/containers/thread/DashboardThread/logic/useBaseInfo/useMediaReports.ts
@@ -48,7 +48,6 @@ export default (): TRet => {
     const restReports = reject((item: TMediaReport) => item.index === index, mediaReports)
     const report = find((item: TMediaReport) => item.index === index, mediaReports)
 
-    // @ts-expect-error
     report.editUrl = url
 
     dsb$.commit({ mediaReports: [...restReports, report] })

--- a/frontend/core/stores/account/hooks.tsx
+++ b/frontend/core/stores/account/hooks.tsx
@@ -1,19 +1,16 @@
 'use client'
 
-import { useContext, useEffect } from 'react'
-import { useSnapshot } from 'valtio'
-
+import { useEffect } from 'react'
 import useQuery from '~/hooks/useQuery'
 import { P } from '~/schemas'
+import createStoreHook from '../createStoreHook'
 import { StoreContext } from './provider'
 
-export default () => {
-  const store = useContext(StoreContext)
-  if (!store) {
-    throw new Error('useStore must be used within a Account store provider')
-  }
+const useBaseStore = createStoreHook(StoreContext)
 
-  const snap = useSnapshot(store)
+export default () => {
+  const storeHook = useBaseStore()
+  const store = storeHook.live$
 
   const { data, loading, error } = useQuery(P.me, {})
 
@@ -30,8 +27,5 @@ export default () => {
     }
   }, [loading, error, data, store])
 
-  return {
-    ...snap,
-    live$: store,
-  }
+  return storeHook
 }

--- a/frontend/core/stores/account/provider.tsx
+++ b/frontend/core/stores/account/provider.tsx
@@ -9,6 +9,7 @@ type TProps = {
 }
 
 export const StoreContext = createContext<TStore | null>(null)
+StoreContext.displayName = 'Account'
 
 export default ({ children }: TProps) => {
   const storeRef = useRef<TStore | null>(null)

--- a/frontend/core/stores/article/hooks.tsx
+++ b/frontend/core/stores/article/hooks.tsx
@@ -1,21 +1,6 @@
 'use client'
 
-import { useContext } from 'react'
-import { useSnapshot } from 'valtio'
-
+import createStoreHook from '../createStoreHook'
 import { StoreContext } from './provider'
 
-export default () => {
-  const store = useContext(StoreContext)
-  if (!store) {
-    throw new Error('useStore must be used within a Article store provider')
-  }
-
-  const snap = useSnapshot(store)
-
-  return {
-    ...snap,
-    commit: store.commit,
-    live$: store,
-  }
-}
+export default createStoreHook(StoreContext)

--- a/frontend/core/stores/article/provider.tsx
+++ b/frontend/core/stores/article/provider.tsx
@@ -10,6 +10,7 @@ type TProps = {
 }
 
 export const StoreContext = createContext<TStore | null>(null)
+StoreContext.displayName = 'Article'
 
 export default ({ children, initData }: TProps) => {
   const storeRef = useRef<TStore | null>(null)

--- a/frontend/core/stores/articleList/hooks.tsx
+++ b/frontend/core/stores/articleList/hooks.tsx
@@ -1,22 +1,9 @@
 'use client'
 
-import { useContext } from 'react'
-import { useSnapshot } from 'valtio'
-
+import createStoreHook from '../createStoreHook'
 import { StoreContext } from './provider'
 
-export default () => {
-  const store = useContext(StoreContext)
-  if (!store) {
-    throw new Error('useStore must be used within a ArticleList store provider')
-  }
-
-  const snap = useSnapshot(store)
-
-  return {
-    ...snap,
-    commit: store.commit,
-    updateActiveFilter: store.updateActiveFilter,
-    live$: store,
-  }
-}
+export default createStoreHook(StoreContext, [
+  'commit',
+  'updateActiveFilter',
+])

--- a/frontend/core/stores/articleList/provider.tsx
+++ b/frontend/core/stores/articleList/provider.tsx
@@ -10,6 +10,7 @@ type TProps = {
 }
 
 export const StoreContext = createContext<TStore | null>(null)
+StoreContext.displayName = 'ArticleList'
 
 export default ({ children, initData }: TProps) => {
   const storeRef = useRef<TStore | null>(null)

--- a/frontend/core/stores/community/hooks.tsx
+++ b/frontend/core/stores/community/hooks.tsx
@@ -1,21 +1,6 @@
 'use client'
 
-import { useContext } from 'react'
-import { useSnapshot } from 'valtio'
-
+import createStoreHook from '../createStoreHook'
 import { StoreContext } from './provider'
 
-export default () => {
-  const store = useContext(StoreContext)
-  if (!store) {
-    throw new Error('useStore must be used within a Community store provider')
-  }
-
-  const snap = useSnapshot(store)
-
-  return {
-    ...snap,
-    commit: store.commit,
-    live$: store,
-  }
-}
+export default createStoreHook(StoreContext)

--- a/frontend/core/stores/community/provider.tsx
+++ b/frontend/core/stores/community/provider.tsx
@@ -10,6 +10,7 @@ type TProps = {
 }
 
 export const StoreContext = createContext<TStore | null>(null)
+StoreContext.displayName = 'Community'
 
 export default ({ children, initData }: TProps) => {
   const storeRef = useRef<TStore | null>(null)

--- a/frontend/core/stores/createStoreHook.tsx
+++ b/frontend/core/stores/createStoreHook.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import type { Context } from 'react'
+import { useContext } from 'react'
+import { useSnapshot } from 'valtio'
+
+type TObject = Record<string, unknown>
+
+const createStoreHook = <TStore extends TObject, TSnap extends TObject = TStore>(
+  StoreContext: Context<TStore | null>,
+  expose?: Array<keyof TStore>,
+) => {
+  const resolvedExpose = expose ?? (['commit'] as Array<keyof TStore>)
+  const storeName = StoreContext.displayName ?? 'Store'
+  const errorMessage = `useStore must be used within a ${storeName} store provider`
+
+  return () => {
+    const store = useContext(StoreContext)
+    if (!store) {
+      throw new Error(errorMessage)
+    }
+
+    const snap = useSnapshot(store) as TSnap
+    const base = snap as TObject
+    const extra = resolvedExpose.reduce<TObject>((acc, key) => {
+      if (key in store) {
+        acc[key as string] = store[key]
+      }
+      return acc
+    }, {})
+
+    return Object.assign({}, base, extra, {
+      live$: store,
+    }) as TSnap & Partial<TStore> & { live$: TStore }
+  }
+}
+
+export default createStoreHook

--- a/frontend/core/stores/dashboard/hooks.tsx
+++ b/frontend/core/stores/dashboard/hooks.tsx
@@ -1,21 +1,6 @@
 'use client'
 
-import { useContext } from 'react'
-import { useSnapshot } from 'valtio'
-
+import createStoreHook from '../createStoreHook'
 import { StoreContext } from './provider'
 
-export default () => {
-  const store = useContext(StoreContext)
-  if (!store) {
-    throw new Error('useStore must be used within a Dashboard store provider')
-  }
-
-  const snap = useSnapshot(store)
-
-  return {
-    ...snap,
-    commit: store.commit,
-    live$: store,
-  }
-}
+export default createStoreHook(StoreContext)

--- a/frontend/core/stores/dashboard/provider.tsx
+++ b/frontend/core/stores/dashboard/provider.tsx
@@ -19,6 +19,7 @@ type TProps = {
 }
 
 export const StoreContext = createContext<TStore | null>(null)
+StoreContext.displayName = 'Dashboard'
 
 export default ({ children, initData }: TProps) => {
   const storeRef = useRef<TStore | null>(null)

--- a/frontend/core/stores/locale/hooks.tsx
+++ b/frontend/core/stores/locale/hooks.tsx
@@ -1,22 +1,9 @@
 'use client'
 
-import { useContext } from 'react'
-import { useSnapshot } from 'valtio'
-
+import createStoreHook from '../createStoreHook'
 import { StoreContext } from './provider'
 
-export default () => {
-  const store = useContext(StoreContext)
-  if (!store) {
-    throw new Error('useStore must be used within a Locale store provider')
-  }
-
-  const snap = useSnapshot(store)
-
-  return {
-    ...snap,
-    setLocale: store.setLocale,
-    setLocaleData: store.setLocaleData,
-    live$: store,
-  }
-}
+export default createStoreHook(StoreContext, [
+  'setLocale',
+  'setLocaleData',
+])

--- a/frontend/core/stores/locale/provider.tsx
+++ b/frontend/core/stores/locale/provider.tsx
@@ -10,6 +10,7 @@ type TProps = {
 }
 
 export const StoreContext = createContext<TStore | null>(null)
+StoreContext.displayName = 'Locale'
 
 export default ({ children, initData }: TProps) => {
   const storeRef = useRef<TStore | null>(null)

--- a/frontend/core/stores/theme/hooks.tsx
+++ b/frontend/core/stores/theme/hooks.tsx
@@ -1,22 +1,6 @@
 'use client'
 
-import { useContext } from 'react'
-import { useSnapshot } from 'valtio'
-
+import createStoreHook from '../createStoreHook'
 import { StoreContext } from './provider'
 
-export default () => {
-  const store = useContext(StoreContext)
-  if (!store) {
-    throw new Error('useStore must be used within a Theme store provider')
-  }
-
-  const snap = useSnapshot(store)
-
-  return {
-    ...snap,
-    change: store.change,
-    changeMode: store.changeMode,
-    live$: store,
-  }
-}
+export default createStoreHook(StoreContext, ['change', 'changeMode'])

--- a/frontend/core/stores/theme/provider.tsx
+++ b/frontend/core/stores/theme/provider.tsx
@@ -10,6 +10,7 @@ type TProps = {
 }
 
 export const StoreContext = createContext<TStore | null>(null)
+StoreContext.displayName = 'Theme'
 
 export default ({ children, initData }: TProps) => {
   const storeRef = useRef<TStore | null>(null)

--- a/frontend/core/stores/wallpaper/hooks.tsx
+++ b/frontend/core/stores/wallpaper/hooks.tsx
@@ -1,21 +1,6 @@
 'use client'
 
-import { useContext } from 'react'
-import { useSnapshot } from 'valtio'
-
+import createStoreHook from '../createStoreHook'
 import { StoreContext } from './provider'
 
-export default () => {
-  const store = useContext(StoreContext)
-  if (!store) {
-    throw new Error('useStore must be used within a Wallpaper store provider')
-  }
-
-  const snap = useSnapshot(store)
-
-  return {
-    ...snap,
-    commit: store.commit,
-    live$: store,
-  }
-}
+export default createStoreHook(StoreContext)

--- a/frontend/core/stores/wallpaper/provider.tsx
+++ b/frontend/core/stores/wallpaper/provider.tsx
@@ -10,6 +10,7 @@ type TProps = {
 }
 
 export const StoreContext = createContext<TStore | null>(null)
+StoreContext.displayName = 'Wallpaper'
 
 export default ({ children, initData }: TProps) => {
   const storeRef = useRef<TStore | null>(null)

--- a/frontend/core/widgets/Buttons/SubmitButton.tsx
+++ b/frontend/core/widgets/Buttons/SubmitButton.tsx
@@ -1,12 +1,9 @@
 import { type FC, memo } from 'react'
-
-import type { TSubmitState } from '~/spec'
-
 import CheckedSVG from '~/icons/Checked'
-
-import YesOrNoButtons from './YesOrNoButtons'
+import type { TSubmitState } from '~/spec'
 import Button from './Button'
 import useSalon from './salon/submit_button'
+import YesOrNoButtons from './YesOrNoButtons'
 
 const space = 22
 
@@ -33,7 +30,7 @@ const TheButton: FC<TProps> = ({
   return withCancel ? (
     <YesOrNoButtons
       cancelText={cancelText}
-      confirmText={okText}
+      saveText={okText}
       onConfirm={onPublish}
       loading={publishing}
       disabled={!isReady}
@@ -43,7 +40,7 @@ const TheButton: FC<TProps> = ({
     <Button
       loading={publishing}
       onClick={() => onPublish()}
-      size="small"
+      size='small'
       space={space}
       disabled={!isReady}
     >
@@ -72,7 +69,7 @@ const SubmitButton: FC<TProps> = ({
 
   if (mode === 'update' && !isArticleAuthor) {
     return (
-      <Button size="small" disabled space={space}>
+      <Button size='small' disabled space={space}>
         无权限
       </Button>
     )
@@ -80,7 +77,7 @@ const SubmitButton: FC<TProps> = ({
 
   if (isArchived) {
     return (
-      <Button size="small" disabled space={space}>
+      <Button size='small' disabled space={space}>
         已存档
       </Button>
     )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extracted a shared store hook to remove duplicate logic across frontend stores and standardize their APIs. Also cleaned up typings and a button prop for minor UI correctness.

- **Refactors**
  - Added createStoreHook to generate consistent store hooks with snapshot, selected actions, and live$.
  - Replaced custom hooks in Account, Article, ArticleList, Community, Dashboard, Locale, Theme, and Wallpaper with createStoreHook.
  - Set StoreContext.displayName on providers to improve error messages and debugging.

- **Bug Fixes**
  - Updated SubmitButton to pass saveText to YesOrNoButtons to show the correct label.
  - Removed a ts-expect-error in useMediaReports; typing now aligns with editUrl assignment.

<sup>Written for commit 55f2babc176be0f58969b961ede106ffa8325fb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  - Consolidated state management patterns across stores for improved code organization and maintainability

* **Chores**
  - Enhanced developer experience with improved debugging support
  - Updated button labels for clarity
  - Internal code cleanup and optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->