### PR TITLE
refactor(be): use front-desk as middle layer

### DIFF
--- a/backend/main/config/test.exs
+++ b/backend/main/config/test.exs
@@ -23,8 +23,6 @@ config :groupher_server, GroupherServer.Repo,
   pool_size: 20,
   # 设置查询超时时间为 60 秒
   timeout: 60_000,
-  # 设置从连接池获取连接的超时时间为 10 秒
-  pool_timeout: 10_000,
   # 设置连接所有权超时时间为 60 秒
   ownership_timeout: 60_000,
   # 设置队列目标为 5000

--- a/backend/main/lib/groupher_server/cms/abuse_reports.ex
+++ b/backend/main/lib/groupher_server/cms/abuse_reports.ex
@@ -3,10 +3,10 @@ defmodule GroupherServer.CMS.AbuseReports do
   CMS abuse reports facade.
   """
 
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
   alias CMS.Model.Comment
+  alias Helper.Types, as: T
 
   alias __MODULE__.{List, Report}
 

--- a/backend/main/lib/groupher_server/cms/abuse_reports.ex
+++ b/backend/main/lib/groupher_server/cms/abuse_reports.ex
@@ -4,8 +4,9 @@ defmodule GroupherServer.CMS.AbuseReports do
   """
 
   alias Helper.Types, as: T
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.Comment
+  alias GroupherServer.{Accounts, CMS}
+  alias Accounts.Model.User
+  alias CMS.Model.Comment
 
   alias __MODULE__.{List, Report}
 

--- a/backend/main/lib/groupher_server/cms/abuse_reports/list.ex
+++ b/backend/main/lib/groupher_server/cms/abuse_reports/list.ex
@@ -8,8 +8,8 @@ defmodule GroupherServer.CMS.AbuseReports.List do
 
   alias Helper.{ORM, QueryBuilder}
   alias Helper.Types, as: T
-
-  alias GroupherServer.CMS.Model.{AbuseReport, Comment}
+  alias GroupherServer.CMS
+  alias CMS.Model.{AbuseReport, Comment}
 
   import Helper.Utils, only: [done: 1, get_config: 2]
 

--- a/backend/main/lib/groupher_server/cms/abuse_reports/list.ex
+++ b/backend/main/lib/groupher_server/cms/abuse_reports/list.ex
@@ -6,10 +6,10 @@ defmodule GroupherServer.CMS.AbuseReports.List do
   import GroupherServer.CMS.Helper.Matcher
   import ShortMaps
 
-  alias Helper.{ORM, QueryBuilder}
-  alias Helper.Types, as: T
   alias GroupherServer.CMS
   alias CMS.Model.{AbuseReport, Comment}
+  alias Helper.Types, as: T
+  alias Helper.{ORM, QueryBuilder}
 
   import Helper.Utils, only: [done: 1, get_config: 2]
 

--- a/backend/main/lib/groupher_server/cms/abuse_reports/report.ex
+++ b/backend/main/lib/groupher_server/cms/abuse_reports/report.ex
@@ -6,10 +6,10 @@ defmodule GroupherServer.CMS.AbuseReports.Report do
   import Helper.Utils, only: [done: 1, strip_struct: 1]
   import GroupherServer.CMS.Helper.Matcher
 
-  alias Helper.{ORM, Transaction}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias CMS.FrontDesk
+  alias Helper.Types, as: T
+  alias Helper.{ORM, Transaction}
 
   alias Accounts.Model.User
   alias CMS.Model.{AbuseReport, Comment, Embeds}

--- a/backend/main/lib/groupher_server/cms/abuse_reports/report.ex
+++ b/backend/main/lib/groupher_server/cms/abuse_reports/report.ex
@@ -4,12 +4,12 @@ defmodule GroupherServer.CMS.AbuseReports.Report do
   """
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1, strip_struct: 1]
-  import GroupherServer.CMS.FrontDesk, only: [sync_embed_replies: 1, thread_of: 1]
   import GroupherServer.CMS.Helper.Matcher
 
   alias Helper.{ORM, Transaction}
   alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
+  alias CMS.FrontDesk
 
   alias Accounts.Model.User
   alias CMS.Model.{AbuseReport, Comment, Embeds}
@@ -59,7 +59,7 @@ defmodule GroupherServer.CMS.AbuseReports.Report do
     Transaction.locking(target_article, fn article ->
       Multi.new()
       |> Multi.run(:create_abuse_report, fn _, _ ->
-        {:ok, thread} = thread_of(article)
+        {:ok, thread} = FrontDesk.thread_of(article)
         create_report(thread, article.id, reason, attr, user)
       end)
       |> Multi.run(:update_report_meta, fn _, _ ->
@@ -72,7 +72,7 @@ defmodule GroupherServer.CMS.AbuseReports.Report do
 
   @spec undo_article(T.article(), User.t()) :: T.domain_res(T.article())
   def undo_article(target_article, %User{} = user) do
-    {:ok, thread} = thread_of(target_article)
+    {:ok, thread} = FrontDesk.thread_of(target_article)
     {:ok, info} = match(thread)
 
     Transaction.locking(target_article, fn article ->
@@ -105,7 +105,7 @@ defmodule GroupherServer.CMS.AbuseReports.Report do
           else: {:ok, comment}
       end)
       |> Multi.run(:sync_embed_replies, fn _, %{update_report_meta: comment} ->
-        sync_embed_replies(comment)
+        FrontDesk.sync_embed_replies(comment)
       end)
       |> Repo.transaction()
       |> result()

--- a/backend/main/lib/groupher_server/cms/articles.ex
+++ b/backend/main/lib/groupher_server/cms/articles.ex
@@ -3,26 +3,36 @@ defmodule GroupherServer.CMS.Articles do
   CMS articles facade.
   """
 
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS}
+  alias Helper.Types, as: T
 
   alias Accounts.Model.User
-  alias CMS.Model.{ArticleCollect, Community}
   alias CMS.Helper.ArticleEnums
+  alias CMS.Model.{ArticleCollect, Community}
 
   alias __MODULE__.{
-    Read,
-    List,
-    Write,
-    Lifecycle,
-    Meta,
-    Moderation,
-    Placement,
-    Reactions,
-    Upvotes,
-    Collects
-  }
 
+    Collects,
+
+    Lifecycle,
+
+    List,
+
+    Meta,
+
+    Moderation,
+
+    Placement,
+
+    Reactions,
+
+    Read,
+
+    Upvotes,
+
+    Write
+
+  }
   # Read
   @spec read(String.t(), T.article_thread(), T.id()) :: T.domain_res(T.article())
   def read(community_slug, thread, inner_id), do: Read.read(community_slug, thread, inner_id)

--- a/backend/main/lib/groupher_server/cms/articles/collects.ex
+++ b/backend/main/lib/groupher_server/cms/articles/collects.ex
@@ -5,23 +5,18 @@ defmodule GroupherServer.CMS.Articles.Collects do
 
   import GroupherServer.CMS.Helper.Matcher
   import Helper.Utils, only: [done: 1]
-  import GroupherServer.CMS.FrontDesk,
-    only: [
-      thread_of: 2,
-      load_reaction_users: 3,
-      update_article_reaction_user_list: 4
-    ]
 
   alias Ecto.Multi
   alias Helper.{ORM, Later, Transaction}
   alias Helper.Types, as: T
-  alias GroupherServer.{Accounts, Repo}
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.ArticleCollect
-  alias GroupherServer.CMS.Events
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias Accounts.Model.User
+  alias CMS.Model.ArticleCollect
+  alias CMS.{FrontDesk, Events}
 
   @spec collected_users(term(), map()) :: T.domain_res(term())
-  def collected_users(article, filter), do: load_reaction_users(ArticleCollect, article, filter)
+  def collected_users(article, filter),
+    do: FrontDesk.load_reaction_users(ArticleCollect, article, filter)
 
   @spec collect(term(), User.t()) :: T.domain_res(term())
   def collect(article, %User{} = user) do
@@ -36,10 +31,10 @@ defmodule GroupherServer.CMS.Articles.Collects do
         ORM.inc(article, :collects_count)
       end)
       |> Multi.run(:update_article_reaction_user_list, fn _, _ ->
-        update_article_reaction_user_list(:collect, article, user, :add)
+        FrontDesk.update_article_reaction_user_list(:collect, article, user, :add)
       end)
       |> Multi.run(:create_collect, fn _, _ ->
-        {:ok, thread} = thread_of(article, :upcase)
+        {:ok, thread} = FrontDesk.thread_of(article, :upcase)
         args = Map.put(%{user_id: user.id, thread: thread}, info.foreign_key, article.id)
 
         ORM.create(ArticleCollect, args)
@@ -113,7 +108,7 @@ defmodule GroupherServer.CMS.Articles.Collects do
   defp maybe_update_collect_user_list(nil, article, _user), do: {:ok, article}
 
   defp maybe_update_collect_user_list(_record, article, user) do
-    update_article_reaction_user_list(:collect, article, user, :remove)
+    FrontDesk.update_article_reaction_user_list(:collect, article, user, :remove)
   end
 
   defp maybe_undo_collect(nil, article, _info, _user_id), do: {:ok, article}
@@ -166,7 +161,7 @@ defmodule GroupherServer.CMS.Articles.Collects do
 
   defp collection_findby_args(article, user_id) do
     {:ok, info} = match(article)
-    {:ok, thread} = thread_of(article, :upcase)
+    {:ok, thread} = FrontDesk.thread_of(article, :upcase)
 
     %{thread: thread, user_id: user_id} |> Map.put(info.foreign_key, article.id)
   end

--- a/backend/main/lib/groupher_server/cms/articles/collects.ex
+++ b/backend/main/lib/groupher_server/cms/articles/collects.ex
@@ -6,13 +6,13 @@ defmodule GroupherServer.CMS.Articles.Collects do
   import GroupherServer.CMS.Helper.Matcher
   import Helper.Utils, only: [done: 1]
 
-  alias Ecto.Multi
-  alias Helper.{ORM, Later, Transaction}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
   alias CMS.Model.ArticleCollect
-  alias CMS.{FrontDesk, Events}
+  alias CMS.{Events, FrontDesk}
+  alias Ecto.Multi
+  alias Helper.Types, as: T
+  alias Helper.{Later, ORM, Transaction}
 
   @spec collected_users(term(), map()) :: T.domain_res(term())
   def collected_users(article, filter),

--- a/backend/main/lib/groupher_server/cms/articles/document.ex
+++ b/backend/main/lib/groupher_server/cms/articles/document.ex
@@ -4,9 +4,9 @@ defmodule GroupherServer.CMS.Articles.Document do
   """
   import Ecto.Query, warn: false
 
-  alias Helper.{ORM, Converter}
   alias GroupherServer.{CMS, Repo}
   alias CMS.FrontDesk
+  alias Helper.{Converter, ORM}
 
   alias CMS.Model.ArticleDocument
   alias Ecto.Multi

--- a/backend/main/lib/groupher_server/cms/articles/document.ex
+++ b/backend/main/lib/groupher_server/cms/articles/document.ex
@@ -3,10 +3,10 @@ defmodule GroupherServer.CMS.Articles.Document do
   CRUD operations for article documents.
   """
   import Ecto.Query, warn: false
-  import GroupherServer.CMS.FrontDesk, only: [thread_of: 2]
 
   alias Helper.{ORM, Converter}
   alias GroupherServer.{CMS, Repo}
+  alias CMS.FrontDesk
 
   alias CMS.Model.ArticleDocument
   alias Ecto.Multi
@@ -24,7 +24,7 @@ defmodule GroupherServer.CMS.Articles.Document do
 
   @spec create(map(), map()) :: document_result()
   def create(article, %{body: body}) do
-    with {:ok, article_thread} <- thread_of(article, :upcase),
+    with {:ok, article_thread} <- FrontDesk.thread_of(article, :upcase),
          false <- article_document_exist(article),
          {:ok, parsed} <- Converter.Article.parse_body(body) do
       attrs = Map.take(parsed, [:body, :body_html])
@@ -56,7 +56,7 @@ defmodule GroupherServer.CMS.Articles.Document do
   end
 
   defp article_document_exist(article) do
-    with {:ok, article_thread} <- thread_of(article, :upcase) do
+    with {:ok, article_thread} <- FrontDesk.thread_of(article, :upcase) do
       {:ok, count} =
         ArticleDocument
         |> where([ad], ad.thread == ^article_thread and ad.article_id == ^article.id)
@@ -71,7 +71,7 @@ defmodule GroupherServer.CMS.Articles.Document do
   """
   @spec update(map(), map()) :: document_result()
   def update(article, %{body: body}) when not is_nil(body) do
-    with {:ok, article_thread} <- thread_of(article, :upcase),
+    with {:ok, article_thread} <- FrontDesk.thread_of(article, :upcase),
          {:ok, article_doc} <- find_article_document(article_thread, article),
          {:ok, thread_doc} <- find_thread_document(article_thread, article),
          {:ok, parsed} <- Converter.Article.parse_body(body) do
@@ -93,7 +93,7 @@ defmodule GroupherServer.CMS.Articles.Document do
   end
 
   def update(article, %{title: _title} = attrs) do
-    with {:ok, article_thread} <- thread_of(article, :upcase),
+    with {:ok, article_thread} <- FrontDesk.thread_of(article, :upcase),
          {:ok, article_doc} <- find_article_document(article_thread, article) do
       article_doc |> ORM.update(%{title: attrs.title})
     end

--- a/backend/main/lib/groupher_server/cms/articles/lifecycle.ex
+++ b/backend/main/lib/groupher_server/cms/articles/lifecycle.ex
@@ -13,12 +13,12 @@ defmodule GroupherServer.CMS.Articles.Lifecycle do
       get_config: 2
     ]
 
-  alias Ecto.Multi
-  alias Helper.{ORM, Transaction}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
-  alias CMS.{FrontDesk, Communities}
   alias CMS.Articles.Document
+  alias CMS.{Communities, FrontDesk}
+  alias Ecto.Multi
+  alias Helper.Types, as: T
+  alias Helper.{ORM, Transaction}
 
   @active_period get_config(:article, :active_period_days)
   @archive_threshold get_config(:article, :archive_threshold)
@@ -120,12 +120,15 @@ defmodule GroupherServer.CMS.Articles.Lifecycle do
   def sink(article) do
     %{inserted_at: inserted_at} = article
 
-    with {:ok, article} <-
-           ORM.update_meta(article, %{
-             is_sunk: true,
-             last_active_at: inserted_at
-           }) do
-      ORM.update(article, %{active_at: inserted_at})
+    case ORM.update_meta(article, %{
+           is_sunk: true,
+           last_active_at: inserted_at
+         }) do
+      {:ok, article} ->
+        ORM.update(article, %{active_at: inserted_at})
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/backend/main/lib/groupher_server/cms/articles/lifecycle.ex
+++ b/backend/main/lib/groupher_server/cms/articles/lifecycle.ex
@@ -13,14 +13,12 @@ defmodule GroupherServer.CMS.Articles.Lifecycle do
       get_config: 2
     ]
 
-  import GroupherServer.CMS.FrontDesk, only: [thread_of: 1]
-
   alias Ecto.Multi
   alias Helper.{ORM, Transaction}
   alias Helper.Types, as: T
-  alias GroupherServer.{Accounts, Repo}
-  alias GroupherServer.CMS.Communities
-  alias GroupherServer.CMS.Articles.Document
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias CMS.{FrontDesk, Communities}
+  alias CMS.Articles.Document
 
   @active_period get_config(:article, :active_period_days)
   @archive_threshold get_config(:article, :archive_threshold)
@@ -28,7 +26,7 @@ defmodule GroupherServer.CMS.Articles.Lifecycle do
 
   @spec mark_delete(term()) :: T.domain_res(term())
   def mark_delete(article) do
-    {:ok, thread} = thread_of(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     Transaction.locking(article, fn article ->
       case article.is_archived do
@@ -51,7 +49,7 @@ defmodule GroupherServer.CMS.Articles.Lifecycle do
 
   @spec undo_mark_delete(term()) :: T.domain_res(term())
   def undo_mark_delete(article) do
-    {:ok, thread} = thread_of(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     Transaction.locking(article, fn article ->
       Multi.new()
@@ -84,7 +82,7 @@ defmodule GroupherServer.CMS.Articles.Lifecycle do
   @spec delete(term(), String.t()) :: T.domain_res(term())
   def delete(article, _reason) do
     article = Repo.preload(article, [:communities, [author: :user]])
-    {:ok, thread} = thread_of(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     Multi.new()
     |> Multi.run(:delete_article, fn _, _ ->
@@ -133,7 +131,7 @@ defmodule GroupherServer.CMS.Articles.Lifecycle do
 
   @spec undo_sink(term()) :: T.domain_res(term())
   def undo_sink(article) do
-    {:ok, thread} = thread_of(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     with true <- in_active_period?(thread, article),
          {:ok, article} <- ORM.update_meta(article, %{is_sunk: false}) do

--- a/backend/main/lib/groupher_server/cms/articles/list.ex
+++ b/backend/main/lib/groupher_server/cms/articles/list.ex
@@ -16,13 +16,13 @@ defmodule GroupherServer.CMS.Articles.List do
       to_upcase: 1
     ]
 
-  alias Helper.{ORM, QueryBuilder}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
   alias CMS.FrontDesk
-  alias CMS.Model.{CitedArtiment, Community, PinnedArticle, Post}
   alias CMS.Helper.ArticleEnums
+  alias CMS.Model.{CitedArtiment, Community, PinnedArticle, Post}
+  alias Helper.Types, as: T
+  alias Helper.{ORM, QueryBuilder}
 
   @article_threads get_config(:article, :threads)
   @article_preloads @article_threads |> Enum.map(&Keyword.new([{&1, [author: :user]}]))

--- a/backend/main/lib/groupher_server/cms/articles/list.ex
+++ b/backend/main/lib/groupher_server/cms/articles/list.ex
@@ -16,19 +16,13 @@ defmodule GroupherServer.CMS.Articles.List do
       to_upcase: 1
     ]
 
-  import GroupherServer.CMS.FrontDesk,
-    only: [
-      mark_viewer_emotion_states: 2,
-      thread_of: 1,
-      article_of: 1
-    ]
-
   alias Helper.{ORM, QueryBuilder}
   alias Helper.Types, as: T
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.Repo
-  alias GroupherServer.CMS.Model.{CitedArtiment, Community, PinnedArticle, Post}
-  alias GroupherServer.CMS.Helper.ArticleEnums
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias Accounts.Model.User
+  alias CMS.FrontDesk
+  alias CMS.Model.{CitedArtiment, Community, PinnedArticle, Post}
+  alias CMS.Helper.ArticleEnums
 
   @article_threads get_config(:article, :threads)
   @article_preloads @article_threads |> Enum.map(&Keyword.new([{&1, [author: :user]}]))
@@ -55,7 +49,7 @@ defmodule GroupherServer.CMS.Articles.List do
   def paged(thread, filter, %User{} = user) do
     with {:ok, stateless_paged_articles} <- paged(thread, filter) do
       case stateless_paged_articles
-           |> mark_viewer_emotion_states(user)
+           |> FrontDesk.mark_viewer_emotion_states(user)
            |> mark_viewer_has_states(user) do
         {:error, reason} -> {:error, reason}
         articles -> done(articles)
@@ -118,7 +112,7 @@ defmodule GroupherServer.CMS.Articles.List do
       |> select([article, author], article)
       |> QueryBuilder.filter_pack(filter)
       |> ORM.paginator(~m(page size)a)
-      |> mark_viewer_emotion_states(user)
+      |> FrontDesk.mark_viewer_emotion_states(user)
       |> mark_viewer_has_states(user)
       |> then(fn result ->
         case result do
@@ -151,8 +145,8 @@ defmodule GroupherServer.CMS.Articles.List do
   defp shape(%CitedArtiment{comment_id: comment_id} = cited) when not is_nil(comment_id) do
     %{block_linker: block_linker, comment: comment, inserted_at: inserted_at} = cited
 
-    {:ok, article} = article_of(comment)
-    {:ok, article_thread} = thread_of(article)
+    {:ok, article} = FrontDesk.article_of(comment)
+    {:ok, article_thread} = FrontDesk.thread_of(article)
 
     user = comment.author |> Map.take([:login, :nickname, :avatar])
 

--- a/backend/main/lib/groupher_server/cms/articles/meta.ex
+++ b/backend/main/lib/groupher_server/cms/articles/meta.ex
@@ -5,12 +5,12 @@ defmodule GroupherServer.CMS.Articles.Meta do
 
   import Helper.Utils, only: [get_config: 2, done: 1]
 
-  alias Helper.Types, as: T
-  alias Helper.ORM
   alias GroupherServer.CMS
   alias CMS.Comments.CRUD
-  alias CMS.Model.{Embeds, Post}
   alias CMS.Helper.ArticleEnums
+  alias CMS.Model.{Embeds, Post}
+  alias Helper.ORM
+  alias Helper.Types, as: T
 
   @active_period get_config(:article, :active_period_days)
   @article_cat ArticleEnums.cat_values() |> Enum.into(%{}, &{&1, &1})

--- a/backend/main/lib/groupher_server/cms/articles/meta.ex
+++ b/backend/main/lib/groupher_server/cms/articles/meta.ex
@@ -7,9 +7,10 @@ defmodule GroupherServer.CMS.Articles.Meta do
 
   alias Helper.Types, as: T
   alias Helper.ORM
-  alias GroupherServer.CMS.Comments.CRUD
-  alias GroupherServer.CMS.Model.{Embeds, Post}
-  alias GroupherServer.CMS.Helper.ArticleEnums
+  alias GroupherServer.CMS
+  alias CMS.Comments.CRUD
+  alias CMS.Model.{Embeds, Post}
+  alias CMS.Helper.ArticleEnums
 
   @active_period get_config(:article, :active_period_days)
   @article_cat ArticleEnums.cat_values() |> Enum.into(%{}, &{&1, &1})

--- a/backend/main/lib/groupher_server/cms/articles/moderation.ex
+++ b/backend/main/lib/groupher_server/cms/articles/moderation.ex
@@ -12,7 +12,9 @@ defmodule GroupherServer.CMS.Articles.Moderation do
   alias Ecto.Multi
   alias Helper.{ORM, Constant, QueryBuilder}
   alias Helper.Types, as: T
-  alias GroupherServer.{FrontDesk, Repo}
+  alias GroupherServer.{CMS, Repo}
+  alias CMS.FrontDesk
+  alias GroupherServer.FrontDesk, as: UserFrontDesk
 
   @audit_legal Constant.CMS.pending(:legal)
   @audit_illegal Constant.CMS.pending(:illegal)
@@ -39,7 +41,7 @@ defmodule GroupherServer.CMS.Articles.Moderation do
   @spec set_illegal(atom(), T.id(), map()) :: T.domain_res(term())
   def set_illegal(thread, id, audit_state) do
     with {:ok, info} <- match(thread),
-         {:ok, article} <- ORM.find(info.model, id) do
+         {:ok, article} <- FrontDesk.get(info.model, id) do
       set_illegal(article, audit_state)
     end
   end
@@ -58,7 +60,7 @@ defmodule GroupherServer.CMS.Articles.Moderation do
       article = Repo.preload(article, :author)
       illegal_articles = Map.get(audit_state, :illegal_articles, [])
 
-      with {:ok, user} <- FrontDesk.user(article.author.user_id) do
+      with {:ok, user} <- UserFrontDesk.user(article.author.user_id) do
         illegal_articles = user.meta.illegal_articles ++ illegal_articles
 
         ORM.update_meta(user, %{has_illegal_articles: true, illegal_articles: illegal_articles})
@@ -71,7 +73,7 @@ defmodule GroupherServer.CMS.Articles.Moderation do
   @spec unset_illegal(atom(), T.id(), map()) :: T.domain_res(term())
   def unset_illegal(thread, id, audit_state) do
     with {:ok, info} <- match(thread),
-         {:ok, article} <- ORM.find(info.model, id) do
+         {:ok, article} <- FrontDesk.get(info.model, id) do
       unset_illegal(article, audit_state)
     end
   end
@@ -91,7 +93,7 @@ defmodule GroupherServer.CMS.Articles.Moderation do
       article = Repo.preload(article, :author)
       illegal_articles = Map.get(audit_state, :illegal_articles, [])
 
-      with {:ok, user} <- FrontDesk.user(article.author.user_id) do
+      with {:ok, user} <- UserFrontDesk.user(article.author.user_id) do
         illegal_articles = user.meta.illegal_articles -- illegal_articles
         has_illegal_articles = not Enum.empty?(illegal_articles)
 

--- a/backend/main/lib/groupher_server/cms/articles/moderation.ex
+++ b/backend/main/lib/groupher_server/cms/articles/moderation.ex
@@ -9,12 +9,12 @@ defmodule GroupherServer.CMS.Articles.Moderation do
   import Helper.Utils, only: [done: 1]
   import ShortMaps
 
-  alias Ecto.Multi
-  alias Helper.{ORM, Constant, QueryBuilder}
-  alias Helper.Types, as: T
+  alias GroupherServer.FrontDesk, as: UserFrontDesk
   alias GroupherServer.{CMS, Repo}
   alias CMS.FrontDesk
-  alias GroupherServer.FrontDesk, as: UserFrontDesk
+  alias Ecto.Multi
+  alias Helper.Types, as: T
+  alias Helper.{Constant, ORM, QueryBuilder}
 
   @audit_legal Constant.CMS.pending(:legal)
   @audit_illegal Constant.CMS.pending(:illegal)

--- a/backend/main/lib/groupher_server/cms/articles/placement.ex
+++ b/backend/main/lib/groupher_server/cms/articles/placement.ex
@@ -7,20 +7,20 @@ defmodule GroupherServer.CMS.Articles.Placement do
   import Ecto.Query, warn: false
   import Helper.ErrorCode
   import Helper.Utils, only: [done: 1]
-  import GroupherServer.CMS.FrontDesk, only: [thread_of: 1]
 
   alias Ecto.Multi
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.Repo
-  alias GroupherServer.CMS.Model.{Community, PinnedArticle}
-  alias GroupherServer.CMS.Communities
+  alias GroupherServer.{CMS, Repo}
+  alias CMS.FrontDesk
+  alias CMS.Model.{Community, PinnedArticle}
+  alias CMS.Communities
 
   @max_pinned_article_count_per_thread Community.max_pinned_article_count_per_thread()
 
   @spec pin(Community.t(), T.article()) :: T.domain_res(T.article())
   def pin(%Community{} = community, article) do
-    with {:ok, thread} <- thread_of(article),
+    with {:ok, thread} <- FrontDesk.thread_of(article),
          args <- pack_pin_args(community, thread, article.id),
          {:ok, _} <- check_pinned_article_count(community, thread),
          {:ok, _} <- ORM.create(PinnedArticle, args) do
@@ -30,7 +30,7 @@ defmodule GroupherServer.CMS.Articles.Placement do
 
   @spec undo_pin(Community.t(), T.article()) :: T.domain_res(T.article())
   def undo_pin(%Community{} = community, article) do
-    with {:ok, thread} <- thread_of(article),
+    with {:ok, thread} <- FrontDesk.thread_of(article),
          args <- pack_pin_args(community, thread, article.id),
          {:ok, _} <- ORM.findby_delete(PinnedArticle, args) do
       {:ok, article}
@@ -42,7 +42,7 @@ defmodule GroupherServer.CMS.Articles.Placement do
   def mirror(%Community{} = target_community, article, community_tag_ids \\ []) do
     article = Repo.preload(article, :communities)
 
-    with {:ok, thread} <- thread_of(article) do
+    with {:ok, thread} <- FrontDesk.thread_of(article) do
       communities =
         (article.communities ++ [target_community])
         |> Enum.uniq_by(& &1.id)
@@ -91,7 +91,7 @@ defmodule GroupherServer.CMS.Articles.Placement do
   def move(%Community{} = target_community, article, community_tag_ids \\ []) do
     article = Repo.preload(article, [:communities, :community, :community_tags])
 
-    with {:ok, thread} <- thread_of(article) do
+    with {:ok, thread} <- FrontDesk.thread_of(article) do
       original_community = article.community
 
       Multi.new()
@@ -125,7 +125,7 @@ defmodule GroupherServer.CMS.Articles.Placement do
   def mirror_to_home(%Community{} = home_community, article, community_tag_ids \\ []) do
     article = Repo.preload(article, [:communities, :community_tags])
 
-    with {:ok, thread} <- thread_of(article) do
+    with {:ok, thread} <- FrontDesk.thread_of(article) do
       communities =
         (article.communities ++ [home_community])
         |> Enum.uniq_by(& &1.id)
@@ -152,7 +152,7 @@ defmodule GroupherServer.CMS.Articles.Placement do
   def move_to_blackhole(%Community{} = blackhole, article, community_tag_ids \\ []) do
     article = Repo.preload(article, [:communities, :community, :community_tags])
 
-    with {:ok, thread} <- thread_of(article) do
+    with {:ok, thread} <- FrontDesk.thread_of(article) do
       Multi.new()
       |> Multi.run(:set_community, fn _, _ ->
         article

--- a/backend/main/lib/groupher_server/cms/articles/placement.ex
+++ b/backend/main/lib/groupher_server/cms/articles/placement.ex
@@ -8,13 +8,13 @@ defmodule GroupherServer.CMS.Articles.Placement do
   import Helper.ErrorCode
   import Helper.Utils, only: [done: 1]
 
+  alias GroupherServer.{CMS, Repo}
+  alias CMS.Communities
+  alias CMS.FrontDesk
+  alias CMS.Model.{Community, PinnedArticle}
   alias Ecto.Multi
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.{CMS, Repo}
-  alias CMS.FrontDesk
-  alias CMS.Model.{Community, PinnedArticle}
-  alias CMS.Communities
 
   @max_pinned_article_count_per_thread Community.max_pinned_article_count_per_thread()
 

--- a/backend/main/lib/groupher_server/cms/articles/reactions.ex
+++ b/backend/main/lib/groupher_server/cms/articles/reactions.ex
@@ -5,14 +5,14 @@ defmodule GroupherServer.CMS.Articles.Reactions do
 
   import Ecto.Query, warn: false
   import GroupherServer.CMS.Helper.Matcher
-  import GroupherServer.CMS.FrontDesk, only: [thread_of: 1, update_emotions_field: 4]
 
   alias Ecto.Multi
   alias Helper.{Transaction, ORM}
   alias Helper.Types, as: T
-  alias GroupherServer.Repo
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.ArticleUserEmotion
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias Accounts.Model.User
+  alias CMS.FrontDesk
+  alias CMS.Model.ArticleUserEmotion
 
   import Ecto.Query
 
@@ -38,7 +38,7 @@ defmodule GroupherServer.CMS.Articles.Reactions do
         query_emotion_status(article, emotion)
       end)
       |> Multi.run(:update_emotions_field, fn _, %{query_emotion_status: status} ->
-        update_emotions_field(article, emotion, status, user)
+        FrontDesk.update_emotions_field(article, emotion, status, user)
       end)
       |> Repo.transaction()
       |> update_emotions_field_result()
@@ -69,7 +69,7 @@ defmodule GroupherServer.CMS.Articles.Reactions do
         query_emotion_status(article, emotion)
       end)
       |> Multi.run(:update_emotions_field, fn _, %{query_emotion_status: status} ->
-        update_emotions_field(article, emotion, status, user)
+        FrontDesk.update_emotions_field(article, emotion, status, user)
       end)
       |> Repo.transaction()
       |> update_emotions_field_result()
@@ -77,7 +77,7 @@ defmodule GroupherServer.CMS.Articles.Reactions do
   end
 
   defp query_emotion_status(article, emotion) do
-    with {:ok, thread} <- thread_of(article),
+    with {:ok, thread} <- FrontDesk.thread_of(article),
          {:ok, info} <- match(thread) do
       query =
         from(a in ArticleUserEmotion,
@@ -88,10 +88,10 @@ defmodule GroupherServer.CMS.Articles.Reactions do
           select: %{login: user.login, nickname: user.nickname, avatar: user.avatar}
         )
 
-      emotioned_user_info_list = Repo.all(query) |> Enum.uniq()
-      emotioned_user_count = length(emotioned_user_info_list)
+      mentioned_user_info_list = Repo.all(query) |> Enum.uniq()
+      mentioned_user_count = length(mentioned_user_info_list)
 
-      {:ok, %{user_list: emotioned_user_info_list, user_count: emotioned_user_count}}
+      {:ok, %{user_list: mentioned_user_info_list, user_count: mentioned_user_count}}
     end
   end
 

--- a/backend/main/lib/groupher_server/cms/articles/reactions.ex
+++ b/backend/main/lib/groupher_server/cms/articles/reactions.ex
@@ -6,13 +6,13 @@ defmodule GroupherServer.CMS.Articles.Reactions do
   import Ecto.Query, warn: false
   import GroupherServer.CMS.Helper.Matcher
 
-  alias Ecto.Multi
-  alias Helper.{Transaction, ORM}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
   alias CMS.FrontDesk
   alias CMS.Model.ArticleUserEmotion
+  alias Ecto.Multi
+  alias Helper.Types, as: T
+  alias Helper.{ORM, Transaction}
 
   import Ecto.Query
 

--- a/backend/main/lib/groupher_server/cms/articles/read.ex
+++ b/backend/main/lib/groupher_server/cms/articles/read.ex
@@ -13,12 +13,12 @@ defmodule GroupherServer.CMS.Articles.Read do
     ]
 
   alias Ecto.Multi
+  alias Helper.{Constant, ORM}
   alias Helper.Types, as: T
-  alias Helper.ORM
-  alias Helper.Constant
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.Repo
-  alias GroupherServer.CMS.Model.{Community, PinnedArticle}
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias Accounts.Model.User
+  alias CMS.FrontDesk
+  alias CMS.Model.{Community, PinnedArticle}
 
   @active_period get_config(:article, :active_period_days)
   @article_threads get_config(:article, :threads)
@@ -112,7 +112,7 @@ defmodule GroupherServer.CMS.Articles.Read do
 
   defp if_article_legal(thread, id, %User{} = user) when thread in @article_threads do
     with {:ok, info} <- match(thread),
-         {:ok, article} <- ORM.find(info.model, id, preload: :author) do
+         {:ok, article} <- FrontDesk.get(info.model, id, preload: :author) do
       if_article_legal(article, user)
     end
   end
@@ -129,7 +129,7 @@ defmodule GroupherServer.CMS.Articles.Read do
 
   defp if_article_legal(thread, id) when thread in @article_threads do
     with {:ok, info} <- match(thread),
-         {:ok, article} <- ORM.find(info.model, id) do
+         {:ok, article} <- FrontDesk.get(info.model, id) do
       if_article_legal(article)
     end
   end

--- a/backend/main/lib/groupher_server/cms/articles/read.ex
+++ b/backend/main/lib/groupher_server/cms/articles/read.ex
@@ -12,13 +12,12 @@ defmodule GroupherServer.CMS.Articles.Read do
       get_config: 2
     ]
 
-  alias Ecto.Multi
-  alias Helper.{Constant, ORM}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
-  alias CMS.FrontDesk
   alias CMS.Model.{Community, PinnedArticle}
+  alias Ecto.Multi
+  alias Helper.Types, as: T
+  alias Helper.{Constant, ORM}
 
   @active_period get_config(:article, :active_period_days)
   @article_threads get_config(:article, :threads)
@@ -110,13 +109,6 @@ defmodule GroupherServer.CMS.Articles.Read do
     end
   end
 
-  defp if_article_legal(thread, id, %User{} = user) when thread in @article_threads do
-    with {:ok, info} <- match(thread),
-         {:ok, article} <- FrontDesk.get(info.model, id, preload: :author) do
-      if_article_legal(article, user)
-    end
-  end
-
   defp if_article_legal(%{pending: @audit_legal} = article, _), do: {:ok, article}
   defp if_article_legal(%{pending: @audit_failed} = article, _), do: {:ok, article}
 
@@ -124,13 +116,6 @@ defmodule GroupherServer.CMS.Articles.Read do
     case article.author.user_id == user_id do
       true -> {:ok, article}
       false -> raise_error(:pending, "this article is under audition")
-    end
-  end
-
-  defp if_article_legal(thread, id) when thread in @article_threads do
-    with {:ok, info} <- match(thread),
-         {:ok, article} <- FrontDesk.get(info.model, id) do
-      if_article_legal(article)
     end
   end
 

--- a/backend/main/lib/groupher_server/cms/articles/upvotes.ex
+++ b/backend/main/lib/groupher_server/cms/articles/upvotes.ex
@@ -6,16 +6,17 @@ defmodule GroupherServer.CMS.Articles.Upvotes do
   import GroupherServer.CMS.Helper.Matcher
   import Helper.Utils, only: [done: 1]
 
-  alias Ecto.Multi
-  alias Helper.{ORM, Later, Transaction}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
   alias CMS.Model.ArticleUpvote
-  alias CMS.{FrontDesk, Events}
+  alias CMS.{Events, FrontDesk}
+  alias Ecto.Multi
+  alias Helper.Types, as: T
+  alias Helper.{Later, ORM, Transaction}
 
   @spec upvoted_users(term(), map()) :: T.domain_res(term())
-  def upvoted_users(article, filter), do: FrontDesk.load_reaction_users(ArticleUpvote, article, filter)
+  def upvoted_users(article, filter),
+    do: FrontDesk.load_reaction_users(ArticleUpvote, article, filter)
 
   @spec upvote(term(), User.t()) :: T.domain_res(term())
   def upvote(article, %User{} = user) do
@@ -38,7 +39,10 @@ defmodule GroupherServer.CMS.Articles.Upvotes do
       end)
       |> Multi.run(:after_events, fn _, _ ->
         Later.run({Events, :emit, [:notify_upvote, %{target: article, from_user: user}]})
-        Later.run({Events, :emit, [:subscribe_community, %{target: article.community, user: user}]})
+
+        Later.run(
+          {Events, :emit, [:subscribe_community, %{target: article.community, user: user}]}
+        )
       end)
       |> Repo.transaction()
       |> result()
@@ -71,9 +75,12 @@ defmodule GroupherServer.CMS.Articles.Upvotes do
           _ -> FrontDesk.update_article_reaction_user_list(:upvote, article, from_user, :remove)
         end
       end)
-      |> Multi.run(:undo_upvote, fn _, %{find_upvote: record, update_reaction_user_list: updated} ->
+      |> Multi.run(:undo_upvote, fn _,
+                                    %{find_upvote: record, update_reaction_user_list: updated} ->
         case record do
-          nil -> {:ok, updated}
+          nil ->
+            {:ok, updated}
+
           _ ->
             args = Map.put(%{user_id: user_id}, info.foreign_key, article.id)
             ORM.findby_delete(ArticleUpvote, args)
@@ -81,7 +88,9 @@ defmodule GroupherServer.CMS.Articles.Upvotes do
         end
       end)
       |> Multi.run(:after_events, fn _, %{undo_upvote: updated} ->
-        Later.run({Events, :emit, [:notify_undo_upvote, %{target: updated, from_user: from_user}]})
+        Later.run(
+          {Events, :emit, [:notify_undo_upvote, %{target: updated, from_user: from_user}]}
+        )
       end)
       |> Repo.transaction()
       |> result()

--- a/backend/main/lib/groupher_server/cms/articles/upvotes.ex
+++ b/backend/main/lib/groupher_server/cms/articles/upvotes.ex
@@ -6,23 +6,16 @@ defmodule GroupherServer.CMS.Articles.Upvotes do
   import GroupherServer.CMS.Helper.Matcher
   import Helper.Utils, only: [done: 1]
 
-  import GroupherServer.CMS.FrontDesk,
-    only: [
-      thread_of: 2,
-      load_reaction_users: 3,
-      update_article_reaction_user_list: 4
-    ]
-
   alias Ecto.Multi
   alias Helper.{ORM, Later, Transaction}
   alias Helper.Types, as: T
-  alias GroupherServer.{Accounts, Repo}
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.ArticleUpvote
-  alias GroupherServer.CMS.Events
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias Accounts.Model.User
+  alias CMS.Model.ArticleUpvote
+  alias CMS.{FrontDesk, Events}
 
   @spec upvoted_users(term(), map()) :: T.domain_res(term())
-  def upvoted_users(article, filter), do: load_reaction_users(ArticleUpvote, article, filter)
+  def upvoted_users(article, filter), do: FrontDesk.load_reaction_users(ArticleUpvote, article, filter)
 
   @spec upvote(term(), User.t()) :: T.domain_res(term())
   def upvote(article, %User{} = user) do
@@ -34,7 +27,7 @@ defmodule GroupherServer.CMS.Articles.Upvotes do
         ORM.inc(article, :upvotes_count)
       end)
       |> Multi.run(:update_reaction_user_list, fn _, %{update_upvotes_count: article} ->
-        update_article_reaction_user_list(:upvote, article, user, :add)
+        FrontDesk.update_article_reaction_user_list(:upvote, article, user, :add)
       end)
       |> Multi.run(:add_achievement, fn _, _ ->
         achiever_id = article.author.user_id
@@ -75,7 +68,7 @@ defmodule GroupherServer.CMS.Articles.Upvotes do
       |> Multi.run(:update_reaction_user_list, fn _, %{find_upvote: record} ->
         case record do
           nil -> {:ok, article}
-          _ -> update_article_reaction_user_list(:upvote, article, from_user, :remove)
+          _ -> FrontDesk.update_article_reaction_user_list(:upvote, article, from_user, :remove)
         end
       end)
       |> Multi.run(:undo_upvote, fn _, %{find_upvote: record, update_reaction_user_list: updated} ->
@@ -96,7 +89,7 @@ defmodule GroupherServer.CMS.Articles.Upvotes do
   end
 
   defp create_upvote(article, info, user) do
-    {:ok, thread} = thread_of(article, :upcase)
+    {:ok, thread} = FrontDesk.thread_of(article, :upcase)
     args = Map.put(%{user_id: user.id, thread: thread}, info.foreign_key, article.id)
 
     case ORM.create(ArticleUpvote, args) do

--- a/backend/main/lib/groupher_server/cms/articles/write.ex
+++ b/backend/main/lib/groupher_server/cms/articles/write.ex
@@ -15,16 +15,16 @@ defmodule GroupherServer.CMS.Articles.Write do
       atom_values_to_upcase: 1
     ]
 
-  alias Ecto.Multi
-  alias Helper.{Converter, Later, ORM, Transaction}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Email, Repo, Statistics}
   alias Accounts.Model.User
-  alias CMS.Helper.ArticleEnums
-  alias CMS.Model.{Author, Community, Embeds}
-  alias CMS.{FrontDesk, Communities, Events}
   alias CMS.Articles.Document
   alias CMS.Articles.{Meta, Placement}
+  alias CMS.Helper.ArticleEnums
+  alias CMS.Model.{Author, Community, Embeds}
+  alias CMS.{Communities, Events, FrontDesk}
+  alias Ecto.Multi
+  alias Helper.Types, as: T
+  alias Helper.{Converter, Later, ORM, Transaction}
 
   @default_emotions Embeds.ArticleEmotion.default_emotions()
   @default_article_meta Embeds.ArticleMeta.default_meta()

--- a/backend/main/lib/groupher_server/cms/articles/write.ex
+++ b/backend/main/lib/groupher_server/cms/articles/write.ex
@@ -18,14 +18,13 @@ defmodule GroupherServer.CMS.Articles.Write do
   alias Ecto.Multi
   alias Helper.{Converter, Later, ORM, Transaction}
   alias Helper.Types, as: T
-  alias GroupherServer.{Accounts, Email, Repo, Statistics}
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Helper.ArticleEnums
-  alias GroupherServer.CMS.Model.{Author, Community, Embeds}
-  alias GroupherServer.CMS.Communities
-  alias GroupherServer.CMS.Articles.Document
-  alias GroupherServer.CMS.Events
-  alias GroupherServer.CMS.Articles.{Meta, Placement}
+  alias GroupherServer.{Accounts, CMS, Email, Repo, Statistics}
+  alias Accounts.Model.User
+  alias CMS.Helper.ArticleEnums
+  alias CMS.Model.{Author, Community, Embeds}
+  alias CMS.{FrontDesk, Communities, Events}
+  alias CMS.Articles.Document
+  alias CMS.Articles.{Meta, Placement}
 
   @default_emotions Embeds.ArticleEmotion.default_emotions()
   @default_article_meta Embeds.ArticleMeta.default_meta()
@@ -88,7 +87,7 @@ defmodule GroupherServer.CMS.Articles.Write do
     target = result.__struct__
     preload = [:community, author: :user]
 
-    with {:ok, article} <- ORM.find(target, id, preload: preload) do
+    with {:ok, article} <- FrontDesk.get(target, id, preload: preload) do
       info = %{
         id: article.id,
         title: article.title,

--- a/backend/main/lib/groupher_server/cms/comments.ex
+++ b/backend/main/lib/groupher_server/cms/comments.ex
@@ -3,20 +3,26 @@ defmodule GroupherServer.CMS.Comments do
   CMS comments facade.
   """
 
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
-  alias CMS.Model.{Community, Comment}
+  alias CMS.Model.{Comment, Community}
+  alias Helper.Types, as: T
 
   alias __MODULE__.{
-    Read,
-    List,
-    CRUD,
-    Actions,
-    Emotion,
-    Moderation
-  }
 
+    Actions,
+
+    CRUD,
+
+    Emotion,
+
+    List,
+
+    Moderation,
+
+    Read
+
+  }
   @spec fetch_comment(T.id()) :: T.domain_res(Comment.t())
   def fetch_comment(comment_id), do: Read.fetch_comment(comment_id)
 

--- a/backend/main/lib/groupher_server/cms/comments.ex
+++ b/backend/main/lib/groupher_server/cms/comments.ex
@@ -4,8 +4,9 @@ defmodule GroupherServer.CMS.Comments do
   """
 
   alias Helper.Types, as: T
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, Comment}
+  alias GroupherServer.{Accounts, CMS}
+  alias Accounts.Model.User
+  alias CMS.Model.{Community, Comment}
 
   alias __MODULE__.{
     Read,

--- a/backend/main/lib/groupher_server/cms/comments/actions.ex
+++ b/backend/main/lib/groupher_server/cms/comments/actions.ex
@@ -16,16 +16,16 @@ defmodule GroupherServer.CMS.Comments.Actions do
 
   import GroupherServer.CMS.Helper.Matcher
 
-  alias Helper.Types, as: T
-  alias Helper.{ORM, Later, Transaction}
   alias GroupherServer.{Accounts, CMS, Repo}
   alias CMS.FrontDesk
+  alias Helper.Types, as: T
+  alias Helper.{Later, ORM, Transaction}
 
   alias Accounts.Model.User
-  alias CMS.Model.{Comment, PinnedComment, CommentUpvote, CommentReply}
-  alias CMS.Events
   alias CMS.Comments.List, as: CommentList
   alias CMS.Comments.Read, as: CommentRead
+  alias CMS.Events
+  alias CMS.Model.{Comment, CommentReply, CommentUpvote, PinnedComment}
 
   alias Ecto.Multi
 
@@ -45,13 +45,7 @@ defmodule GroupherServer.CMS.Comments.Actions do
             where: field(p, ^info.foreign_key) == ^full_comment.article.id
           )
 
-        with {:ok, pined_comments_count} <- ORM.count(pined_comments_query) do
-          if pined_comments_count >= @pinned_comment_limit do
-            {:error, {:comment_pin_limit, @pinned_comment_limit}}
-          else
-            {:ok, :pass}
-          end
-        end
+        check_pined_comments_count(pined_comments_query)
       end)
       |> Multi.run(:update_comment_flag, fn _, _ ->
         ORM.update(comment, %{is_pinned: true})
@@ -270,10 +264,14 @@ defmodule GroupherServer.CMS.Comments.Actions do
   end
 
   defp update_article_author_upvoted_info(%Comment{} = comment, user_id) do
-    with {:ok, article} = CommentRead.fetch_full_comment(comment.id) do
-      is_article_author_upvoted = article.author.id == user_id
-      meta = comment.meta |> Map.put(:is_article_author_upvoted, is_article_author_upvoted)
-      comment |> ORM.update_meta(meta)
+    case CommentRead.fetch_full_comment(comment.id) do
+      {:ok, article} ->
+        is_article_author_upvoted = article.author.id == user_id
+        meta = comment.meta |> Map.put(:is_article_author_upvoted, is_article_author_upvoted)
+        comment |> ORM.update_meta(meta)
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -282,6 +280,19 @@ defmodule GroupherServer.CMS.Comments.Actions do
   defp get_parent_comment(%Comment{reply_to_id: reply_to_id} = comment)
        when not is_nil(reply_to_id) do
     get_parent_comment(Repo.preload(comment.reply_to, reply_to: :author))
+  end
+
+  defp check_pined_comments_count(pined_comments_query) do
+    case ORM.count(pined_comments_query) do
+      {:ok, pined_comments_count} when pined_comments_count >= @pinned_comment_limit ->
+        {:error, {:comment_pin_limit, @pinned_comment_limit}}
+
+      {:ok, _} ->
+        {:ok, :pass}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   defp add_replies_ifneed(

--- a/backend/main/lib/groupher_server/cms/comments/actions.ex
+++ b/backend/main/lib/groupher_server/cms/comments/actions.ex
@@ -12,23 +12,20 @@ defmodule GroupherServer.CMS.Comments.Actions do
       get_config: 2
     ]
 
-  import GroupherServer.CMS.FrontDesk,
-    only: [sync_embed_replies: 1, article_of: 1, thread_of: 1]
-
   import Helper.ErrorCode
 
   import GroupherServer.CMS.Helper.Matcher
 
   alias Helper.Types, as: T
   alias Helper.{ORM, Later, Transaction}
-  alias GroupherServer.{Accounts, Repo}
-  alias GroupherServer.CMS.FrontDesk
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias CMS.FrontDesk
 
   alias Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Comment, PinnedComment, CommentUpvote, CommentReply}
-  alias GroupherServer.CMS.Events
-  alias GroupherServer.CMS.Comments.List, as: CommentList
-  alias GroupherServer.CMS.Comments.Read, as: CommentRead
+  alias CMS.Model.{Comment, PinnedComment, CommentUpvote, CommentReply}
+  alias CMS.Events
+  alias CMS.Comments.List, as: CommentList
+  alias CMS.Comments.Read, as: CommentRead
 
   alias Ecto.Multi
 
@@ -113,7 +110,7 @@ defmodule GroupherServer.CMS.Comments.Actions do
         do_create_comment(body, info.foreign_key, article, user)
       end)
       |> Multi.run(:update_comments_count, fn _, %{create_reply_comment: replied_comment} ->
-        {:ok, article} = article_of(replied_comment)
+        {:ok, article} = FrontDesk.article_of(replied_comment)
         ORM.inc(article, :comments_count)
       end)
       |> Multi.run(:create_comment_reply, fn _, %{create_reply_comment: replied_comment} ->
@@ -183,7 +180,7 @@ defmodule GroupherServer.CMS.Comments.Actions do
         |> done
       end)
       |> Multi.run(:sync_embed_replies, fn _, %{viewer_states: comment} ->
-        sync_embed_replies(comment)
+        FrontDesk.sync_embed_replies(comment)
       end)
       |> Multi.run(:after_events, fn _, _ ->
         Later.run({Events, :emit, [:subscribe_community, %{target: comment, user: from_user}]})
@@ -225,7 +222,7 @@ defmodule GroupherServer.CMS.Comments.Actions do
         |> done
       end)
       |> Multi.run(:sync_embed_replies, fn _, %{viewer_states: comment} ->
-        sync_embed_replies(comment)
+        FrontDesk.sync_embed_replies(comment)
       end)
       |> Multi.run(:after_events, fn _, _ ->
         Later.run({Events, :emit, [:notify_undo_upvote, %{target: comment, from_user: from_user}]})
@@ -255,8 +252,8 @@ defmodule GroupherServer.CMS.Comments.Actions do
       comment |> ORM.update(%{is_folded: is_folded})
     end)
     |> Multi.run(:update_article_fold_count, fn _, _ ->
-      {:ok, article} = article_of(comment)
-      {:ok, article_thread} = thread_of(article)
+      {:ok, article} = FrontDesk.article_of(comment)
+      {:ok, article_thread} = FrontDesk.thread_of(article)
 
       {:ok, %{total_count: total_count}} =
         CommentList.paged_folded_comments(article_thread, article.id, %{page: 1, size: 1})

--- a/backend/main/lib/groupher_server/cms/comments/crud.ex
+++ b/backend/main/lib/groupher_server/cms/comments/crud.ex
@@ -8,20 +8,17 @@ defmodule GroupherServer.CMS.Comments.CRUD do
   import Helper.Utils, only: [done: 1, strip_struct: 1, get_config: 2]
   import Helper.ErrorCode
 
-  import GroupherServer.CMS.FrontDesk, only: [sync_embed_replies: 1, article_of: 1, article: 4]
-
   import GroupherServer.CMS.Helper.Matcher
 
   alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
-  alias GroupherServer.CMS.FrontDesk
+  alias CMS.FrontDesk
 
   alias Accounts.Model.User
-  alias GroupherServer.CMS.Helper.ArticleEnums
-  alias GroupherServer.CMS.Model.{Post, Comment, PinnedComment, Embeds, Community}
-
-  alias GroupherServer.CMS.Events
-  alias GroupherServer.CMS.Comments.Actions
+  alias CMS.Helper.ArticleEnums
+  alias CMS.Model.{Post, Comment, PinnedComment, Embeds, Community}
+  alias CMS.Events
+  alias CMS.Comments.Actions
   alias Helper.{Later, ORM}
 
   alias Ecto.Multi
@@ -42,16 +39,16 @@ defmodule GroupherServer.CMS.Comments.CRUD do
   def create_comment(%Community{slug: community_slug}, thread, article_id, body, %User{} = user) do
     with {:ok, info} <- match(thread),
          {:ok, article} <-
-           article(community_slug, thread, article_id,
-             preload: [[author: :user], :community]
-           ),
+            FrontDesk.article(community_slug, thread, article_id,
+              preload: [[author: :user], :community]
+            ),
          true <- can_comment?(article, user) do
       Multi.new()
       |> Multi.run(:create_comment, fn _, _ ->
         do_create_comment(body, info.foreign_key, article, user)
       end)
       |> Multi.run(:update_comments_count, fn _, %{create_comment: comment} ->
-        {:ok, article} = article_of(comment)
+        {:ok, article} = FrontDesk.article_of(comment)
         ORM.inc(article, :comments_count)
       end)
       |> Multi.run(:set_question_flag_ifneed, fn _, %{create_comment: comment} ->
@@ -100,7 +97,7 @@ defmodule GroupherServer.CMS.Comments.CRUD do
         comment |> ORM.update(%{body: body, body_html: body_html})
       end)
       |> Multi.run(:sync_embed_replies, fn _, %{update_comment: comment} ->
-        sync_embed_replies(comment)
+        FrontDesk.sync_embed_replies(comment)
       end)
       |> Multi.run(:after_events, fn _, %{update_comment: comment} ->
         Later.run({Events, :emit, [:audition, %{artiment: comment}]})
@@ -117,7 +114,7 @@ defmodule GroupherServer.CMS.Comments.CRUD do
         ORM.update(comment, %{body: body, body_html: body_html})
       end)
       |> Multi.run(:sync_embed_replies, fn _, %{update_comment: comment} ->
-        sync_embed_replies(comment)
+        FrontDesk.sync_embed_replies(comment)
       end)
       |> Multi.run(:after_events, fn _, %{update_comment: comment} ->
         Later.run({Events, :emit, [:audition, %{artiment: comment}]})
@@ -134,7 +131,7 @@ defmodule GroupherServer.CMS.Comments.CRUD do
   def delete_comment(%Comment{} = comment) do
     Multi.new()
     |> Multi.run(:update_comments_count, fn _, _ ->
-      {:ok, article} = article_of(comment)
+      {:ok, article} = FrontDesk.article_of(comment)
       ORM.dec(article, :comments_count)
     end)
     |> Multi.run(:remove_pined_comment, fn _, _ ->
@@ -186,7 +183,7 @@ defmodule GroupherServer.CMS.Comments.CRUD do
           end
         end)
         |> Multi.run(:sync_embed_replies, fn _, %{mark_solution: updated_comment} ->
-          sync_embed_replies(updated_comment)
+          FrontDesk.sync_embed_replies(updated_comment)
         end)
         |> Repo.transaction()
         |> result()

--- a/backend/main/lib/groupher_server/cms/comments/crud.ex
+++ b/backend/main/lib/groupher_server/cms/comments/crud.ex
@@ -10,15 +10,15 @@ defmodule GroupherServer.CMS.Comments.CRUD do
 
   import GroupherServer.CMS.Helper.Matcher
 
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias CMS.FrontDesk
+  alias Helper.Types, as: T
 
   alias Accounts.Model.User
-  alias CMS.Helper.ArticleEnums
-  alias CMS.Model.{Post, Comment, PinnedComment, Embeds, Community}
-  alias CMS.Events
   alias CMS.Comments.Actions
+  alias CMS.Events
+  alias CMS.Helper.ArticleEnums
+  alias CMS.Model.{Comment, Community, Embeds, PinnedComment, Post}
   alias Helper.{Later, ORM}
 
   alias Ecto.Multi
@@ -177,10 +177,7 @@ defmodule GroupherServer.CMS.Comments.CRUD do
           ORM.update(updated_comment, %{is_solution: is_solution, is_for_question: true})
         end)
         |> Multi.run(:update_post_state, fn _, _ ->
-          with {:ok, updated_post} <- ORM.update(post, %{solution_digest: comment.body_html}) do
-            state = if is_solution, do: @article_state.resolved, else: @article_state.default
-            CMS.Articles.set_state(updated_post, state)
-          end
+          update_post_state_for_solution(post, comment, is_solution)
         end)
         |> Multi.run(:sync_embed_replies, fn _, %{mark_solution: updated_comment} ->
           FrontDesk.sync_embed_replies(updated_comment)
@@ -293,6 +290,17 @@ defmodule GroupherServer.CMS.Comments.CRUD do
       |> ORM.count()
 
     cur_count + 1
+  end
+
+  defp update_post_state_for_solution(post, comment, is_solution) do
+    case ORM.update(post, %{solution_digest: comment.body_html}) do
+      {:ok, updated_post} ->
+        state = if is_solution, do: @article_state.resolved, else: @article_state.default
+        CMS.Articles.set_state(updated_post, state)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   defp result({:ok, %{set_question_flag_ifneed: result}}), do: {:ok, result}

--- a/backend/main/lib/groupher_server/cms/comments/emotion.ex
+++ b/backend/main/lib/groupher_server/cms/comments/emotion.ex
@@ -7,20 +7,13 @@ defmodule GroupherServer.CMS.Comments.Emotion do
 
   import Helper.Utils, only: [done: 1]
 
-  import GroupherServer.CMS.FrontDesk,
-    only: [
-      update_emotions_field: 4,
-      mark_viewer_emotion_states: 2,
-      sync_embed_replies: 1
-    ]
-
   alias Helper.{ORM, Later}
   alias Helper.Types, as: T
-  alias GroupherServer.{Accounts, Repo}
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias CMS.{FrontDesk, Events}
 
-  alias GroupherServer.CMS.Events
   alias Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Comment, CommentUserEmotion}
+  alias CMS.Model.{Comment, CommentUserEmotion}
 
   alias Ecto.Multi
 
@@ -29,7 +22,7 @@ defmodule GroupherServer.CMS.Comments.Emotion do
 
   @spec emotion_to_comment(T.id(), atom(), User.t()) :: T.domain_res(Comment.t())
   def emotion_to_comment(comment_id, emotion, %User{} = user) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id, preload: :author) do
+    with {:ok, comment} <- FrontDesk.comment(comment_id) do
       Multi.new()
       |> Multi.run(:create_user_emotion, fn _, _ ->
         target = %{
@@ -49,9 +42,9 @@ defmodule GroupherServer.CMS.Comments.Emotion do
         query_emotion_states(comment, emotion)
       end)
       |> Multi.run(:update_emotions_field, fn _, %{query_emotion_states: status} ->
-        with {:ok, comment} <- update_emotions_field(comment, emotion, status, user),
-             {:ok, comment} <- sync_embed_replies(comment) do
-          mark_viewer_emotion_states(comment, user) |> done
+        with {:ok, comment} <- FrontDesk.update_emotions_field(comment, emotion, status, user),
+             {:ok, comment} <- FrontDesk.sync_embed_replies(comment) do
+          FrontDesk.mark_viewer_emotion_states(comment, user) |> done
         end
       end)
       |> Multi.run(:after_events, fn _, _ ->
@@ -64,7 +57,7 @@ defmodule GroupherServer.CMS.Comments.Emotion do
 
   @spec undo_emotion_to_comment(T.id(), atom(), User.t()) :: T.domain_res(Comment.t())
   def undo_emotion_to_comment(comment_id, emotion, %User{} = user) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id, preload: :author) do
+    with {:ok, comment} <- FrontDesk.comment(comment_id) do
       Multi.new()
       |> Multi.run(:update_user_emotion, fn _, _ ->
         target = %{
@@ -86,8 +79,8 @@ defmodule GroupherServer.CMS.Comments.Emotion do
         query_emotion_states(comment, emotion)
       end)
       |> Multi.run(:update_emotions_field, fn _, %{query_emotion_states: status} ->
-        with {:ok, comment} <- update_emotions_field(comment, emotion, status, user) do
-          mark_viewer_emotion_states(comment, user) |> done
+        with {:ok, comment} <- FrontDesk.update_emotions_field(comment, emotion, status, user) do
+          FrontDesk.mark_viewer_emotion_states(comment, user) |> done
         end
       end)
       |> Repo.transaction()

--- a/backend/main/lib/groupher_server/cms/comments/emotion.ex
+++ b/backend/main/lib/groupher_server/cms/comments/emotion.ex
@@ -7,10 +7,10 @@ defmodule GroupherServer.CMS.Comments.Emotion do
 
   import Helper.Utils, only: [done: 1]
 
-  alias Helper.{ORM, Later}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
-  alias CMS.{FrontDesk, Events}
+  alias CMS.{Events, FrontDesk}
+  alias Helper.Types, as: T
+  alias Helper.{Later, ORM}
 
   alias Accounts.Model.User
   alias CMS.Model.{Comment, CommentUserEmotion}
@@ -99,10 +99,10 @@ defmodule GroupherServer.CMS.Comments.Emotion do
         select: %{login: user.login, nickname: user.nickname}
       )
 
-    emotioned_user_info_list = Repo.all(query) |> Enum.uniq()
-    emotioned_user_count = length(emotioned_user_info_list)
+    mentioned_user_info_list = Repo.all(query) |> Enum.uniq()
+    mentioned_user_count = length(mentioned_user_info_list)
 
-    {:ok, %{user_list: emotioned_user_info_list, user_count: emotioned_user_count}}
+    {:ok, %{user_list: mentioned_user_info_list, user_count: mentioned_user_count}}
   end
 
   defp result({:ok, %{update_emotions_field: result}}), do: {:ok, result}

--- a/backend/main/lib/groupher_server/cms/comments/list.ex
+++ b/backend/main/lib/groupher_server/cms/comments/list.ex
@@ -10,10 +10,10 @@ defmodule GroupherServer.CMS.Comments.List do
 
   import GroupherServer.CMS.Helper.Matcher
 
-  alias Helper.Types, as: T
-  alias Helper.{Later, ORM, QueryBuilder}
   alias GroupherServer.{Accounts, CMS, Repo}
   alias CMS.FrontDesk
+  alias Helper.Types, as: T
+  alias Helper.{Later, ORM, QueryBuilder}
 
   alias Accounts.Model.User
   alias CMS.Model.{Comment, PinnedComment}

--- a/backend/main/lib/groupher_server/cms/comments/list.ex
+++ b/backend/main/lib/groupher_server/cms/comments/list.ex
@@ -8,18 +8,15 @@ defmodule GroupherServer.CMS.Comments.List do
   import Helper.Utils, only: [done: 1]
   import ShortMaps
 
-  import GroupherServer.CMS.FrontDesk,
-    only: [mark_viewer_emotion_states: 2]
-
   import GroupherServer.CMS.Helper.Matcher
 
   alias Helper.Types, as: T
   alias Helper.{Later, ORM, QueryBuilder}
-  alias GroupherServer.{Accounts, Repo}
-  alias GroupherServer.CMS.FrontDesk
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias CMS.FrontDesk
 
   alias Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Comment, PinnedComment}
+  alias CMS.Model.{Comment, PinnedComment}
 
   @pinned_comment_limit Comment.pinned_comment_limit()
 
@@ -180,7 +177,7 @@ defmodule GroupherServer.CMS.Comments.List do
       |> QueryBuilder.filter_pack(Map.merge(filters, %{sort: sort}))
       |> ORM.paginator(~m(page size)a)
       |> add_pinned_comments_ifneed(thread, article_id, filters)
-      |> mark_viewer_emotion_states(user)
+      |> FrontDesk.mark_viewer_emotion_states(user)
       |> mark_viewer_has_upvoted(user)
       |> done()
     end
@@ -197,7 +194,7 @@ defmodule GroupherServer.CMS.Comments.List do
     |> where(^where_query)
     |> QueryBuilder.filter_pack(Map.merge(filters, %{sort: sort}))
     |> ORM.paginator(~m(page size)a)
-    |> mark_viewer_emotion_states(user)
+    |> FrontDesk.mark_viewer_emotion_states(user)
     |> mark_viewer_has_upvoted(user)
     |> done()
   end

--- a/backend/main/lib/groupher_server/cms/comments/moderation.ex
+++ b/backend/main/lib/groupher_server/cms/comments/moderation.ex
@@ -8,11 +8,11 @@ defmodule GroupherServer.CMS.Comments.Moderation do
   import Helper.Utils, only: [done: 1]
   import ShortMaps
 
-  alias Helper.Types, as: T
-  alias Helper.{ORM, QueryBuilder}
+  alias GroupherServer.FrontDesk, as: GlobalFrontDesk
   alias GroupherServer.{CMS, Repo}
   alias CMS.FrontDesk
-  alias GroupherServer.FrontDesk, as: UserFrontDesk
+  alias Helper.Types, as: T
+  alias Helper.{ORM, QueryBuilder}
 
   alias CMS.Model.Comment
 
@@ -43,7 +43,7 @@ defmodule GroupherServer.CMS.Comments.Moderation do
     |> Multi.run(:update_author_meta, fn _, _ ->
       illegal_comments = Map.get(audit_state, :illegal_comments, [])
 
-      with {:ok, user} <- UserFrontDesk.user(comment.author_id) do
+      with {:ok, user} <- GlobalFrontDesk.user(comment.author_id) do
         illegal_comments = user.meta.illegal_comments ++ illegal_comments
 
         ORM.update_meta(user, %{has_illegal_comments: true, illegal_comments: illegal_comments})
@@ -73,7 +73,7 @@ defmodule GroupherServer.CMS.Comments.Moderation do
     |> Multi.run(:update_author_meta, fn _, _ ->
       illegal_comments = Map.get(audit_state, :illegal_comments, [])
 
-      with {:ok, user} <- UserFrontDesk.user(comment.author_id) do
+      with {:ok, user} <- GlobalFrontDesk.user(comment.author_id) do
         illegal_comments = user.meta.illegal_comments -- illegal_comments
         has_illegal_comments = not Enum.empty?(illegal_comments)
 

--- a/backend/main/lib/groupher_server/cms/comments/moderation.ex
+++ b/backend/main/lib/groupher_server/cms/comments/moderation.ex
@@ -10,9 +10,11 @@ defmodule GroupherServer.CMS.Comments.Moderation do
 
   alias Helper.Types, as: T
   alias Helper.{ORM, QueryBuilder}
-  alias GroupherServer.{FrontDesk, Repo}
+  alias GroupherServer.{CMS, Repo}
+  alias CMS.FrontDesk
+  alias GroupherServer.FrontDesk, as: UserFrontDesk
 
-  alias GroupherServer.CMS.Model.Comment
+  alias CMS.Model.Comment
 
   alias Ecto.Multi
 
@@ -22,7 +24,7 @@ defmodule GroupherServer.CMS.Comments.Moderation do
 
   @spec set_comment_illegal(T.id(), map()) :: T.domain_res(Comment.t())
   def set_comment_illegal(comment_id, audit_state) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id) do
+    with {:ok, comment} <- FrontDesk.get(Comment, comment_id) do
       do_set_comment_illegal(comment, audit_state)
     end
   end
@@ -41,7 +43,7 @@ defmodule GroupherServer.CMS.Comments.Moderation do
     |> Multi.run(:update_author_meta, fn _, _ ->
       illegal_comments = Map.get(audit_state, :illegal_comments, [])
 
-      with {:ok, user} <- FrontDesk.user(comment.author_id) do
+      with {:ok, user} <- UserFrontDesk.user(comment.author_id) do
         illegal_comments = user.meta.illegal_comments ++ illegal_comments
 
         ORM.update_meta(user, %{has_illegal_comments: true, illegal_comments: illegal_comments})
@@ -53,7 +55,7 @@ defmodule GroupherServer.CMS.Comments.Moderation do
 
   @spec unset_comment_illegal(T.id(), map()) :: T.domain_res(Comment.t())
   def unset_comment_illegal(comment_id, audit_state) do
-    with {:ok, comment} <- ORM.find(Comment, comment_id) do
+    with {:ok, comment} <- FrontDesk.get(Comment, comment_id) do
       do_unset_comment_illegal(comment, audit_state)
     end
   end
@@ -71,7 +73,7 @@ defmodule GroupherServer.CMS.Comments.Moderation do
     |> Multi.run(:update_author_meta, fn _, _ ->
       illegal_comments = Map.get(audit_state, :illegal_comments, [])
 
-      with {:ok, user} <- FrontDesk.user(comment.author_id) do
+      with {:ok, user} <- UserFrontDesk.user(comment.author_id) do
         illegal_comments = user.meta.illegal_comments -- illegal_comments
         has_illegal_comments = not Enum.empty?(illegal_comments)
 

--- a/backend/main/lib/groupher_server/cms/comments/read.ex
+++ b/backend/main/lib/groupher_server/cms/comments/read.ex
@@ -7,11 +7,11 @@ defmodule GroupherServer.CMS.Comments.Read do
 
   import Helper.Utils, only: [done: 1, get_config: 2]
 
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
   alias CMS.FrontDesk
   alias CMS.Model.Comment
+  alias Helper.Types, as: T
 
   @article_threads get_config(:article, :threads)
 
@@ -70,8 +70,6 @@ defmodule GroupherServer.CMS.Comments.Read do
     |> Enum.filter(&Map.get(comment, :"#{&1}_id"))
     |> List.first()
   end
-
-  defp mark_viewer_has_upvoted(paged_comments, nil), do: paged_comments
 
   defp mark_viewer_has_upvoted(%{entries: entries} = paged_comments, %User{} = user) do
     entries =

--- a/backend/main/lib/groupher_server/cms/comments/read.ex
+++ b/backend/main/lib/groupher_server/cms/comments/read.ex
@@ -7,22 +7,17 @@ defmodule GroupherServer.CMS.Comments.Read do
 
   import Helper.Utils, only: [done: 1, get_config: 2]
 
-  import GroupherServer.CMS.FrontDesk,
-    only: [mark_viewer_emotion_states: 2]
-
   alias Helper.Types, as: T
-  alias Helper.ORM
-  alias GroupherServer.Repo
-
-  alias GroupherServer.CMS.Model.Comment
-  alias GroupherServer.CMS.FrontDesk
-  alias GroupherServer.Accounts.Model.User
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias Accounts.Model.User
+  alias CMS.FrontDesk
+  alias CMS.Model.Comment
 
   @article_threads get_config(:article, :threads)
 
   @spec fetch_comment(T.id()) :: T.domain_res(Comment.t())
   def fetch_comment(comment_id) do
-    ORM.find(Comment, comment_id)
+    FrontDesk.get(Comment, comment_id)
   end
 
   @spec fetch_full_comment(T.id()) :: T.domain_res(T.article_info())
@@ -37,7 +32,7 @@ defmodule GroupherServer.CMS.Comments.Read do
   def one_comment(id, %User{} = user) do
     with {:ok, comment} <- FrontDesk.get(Comment, id) do
       %{entries: [comment]}
-      |> mark_viewer_emotion_states(user)
+      |> FrontDesk.mark_viewer_emotion_states(user)
       |> mark_viewer_has_upvoted(user)
       |> Map.get(:entries)
       |> List.first()

--- a/backend/main/lib/groupher_server/cms/communities.ex
+++ b/backend/main/lib/groupher_server/cms/communities.ex
@@ -4,8 +4,9 @@ defmodule GroupherServer.CMS.Communities do
   """
 
   alias Helper.Types, as: T
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, Category, Thread, CommunityTag}
+  alias GroupherServer.{Accounts, CMS}
+  alias Accounts.Model.User
+  alias CMS.Model.{Community, Category, Thread, CommunityTag}
 
   alias __MODULE__.{
     Read,

--- a/backend/main/lib/groupher_server/cms/communities.ex
+++ b/backend/main/lib/groupher_server/cms/communities.ex
@@ -3,27 +3,40 @@ defmodule GroupherServer.CMS.Communities do
   CMS communities facade.
   """
 
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
-  alias CMS.Model.{Community, Category, Thread, CommunityTag}
+  alias CMS.Model.{Category, Community, CommunityTag, Thread}
+  alias Helper.Types, as: T
 
   alias __MODULE__.{
-    Read,
-    List,
-    Write,
-    Dashboard,
-    Apply,
-    Members,
-    Moderator,
-    Subscribe,
-    Count,
-    Categories,
-    Threads,
-    Passport,
-    Tags
-  }
 
+    Apply,
+
+    Categories,
+
+    Count,
+
+    Dashboard,
+
+    List,
+
+    Members,
+
+    Moderator,
+
+    Passport,
+
+    Read,
+
+    Subscribe,
+
+    Tags,
+
+    Threads,
+
+    Write
+
+  }
   # Read
   @spec read(String.t()) :: T.domain_res(Community.t())
   def read(slug), do: Read.read(slug)

--- a/backend/main/lib/groupher_server/cms/communities/apply.ex
+++ b/backend/main/lib/groupher_server/cms/communities/apply.ex
@@ -6,12 +6,12 @@ defmodule GroupherServer.CMS.Communities.Apply do
   import Helper.Utils, only: [done: 1]
   import ShortMaps
 
-  alias Helper.{ORM, Constant}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
   alias CMS.Communities
   alias CMS.Model.Community
+  alias Helper.Types, as: T
+  alias Helper.{Constant, ORM}
 
   @community_normal Constant.CMS.pending(:normal)
   @community_applying Constant.CMS.pending(:applying)

--- a/backend/main/lib/groupher_server/cms/communities/apply.ex
+++ b/backend/main/lib/groupher_server/cms/communities/apply.ex
@@ -8,9 +8,10 @@ defmodule GroupherServer.CMS.Communities.Apply do
 
   alias Helper.{ORM, Constant}
   alias Helper.Types, as: T
-  alias GroupherServer.CMS.Communities
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.Community
+  alias GroupherServer.{Accounts, CMS}
+  alias Accounts.Model.User
+  alias CMS.Communities
+  alias CMS.Model.Community
 
   @community_normal Constant.CMS.pending(:normal)
   @community_applying Constant.CMS.pending(:applying)

--- a/backend/main/lib/groupher_server/cms/communities/categories.ex
+++ b/backend/main/lib/groupher_server/cms/communities/categories.ex
@@ -5,11 +5,11 @@ defmodule GroupherServer.CMS.Communities.Categories do
   import GroupherServer.CMS.Articles.Write, only: [ensure_author_exists: 1]
   import ShortMaps
 
-  alias Helper.ORM
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
-  alias CMS.Model.{Community, Category, CommunityCategory}
+  alias CMS.Model.{Category, Community, CommunityCategory}
+  alias Helper.ORM
+  alias Helper.Types, as: T
 
   @spec create(map(), User.t()) :: T.domain_res(term())
   def create(attrs, %User{id: user_id}) do

--- a/backend/main/lib/groupher_server/cms/communities/categories.ex
+++ b/backend/main/lib/groupher_server/cms/communities/categories.ex
@@ -7,8 +7,9 @@ defmodule GroupherServer.CMS.Communities.Categories do
 
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, Category, CommunityCategory}
+  alias GroupherServer.{Accounts, CMS}
+  alias Accounts.Model.User
+  alias CMS.Model.{Community, Category, CommunityCategory}
 
   @spec create(map(), User.t()) :: T.domain_res(term())
   def create(attrs, %User{id: user_id}) do

--- a/backend/main/lib/groupher_server/cms/communities/count.ex
+++ b/backend/main/lib/groupher_server/cms/communities/count.ex
@@ -8,9 +8,9 @@ defmodule GroupherServer.CMS.Communities.Count do
 
   alias Helper.{ORM, Transaction, Constant}
   alias Helper.Types, as: T
-  alias GroupherServer.Repo
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, CommunityTag}
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias Accounts.Model.User
+  alias CMS.Model.{Community, CommunityTag}
 
   @article_threads get_config(:article, :threads)
 

--- a/backend/main/lib/groupher_server/cms/communities/count.ex
+++ b/backend/main/lib/groupher_server/cms/communities/count.ex
@@ -6,11 +6,11 @@ defmodule GroupherServer.CMS.Communities.Count do
   import Helper.Utils, only: [get_config: 2, plural: 1, strip_struct: 1]
   import GroupherServer.CMS.Helper.Matcher
 
-  alias Helper.{ORM, Transaction, Constant}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
   alias CMS.Model.{Community, CommunityTag}
+  alias Helper.Types, as: T
+  alias Helper.{Constant, ORM, Transaction}
 
   @article_threads get_config(:article, :threads)
 

--- a/backend/main/lib/groupher_server/cms/communities/dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/communities/dashboard.ex
@@ -5,7 +5,8 @@ defmodule GroupherServer.CMS.Communities.Dashboard do
 
   alias Helper.{ORM, OSS}
   alias Helper.Types, as: T
-  alias GroupherServer.CMS.Model.{Community, CommunityDashboard}
+  alias GroupherServer.CMS
+  alias CMS.Model.{Community, CommunityDashboard}
 
   @default_dashboard CommunityDashboard.default()
 

--- a/backend/main/lib/groupher_server/cms/communities/dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/communities/dashboard.ex
@@ -3,10 +3,10 @@ defmodule GroupherServer.CMS.Communities.Dashboard do
   Dashboard helpers for communities.
   """
 
-  alias Helper.{ORM, OSS}
-  alias Helper.Types, as: T
   alias GroupherServer.CMS
   alias CMS.Model.{Community, CommunityDashboard}
+  alias Helper.Types, as: T
+  alias Helper.{ORM, OSS}
 
   @default_dashboard CommunityDashboard.default()
 

--- a/backend/main/lib/groupher_server/cms/communities/list.ex
+++ b/backend/main/lib/groupher_server/cms/communities/list.ex
@@ -7,8 +7,9 @@ defmodule GroupherServer.CMS.Communities.List do
 
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.Community
+  alias GroupherServer.{Accounts, CMS}
+  alias Accounts.Model.User
+  alias CMS.Model.Community
 
   @spec paged(map(), User.t()) :: T.domain_res(term())
   def paged(filter, %User{meta: meta}) do

--- a/backend/main/lib/groupher_server/cms/communities/list.ex
+++ b/backend/main/lib/groupher_server/cms/communities/list.ex
@@ -5,11 +5,11 @@ defmodule GroupherServer.CMS.Communities.List do
 
   import Helper.Utils, only: [done: 1]
 
-  alias Helper.ORM
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
   alias CMS.Model.Community
+  alias Helper.ORM
+  alias Helper.Types, as: T
 
   @spec paged(map(), User.t()) :: T.domain_res(term())
   def paged(filter, %User{meta: meta}) do

--- a/backend/main/lib/groupher_server/cms/communities/members.ex
+++ b/backend/main/lib/groupher_server/cms/communities/members.ex
@@ -8,8 +8,9 @@ defmodule GroupherServer.CMS.Communities.Members do
 
   alias Helper.{ORM, QueryBuilder}
   alias Helper.Types, as: T
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, CommunityModerator, CommunitySubscriber}
+  alias GroupherServer.{Accounts, CMS}
+  alias Accounts.Model.User
+  alias CMS.Model.{Community, CommunityModerator, CommunitySubscriber}
 
   @doc """
   return paged community subscribers

--- a/backend/main/lib/groupher_server/cms/communities/members.ex
+++ b/backend/main/lib/groupher_server/cms/communities/members.ex
@@ -6,11 +6,11 @@ defmodule GroupherServer.CMS.Communities.Members do
   import Helper.Utils, only: [done: 1]
   import ShortMaps
 
-  alias Helper.{ORM, QueryBuilder}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
   alias CMS.Model.{Community, CommunityModerator, CommunitySubscriber}
+  alias Helper.Types, as: T
+  alias Helper.{ORM, QueryBuilder}
 
   @doc """
   return paged community subscribers

--- a/backend/main/lib/groupher_server/cms/communities/moderator.ex
+++ b/backend/main/lib/groupher_server/cms/communities/moderator.ex
@@ -3,18 +3,14 @@ defmodule GroupherServer.CMS.Communities.Moderator do
   Moderator helpers for communities.
   """
 
-  alias Helper.{Certification, ORM, Transaction}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
-  alias CMS.Communities
-  alias CMS.Model.{Community, CommunityModerator}
   alias CMS.Communities.Passport
+  alias CMS.Model.{Community, CommunityModerator}
+  alias CMS.{Communities, FrontDesk}
   alias Ecto.Multi
-
-
-
-
+  alias Helper.Types, as: T
+  alias Helper.{Certification, ORM, Transaction}
 
   @doc """
   set a community moderator
@@ -70,8 +66,12 @@ defmodule GroupherServer.CMS.Communities.Moderator do
         %User{} = cur_user
       )
       when is_binary(community_slug) do
-    with {:ok, community} <- ORM.find_by(Community, %{slug: community_slug}, preload: :moderators) do
-      update_passport(community, rules, target_user, cur_user)
+    case FrontDesk.community(community_slug) do
+      {:ok, community} ->
+        update_passport(community, rules, target_user, cur_user)
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -106,8 +106,13 @@ defmodule GroupherServer.CMS.Communities.Moderator do
   unset a community moderator
   """
   @spec remove(String.t() | Community.t(), User.t(), User.t()) :: T.domain_res(term())
-  def remove(community_slug, %User{} = target_user, %User{} = cur_user) do
-    with {:ok, community} <- ORM.find_community(community_slug),
+  def remove(%Community{slug: community_slug}, %User{} = target_user, %User{} = cur_user) do
+    remove(community_slug, target_user, cur_user)
+  end
+
+  def remove(community_slug, %User{} = target_user, %User{} = cur_user)
+      when is_binary(community_slug) do
+    with {:ok, community} <- FrontDesk.community(community_slug),
          {:ok, true} <- user_is_root?(community, cur_user) do
       Multi.new()
       |> Multi.run(:stamp_passport, fn _, _ ->
@@ -134,6 +139,9 @@ defmodule GroupherServer.CMS.Communities.Moderator do
     else
       {:error, :community_root_only} ->
         {:error, {:community_root_only, "only community root can remove moderator"}}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/backend/main/lib/groupher_server/cms/communities/moderator.ex
+++ b/backend/main/lib/groupher_server/cms/communities/moderator.ex
@@ -5,11 +5,11 @@ defmodule GroupherServer.CMS.Communities.Moderator do
 
   alias Helper.{Certification, ORM, Transaction}
   alias Helper.Types, as: T
-  alias GroupherServer.Repo
-  alias GroupherServer.CMS.Communities
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, CommunityModerator}
-  alias GroupherServer.CMS.Communities.Passport
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias Accounts.Model.User
+  alias CMS.Communities
+  alias CMS.Model.{Community, CommunityModerator}
+  alias CMS.Communities.Passport
   alias Ecto.Multi
 
 

--- a/backend/main/lib/groupher_server/cms/communities/passport.ex
+++ b/backend/main/lib/groupher_server/cms/communities/passport.ex
@@ -6,9 +6,9 @@ defmodule GroupherServer.CMS.Communities.Passport do
   import Ecto.Query, warn: false
   import ShortMaps
 
-  alias Helper.{Certification, NestedFilter, ORM}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
+  alias Helper.Types, as: T
+  alias Helper.{Certification, NestedFilter, ORM}
 
   alias Accounts.Model.User
   alias CMS.Model.Passport, as: UserPassport

--- a/backend/main/lib/groupher_server/cms/communities/read.ex
+++ b/backend/main/lib/groupher_server/cms/communities/read.ex
@@ -7,9 +7,9 @@ defmodule GroupherServer.CMS.Communities.Read do
 
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.{Accounts, Repo}
+  alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, CommunityDashboard}
+  alias CMS.Model.{Community, CommunityDashboard}
 
   @default_dashboard CommunityDashboard.default()
   @default_read_opt [inc_views: true]

--- a/backend/main/lib/groupher_server/cms/communities/read.ex
+++ b/backend/main/lib/groupher_server/cms/communities/read.ex
@@ -5,11 +5,12 @@ defmodule GroupherServer.CMS.Communities.Read do
 
   import Helper.Utils, only: [done: 1]
 
-  alias Helper.ORM
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
+  alias CMS.FrontDesk
   alias CMS.Model.{Community, CommunityDashboard}
+  alias Helper.ORM
+  alias Helper.Types, as: T
 
   @default_dashboard CommunityDashboard.default()
   @default_read_opt [inc_views: true]
@@ -40,9 +41,8 @@ defmodule GroupherServer.CMS.Communities.Read do
   end
 
   defp do_read(slug, opt) do
-    with {:ok, community} <- ORM.find_community(slug),
+    with {:ok, community} <- FrontDesk.community(slug),
          {:ok, community} <- ensure_community_with_dashboard(community),
-         {:ok, community} <- ORM.fill_meta(community),
          {:ok, community} <- read_moderators(community) do
       case get_in(opt, [:inc_views]) do
         true -> ORM.inc(community, :views)

--- a/backend/main/lib/groupher_server/cms/communities/subscribe.ex
+++ b/backend/main/lib/groupher_server/cms/communities/subscribe.ex
@@ -3,15 +3,13 @@ defmodule GroupherServer.CMS.Communities.Subscribe do
   Subscribe helpers for communities.
   """
 
-
-
-  alias Helper.ORM
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
   alias CMS.Communities
   alias CMS.Model.{Community, CommunitySubscriber}
   alias Ecto.Multi
+  alias Helper.ORM
+  alias Helper.Types, as: T
 
   @doc """
   subscribe a community. (ONLY community, post etc use watch )

--- a/backend/main/lib/groupher_server/cms/communities/subscribe.ex
+++ b/backend/main/lib/groupher_server/cms/communities/subscribe.ex
@@ -7,10 +7,10 @@ defmodule GroupherServer.CMS.Communities.Subscribe do
 
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.{Accounts, Repo}
-  alias GroupherServer.CMS.Communities
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, CommunitySubscriber}
+  alias GroupherServer.{Accounts, CMS, Repo}
+  alias Accounts.Model.User
+  alias CMS.Communities
+  alias CMS.Model.{Community, CommunitySubscriber}
   alias Ecto.Multi
 
   @doc """

--- a/backend/main/lib/groupher_server/cms/communities/tags.ex
+++ b/backend/main/lib/groupher_server/cms/communities/tags.ex
@@ -11,8 +11,7 @@ defmodule GroupherServer.CMS.Communities.Tags do
   import ShortMaps
   import Helper.ErrorCode
 
-  alias Helper.ORM
-  alias Helper.QueryBuilder
+  alias Helper.{ORM, QueryBuilder}
   alias Helper.Types, as: T
   alias GroupherServer.{Accounts, Repo}
 

--- a/backend/main/lib/groupher_server/cms/communities/tags.ex
+++ b/backend/main/lib/groupher_server/cms/communities/tags.ex
@@ -11,14 +11,14 @@ defmodule GroupherServer.CMS.Communities.Tags do
   import ShortMaps
   import Helper.ErrorCode
 
-  alias Helper.{ORM, QueryBuilder}
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, Repo}
+  alias Helper.Types, as: T
+  alias Helper.{ORM, QueryBuilder}
 
-  alias Accounts.Model.User
   alias GroupherServer.CMS
+  alias Accounts.Model.User
 
-  alias CMS.Model.{CommunityTag, Community}
+  alias CMS.Model.{Community, CommunityTag}
 
   alias Ecto.Multi
 
@@ -138,7 +138,7 @@ defmodule GroupherServer.CMS.Communities.Tags do
 
     with true <- tag_in_same_thread?(tag_ids, check_filter),
          {:ok, article} <- do_overwrite_tags(article, []),
-         {:ok, related_tags} = find_related_tags(tag_ids) do
+         {:ok, related_tags} <- find_related_tags(tag_ids) do
       do_overwrite_tags(article, related_tags)
     else
       false ->
@@ -153,11 +153,11 @@ defmodule GroupherServer.CMS.Communities.Tags do
       }) do
     check_filter = %{page: 1, size: 100, community_id: cid, thread: thread}
 
-    with true <- tag_in_same_thread?(tag_ids, check_filter),
-         Enum.each(tag_ids, &add(article, &1))
-         |> done do
-      {:ok, article}
-    else
+    case tag_in_same_thread?(tag_ids, check_filter) do
+      true ->
+        Enum.each(tag_ids, &add(article, &1))
+        {:ok, article}
+
       false ->
         raise_error(:invalid_domain_tag, "tag not in same community & thread")
     end
@@ -223,7 +223,7 @@ defmodule GroupherServer.CMS.Communities.Tags do
   """
   @spec reindex_in_group(Community.t(), atom(), atom(), list()) :: {:ok, atom()} | {:error, any()}
   def reindex_in_group(%Community{} = community, thread, group, indexed_tags) do
-    with {:ok, group_tags} <- _find_group_tags(community, thread, group) do
+    with {:ok, group_tags} <- find_group_tags(community, thread, group) do
       group_tags
       |> Enum.each(fn tag ->
         target =
@@ -246,18 +246,8 @@ defmodule GroupherServer.CMS.Communities.Tags do
     end
   end
 
-  defp _find_group_tags(%Community{} = community, thread, group) do
+  defp find_group_tags(%Community{} = community, thread, group) do
     filter = %{community: community.slug, thread: thread} |> atom_values_to_upcase
-
-    CommunityTag
-    |> where([t], t.group == ^group)
-    |> QueryBuilder.filter_pack(replace_community_ifneed(filter))
-    |> Repo.all()
-    |> done
-  end
-
-  defp _find_group_tags(community, thread, group) do
-    filter = %{community: community, thread: thread} |> atom_values_to_upcase
 
     CommunityTag
     |> where([t], t.group == ^group)

--- a/backend/main/lib/groupher_server/cms/communities/threads.ex
+++ b/backend/main/lib/groupher_server/cms/communities/threads.ex
@@ -4,10 +4,10 @@ defmodule GroupherServer.CMS.Communities.Threads do
   """
   import ShortMaps
 
+  alias GroupherServer.CMS
+  alias CMS.Model.{Community, CommunityThread, Thread}
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.CMS
-  alias CMS.Model.{Community, Thread, CommunityThread}
 
   @spec create(map()) :: T.domain_res(term())
   def create(attrs) do

--- a/backend/main/lib/groupher_server/cms/communities/threads.ex
+++ b/backend/main/lib/groupher_server/cms/communities/threads.ex
@@ -6,7 +6,8 @@ defmodule GroupherServer.CMS.Communities.Threads do
 
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.CMS.Model.{Community, Thread, CommunityThread}
+  alias GroupherServer.CMS
+  alias CMS.Model.{Community, Thread, CommunityThread}
 
   @spec create(map()) :: T.domain_res(term())
   def create(attrs) do

--- a/backend/main/lib/groupher_server/cms/communities/write.ex
+++ b/backend/main/lib/groupher_server/cms/communities/write.ex
@@ -7,12 +7,12 @@ defmodule GroupherServer.CMS.Communities.Write do
   import GroupherServer.CMS.Articles.Write, only: [ensure_author_exists: 1]
   import ShortMaps
 
-  alias Helper.ORM
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
   alias CMS.Communities
-  alias CMS.Model.{Community, Embeds, CommunityDashboard, Thread}
+  alias CMS.Model.{Community, CommunityDashboard, Embeds, Thread}
+  alias Helper.ORM
+  alias Helper.Types, as: T
 
   @default_meta Embeds.CommunityMeta.default_meta()
   @default_dashboard CommunityDashboard.default()

--- a/backend/main/lib/groupher_server/cms/communities/write.ex
+++ b/backend/main/lib/groupher_server/cms/communities/write.ex
@@ -9,10 +9,10 @@ defmodule GroupherServer.CMS.Communities.Write do
 
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.{Accounts, Repo}
-  alias GroupherServer.CMS.Communities
+  alias GroupherServer.{Accounts, CMS, Repo}
   alias Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, Embeds, CommunityDashboard, Thread}
+  alias CMS.Communities
+  alias CMS.Model.{Community, Embeds, CommunityDashboard, Thread}
 
   @default_meta Embeds.CommunityMeta.default_meta()
   @default_dashboard CommunityDashboard.default()

--- a/backend/main/lib/groupher_server/cms/events.ex
+++ b/backend/main/lib/groupher_server/cms/events.ex
@@ -17,7 +17,8 @@ defmodule GroupherServer.CMS.Events do
   or reconfigure events without touching the rest of the codebase.
   """
 
-  alias GroupherServer.CMS.Events.Event
+  alias GroupherServer.CMS
+  alias CMS.Events.Event
 
   @type event_result :: {:ok, term()} | {:error, term()}
 

--- a/backend/main/lib/groupher_server/cms/events/audition.ex
+++ b/backend/main/lib/groupher_server/cms/events/audition.ex
@@ -8,8 +8,8 @@ defmodule GroupherServer.CMS.Events.Audition do
 
   alias GroupherServer.{CMS, Repo}
   alias CMS.Events.Event
-  alias Helper.AuditBot
   alias CMS.Model.Comment
+  alias Helper.AuditBot
 
   @behaviour GroupherServer.CMS.Events.Handler
 

--- a/backend/main/lib/groupher_server/cms/events/audition.ex
+++ b/backend/main/lib/groupher_server/cms/events/audition.ex
@@ -7,9 +7,9 @@ defmodule GroupherServer.CMS.Events.Audition do
   import Ecto.Query, warn: false
 
   alias GroupherServer.{CMS, Repo}
-  alias GroupherServer.CMS.Events.Event
+  alias CMS.Events.Event
   alias Helper.AuditBot
-  alias GroupherServer.CMS.Model.Comment
+  alias CMS.Model.Comment
 
   @behaviour GroupherServer.CMS.Events.Handler
 

--- a/backend/main/lib/groupher_server/cms/events/cite.ex
+++ b/backend/main/lib/groupher_server/cms/events/cite.ex
@@ -34,10 +34,9 @@ defmodule GroupherServer.CMS.Events.Cite do
   import Helper.Utils, only: [get_config: 2]
   import GroupherServer.CMS.Events.Helper, only: [merge_same_block_linker: 2]
 
-
   alias GroupherServer.{CMS, Repo}
+  alias CMS.Events.{CitedArtiment, Event}
   alias CMS.FrontDesk
-  alias CMS.Events.{Event, CitedArtiment}
   alias CMS.Model.Comment
 
   alias Ecto.Multi

--- a/backend/main/lib/groupher_server/cms/events/cite.ex
+++ b/backend/main/lib/groupher_server/cms/events/cite.ex
@@ -32,16 +32,14 @@ defmodule GroupherServer.CMS.Events.Cite do
 
   import GroupherServer.CMS.Helper.Matcher
   import Helper.Utils, only: [get_config: 2]
-  import GroupherServer.CMS.FrontDesk, only: [preload_author: 1, thread_of: 1]
   import GroupherServer.CMS.Events.Helper, only: [merge_same_block_linker: 2]
 
 
   alias GroupherServer.{CMS, Repo}
-  alias GroupherServer.CMS.Events.Event
-  alias CMS.Events.CitedArtiment
+  alias CMS.FrontDesk
+  alias CMS.Events.{Event, CitedArtiment}
   alias CMS.Model.Comment
 
-  alias Helper.ORM
   alias Ecto.Multi
 
   @site_host get_config(:general, :site_host)
@@ -62,7 +60,7 @@ defmodule GroupherServer.CMS.Events.Cite do
   @spec handle(Comment.t() | map()) :: cite_result()
   def handle(%{body: body} = artiment) when not is_nil(body) do
     with {:ok, %{"blocks" => blocks}} <- Jason.decode(body),
-         {:ok, artiment} <- preload_author(artiment) do
+         {:ok, artiment} <- FrontDesk.preload_author(artiment) do
       Multi.new()
       |> Multi.run(:delete_all_cited_artiments, fn _, _ ->
         CitedArtiment.batch_delete_by(artiment)
@@ -133,7 +131,7 @@ defmodule GroupherServer.CMS.Events.Cite do
     try do
       comment_id = URI.decode_query(query) |> Map.get("comment_id")
 
-      with {:ok, comment} <- ORM.find(Comment, comment_id) do
+      with {:ok, comment} <- FrontDesk.get(Comment, comment_id) do
         {:ok, %{type: :comment, artiment: comment}}
       end
     rescue
@@ -148,7 +146,7 @@ defmodule GroupherServer.CMS.Events.Cite do
     article_id = path_list |> Enum.at(2)
 
     with {:ok, info} <- match(thread),
-         {:ok, article} <- ORM.find(info.model, article_id) do
+         {:ok, article} <- FrontDesk.get(info.model, article_id) do
       {:ok, %{type: :article, artiment: article}}
     end
   end
@@ -190,7 +188,7 @@ defmodule GroupherServer.CMS.Events.Cite do
   end
 
   defp shape(article, %{type: :article, artiment: cited}, block_id) do
-    {:ok, thread} = thread_of(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
     {:ok, info} = match(thread)
 
     %{
@@ -205,7 +203,7 @@ defmodule GroupherServer.CMS.Events.Cite do
   end
 
   defp shape(article, %{type: :comment, artiment: cited}, block_id) do
-    {:ok, thread} = thread_of(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
     {:ok, info} = match(thread)
 
     %{

--- a/backend/main/lib/groupher_server/cms/events/cited_artiment.ex
+++ b/backend/main/lib/groupher_server/cms/events/cited_artiment.ex
@@ -15,9 +15,9 @@ defmodule GroupherServer.CMS.Events.CitedArtiment do
   import GroupherServer.CMS.Helper.Matcher
   import ShortMaps
 
-  alias Helper.Types, as: T
   alias GroupherServer.{CMS, Repo}
   alias CMS.FrontDesk
+  alias Helper.Types, as: T
 
   alias Helper.{ORM, QueryBuilder}
 

--- a/backend/main/lib/groupher_server/cms/events/cited_artiment.ex
+++ b/backend/main/lib/groupher_server/cms/events/cited_artiment.ex
@@ -12,13 +12,12 @@ defmodule GroupherServer.CMS.Events.CitedArtiment do
       to_upcase: 1
     ]
 
-  import GroupherServer.CMS.FrontDesk, only: [thread_of: 1, article_of: 1]
-
   import GroupherServer.CMS.Helper.Matcher
   import ShortMaps
 
   alias Helper.Types, as: T
   alias GroupherServer.{CMS, Repo}
+  alias CMS.FrontDesk
 
   alias Helper.{ORM, QueryBuilder}
 
@@ -53,7 +52,7 @@ defmodule GroupherServer.CMS.Events.CitedArtiment do
 
   @spec batch_delete_by(map()) :: {:ok, :pass}
   def batch_delete_by(article) do
-    with {:ok, thread} <- thread_of(article),
+    with {:ok, thread} <- FrontDesk.thread_of(article),
          {:ok, info} <- match(thread) do
       thread = to_upcase(thread)
 
@@ -107,8 +106,8 @@ defmodule GroupherServer.CMS.Events.CitedArtiment do
   defp shape(%CitedArtiment{comment_id: comment_id} = cited) when not is_nil(comment_id) do
     %{block_linker: block_linker, comment: comment, inserted_at: inserted_at} = cited
 
-    {:ok, article} = article_of(comment)
-    {:ok, article_thread} = thread_of(article)
+    {:ok, article} = FrontDesk.article_of(comment)
+    {:ok, article_thread} = FrontDesk.thread_of(article)
 
     user = comment.author |> Map.take([:login, :nickname, :avatar])
 

--- a/backend/main/lib/groupher_server/cms/events/handler.ex
+++ b/backend/main/lib/groupher_server/cms/events/handler.ex
@@ -3,7 +3,8 @@ defmodule GroupherServer.CMS.Events.Handler do
   Callback contract for CMS event handlers.
   """
 
-  alias GroupherServer.CMS.Events.Event
+  alias GroupherServer.CMS
+  alias CMS.Events.Event
 
   @callback handle(Event.t()) :: {:ok, term()} | {:error, term()}
 end

--- a/backend/main/lib/groupher_server/cms/events/mention.ex
+++ b/backend/main/lib/groupher_server/cms/events/mention.ex
@@ -6,12 +6,12 @@ defmodule GroupherServer.CMS.Events.Mention do
   """
   import Ecto.Query, warn: false
   import Helper.Utils, only: [get_config: 2]
-  import GroupherServer.CMS.FrontDesk, only: [preload_author: 1, author_of: 1, thread_of: 1]
 
   import GroupherServer.CMS.Events.Helper, only: [merge_same_block_linker: 2]
 
   alias GroupherServer.{Accounts, CMS, Delivery, Repo}
-  alias GroupherServer.CMS.Events.Event
+  alias CMS.FrontDesk
+  alias CMS.Events.Event
   alias CMS.Model.Comment
 
   @article_threads get_config(:article, :threads)
@@ -32,7 +32,7 @@ defmodule GroupherServer.CMS.Events.Mention do
   @spec handle(Comment.t() | map()) :: mention_result()
   def handle(%{body: body} = artiment) when not is_nil(body) do
     with {:ok, %{"blocks" => blocks}} <- Jason.decode(body),
-         {:ok, artiment} <- preload_author(artiment) do
+         {:ok, artiment} <- FrontDesk.preload_author(artiment) do
       blocks
       |> Enum.reduce([], &(&2 ++ parse_mention_info_per_block(artiment, &1)))
       |> merge_same_block_linker(:to_user_id)
@@ -49,7 +49,7 @@ defmodule GroupherServer.CMS.Events.Mention do
 
   @spec handle_mentions(list(), Comment.t() | map()) :: mention_result()
   defp handle_mentions(mentions, artiment) do
-    with {:ok, author} <- author_of(artiment) do
+    with {:ok, author} <- FrontDesk.author_of(artiment) do
       Delivery.send(:mention, artiment, mentions, author)
     end
   end
@@ -71,7 +71,7 @@ defmodule GroupherServer.CMS.Events.Mention do
   end
 
   defp parse_mention_user_id(artiment, {_, _, [user_login]}) do
-    with {:ok, author} <- author_of(artiment),
+    with {:ok, author} <- FrontDesk.author_of(artiment),
          {:ok, user_id} <- Accounts.get_userid_and_cache(user_login) do
       case author.id !== user_id do
         true -> {:ok, user_id}
@@ -100,7 +100,7 @@ defmodule GroupherServer.CMS.Events.Mention do
   end
 
   defp shape(article, to_user_id, block_id) do
-    {:ok, thread} = thread_of(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     %{
       thread: thread,

--- a/backend/main/lib/groupher_server/cms/events/mention.ex
+++ b/backend/main/lib/groupher_server/cms/events/mention.ex
@@ -10,8 +10,8 @@ defmodule GroupherServer.CMS.Events.Mention do
   import GroupherServer.CMS.Events.Helper, only: [merge_same_block_linker: 2]
 
   alias GroupherServer.{Accounts, CMS, Delivery, Repo}
-  alias CMS.FrontDesk
   alias CMS.Events.Event
+  alias CMS.FrontDesk
   alias CMS.Model.Comment
 
   @article_threads get_config(:article, :threads)

--- a/backend/main/lib/groupher_server/cms/events/notify.ex
+++ b/backend/main/lib/groupher_server/cms/events/notify.ex
@@ -2,11 +2,9 @@ defmodule GroupherServer.CMS.Events.Notify do
   @moduledoc """
   notify events, for upvote, collect, comment, reply
   """
-  import GroupherServer.CMS.FrontDesk,
-    only: [preload_author: 1, article_of: 1, thread_of: 1]
-
   alias GroupherServer.{Accounts, CMS, Delivery, Repo}
-  alias GroupherServer.CMS.Events.Event
+  alias CMS.FrontDesk
+  alias CMS.Events.Event
 
   alias Accounts.Model.User
   alias CMS.Model.Comment
@@ -45,9 +43,9 @@ defmodule GroupherServer.CMS.Events.Notify do
 
   @spec handle(:comment, Comment.t(), User.t()) :: notify_result()
   def handle(:comment, %Comment{} = comment, %User{} = from_user) do
-    {:ok, article} = article_of(comment)
-    {:ok, article} = preload_author(article)
-    {:ok, thread} = thread_of(article)
+    {:ok, article} = FrontDesk.article_of(comment)
+    {:ok, article} = FrontDesk.preload_author(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     notify_attrs = %{
       action: :comment,
@@ -65,9 +63,9 @@ defmodule GroupherServer.CMS.Events.Notify do
   def handle(:reply, %Comment{} = reply_comment, %User{} = from_user) do
     reply_comment = Repo.preload(reply_comment, reply_to: :author)
 
-    {:ok, article} = article_of(reply_comment)
-    {:ok, article} = preload_author(article)
-    {:ok, thread} = thread_of(article)
+    {:ok, article} = FrontDesk.article_of(reply_comment)
+    {:ok, article} = FrontDesk.preload_author(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     notify_attrs = %{
       action: :reply,
@@ -83,8 +81,8 @@ defmodule GroupherServer.CMS.Events.Notify do
 
   @spec handle(notify_action(), Comment.t(), User.t()) :: notify_result()
   def handle(action, %Comment{} = comment, %User{} = from_user) do
-    {:ok, article} = article_of(comment)
-    {:ok, thread} = thread_of(article)
+    {:ok, article} = FrontDesk.article_of(comment)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     notify_attrs = %{
       action: action,
@@ -100,8 +98,8 @@ defmodule GroupherServer.CMS.Events.Notify do
 
   @spec handle(notify_action(), map(), User.t()) :: notify_result()
   def handle(action, article, %User{} = from_user) do
-    {:ok, article} = preload_author(article)
-    {:ok, thread} = thread_of(article)
+    {:ok, article} = FrontDesk.preload_author(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     notify_attrs = %{
       action: action,
@@ -116,8 +114,8 @@ defmodule GroupherServer.CMS.Events.Notify do
 
   @spec handle(:undo, notify_action(), Comment.t(), User.t()) :: notify_result()
   def handle(:undo, action, %Comment{} = comment, %User{} = from_user) do
-    {:ok, article} = article_of(comment)
-    {:ok, thread} = thread_of(article)
+    {:ok, article} = FrontDesk.article_of(comment)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     notify_attrs = %{
       action: action,
@@ -133,8 +131,8 @@ defmodule GroupherServer.CMS.Events.Notify do
 
   @spec handle(:undo, notify_action(), map(), User.t()) :: notify_result()
   def handle(:undo, action, article, %User{} = from_user) do
-    {:ok, article} = preload_author(article)
-    {:ok, thread} = thread_of(article)
+    {:ok, article} = FrontDesk.preload_author(article)
+    {:ok, thread} = FrontDesk.thread_of(article)
 
     notify_attrs = %{
       action: action,

--- a/backend/main/lib/groupher_server/cms/events/notify.ex
+++ b/backend/main/lib/groupher_server/cms/events/notify.ex
@@ -3,8 +3,8 @@ defmodule GroupherServer.CMS.Events.Notify do
   notify events, for upvote, collect, comment, reply
   """
   alias GroupherServer.{Accounts, CMS, Delivery, Repo}
-  alias CMS.FrontDesk
   alias CMS.Events.Event
+  alias CMS.FrontDesk
 
   alias Accounts.Model.User
   alias CMS.Model.Comment

--- a/backend/main/lib/groupher_server/cms/events/subscribe_community.ex
+++ b/backend/main/lib/groupher_server/cms/events/subscribe_community.ex
@@ -5,9 +5,9 @@ defmodule GroupherServer.CMS.Events.SubscribeCommunity do
   import Ecto.Query, warn: false
 
   alias GroupherServer.CMS
-  alias CMS.Events.Event
   alias CMS.Communities
-  alias CMS.Model.{Community, Comment, Post, Blog, Changelog}
+  alias CMS.Events.Event
+  alias CMS.Model.{Blog, Changelog, Comment, Community, Post}
 
   @behaviour GroupherServer.CMS.Events.Handler
 

--- a/backend/main/lib/groupher_server/cms/events/subscribe_community.ex
+++ b/backend/main/lib/groupher_server/cms/events/subscribe_community.ex
@@ -4,11 +4,10 @@ defmodule GroupherServer.CMS.Events.SubscribeCommunity do
   """
   import Ecto.Query, warn: false
 
-  alias GroupherServer.CMS.Events.Event
   alias GroupherServer.CMS
+  alias CMS.Events.Event
   alias CMS.Communities
   alias CMS.Model.{Community, Comment, Post, Blog, Changelog}
-  alias Helper.ORM
 
   @behaviour GroupherServer.CMS.Events.Handler
 
@@ -48,6 +47,6 @@ defmodule GroupherServer.CMS.Events.SubscribeCommunity do
 
   @spec comment_parent_article(module(), integer() | String.t()) :: {:ok, struct()} | {:error, map()}
   defp comment_parent_article(article, id) do
-    ORM.find(article, id, preload: [[author: :user], :community])
+    CMS.FrontDesk.get(article, id, preload: [[author: :user], :community])
   end
 end

--- a/backend/main/lib/groupher_server/cms/front_desk.ex
+++ b/backend/main/lib/groupher_server/cms/front_desk.ex
@@ -6,9 +6,9 @@ defmodule GroupherServer.CMS.FrontDesk do
   import GroupherServer.CMS.Helper.Matcher
   import ShortMaps
 
+  alias GroupherServer.{Accounts, CMS, Repo}
   alias Helper.Types, as: T
   alias Helper.{ORM, QueryBuilder}
-  alias GroupherServer.{Accounts, Repo, CMS}
 
   alias Accounts.Model.User
   alias CMS.Model.{Comment, Community, Thread}

--- a/backend/main/lib/groupher_server/cms/helper/macros.ex
+++ b/backend/main/lib/groupher_server/cms/helper/macros.ex
@@ -4,21 +4,29 @@ defmodule GroupherServer.CMS.Helper.Macros do
   """
   import Helper.Utils, only: [get_config: 2]
 
-  alias GroupherServer.{CMS, Accounts}
+  alias GroupherServer.{Accounts, CMS}
 
   alias Accounts.Model.User
 
   alias CMS.Model.{
-    Embeds,
-    Author,
-    Community,
-    Comment,
-    ArticleUpvote,
-    ArticleCollect,
-    CommunityTag,
-    CommunityJoinTag
-  }
 
+    ArticleCollect,
+
+    ArticleUpvote,
+
+    Author,
+
+    Comment,
+
+    Community,
+
+    CommunityJoinTag,
+
+    CommunityTag,
+
+    Embeds
+
+  }
   @article_threads get_config(:article, :threads)
 
   @doc """

--- a/backend/main/lib/groupher_server/cms/models/abuse_report.ex
+++ b/backend/main/lib/groupher_server/cms/models/abuse_report.ex
@@ -12,9 +12,9 @@ defmodule GroupherServer.CMS.Model.AbuseReport do
 
   alias GroupherServer.{Accounts, CMS}
 
-  alias Helper.Constant.DBPrefix
   alias Accounts.Model.User
   alias CMS.Model.{Comment, Embeds}
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
 

--- a/backend/main/lib/groupher_server/cms/models/article_collect.ex
+++ b/backend/main/lib/groupher_server/cms/models/article_collect.ex
@@ -9,9 +9,9 @@ defmodule GroupherServer.CMS.Model.ArticleCollect do
   import GroupherServer.CMS.Helper.Macros
   import GroupherServer.CMS.Helper.Constraints, only: [articles_foreign_key_constraint: 1]
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.Accounts
-  alias Accounts.Model.{User, CollectFolder}
+  alias Accounts.Model.{CollectFolder, User}
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
 

--- a/backend/main/lib/groupher_server/cms/models/article_upvote.ex
+++ b/backend/main/lib/groupher_server/cms/models/article_upvote.ex
@@ -11,9 +11,9 @@ defmodule GroupherServer.CMS.Model.ArticleUpvote do
   import GroupherServer.CMS.Helper.Constraints,
     only: [articles_foreign_key_constraint: 1, articles_upvote_unique_key_constraint: 1]
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.Accounts
   alias Accounts.Model.User
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
   @article_threads get_config(:article, :threads)

--- a/backend/main/lib/groupher_server/cms/models/article_user_emotion.ex
+++ b/backend/main/lib/groupher_server/cms/models/article_user_emotion.ex
@@ -24,9 +24,9 @@ defmodule GroupherServer.CMS.Model.ArticleUserEmotion do
   import GroupherServer.CMS.Helper.Macros
   import GroupherServer.CMS.Helper.Constraints, only: [articles_foreign_key_constraint: 1]
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.Accounts
   alias Accounts.Model.User
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
   @supported_emotions get_config(:article, :emotions)

--- a/backend/main/lib/groupher_server/cms/models/author.ex
+++ b/backend/main/lib/groupher_server/cms/models/author.ex
@@ -7,9 +7,9 @@ defmodule GroupherServer.CMS.Model.Author do
 
   import Ecto.Changeset
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.Accounts
   alias Accounts.Model.User
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
 

--- a/backend/main/lib/groupher_server/cms/models/blog.ex
+++ b/backend/main/lib/groupher_server/cms/models/blog.ex
@@ -8,9 +8,9 @@ defmodule GroupherServer.CMS.Model.Blog do
   import Ecto.Changeset
   import GroupherServer.CMS.Helper.Macros
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.CMS
   alias CMS.Model.Embeds
+  alias Helper.Constant.DBPrefix
 
   @timestamps_opts [type: :utc_datetime]
 

--- a/backend/main/lib/groupher_server/cms/models/category.ex
+++ b/backend/main/lib/groupher_server/cms/models/category.ex
@@ -5,7 +5,8 @@ defmodule GroupherServer.CMS.Model.Category do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias GroupherServer.CMS.Model.{Author, Community, CommunityCategory}
+  alias GroupherServer.CMS
+  alias CMS.Model.{Author, Community, CommunityCategory}
   alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()

--- a/backend/main/lib/groupher_server/cms/models/changelog_document.ex
+++ b/backend/main/lib/groupher_server/cms/models/changelog_document.ex
@@ -10,9 +10,9 @@ defmodule GroupherServer.CMS.Model.ChangelogDocument do
   import Ecto.Changeset
   import Helper.Utils, only: [get_config: 2]
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.CMS
   alias CMS.Model.Changelog
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
   @timestamps_opts [type: :utc_datetime]

--- a/backend/main/lib/groupher_server/cms/models/cited_artiment.ex
+++ b/backend/main/lib/groupher_server/cms/models/cited_artiment.ex
@@ -11,8 +11,8 @@ defmodule GroupherServer.CMS.Model.CitedArtiment do
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
 
-  alias Helper.Constant.DBPrefix
   alias CMS.Model.Comment
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
 

--- a/backend/main/lib/groupher_server/cms/models/comment.ex
+++ b/backend/main/lib/groupher_server/cms/models/comment.ex
@@ -12,7 +12,7 @@ defmodule GroupherServer.CMS.Model.Comment do
 
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
-  alias CMS.Model.{Embeds, CommentUpvote}
+  alias CMS.Model.{CommentUpvote, Embeds}
   alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()

--- a/backend/main/lib/groupher_server/cms/models/community.ex
+++ b/backend/main/lib/groupher_server/cms/models/community.ex
@@ -7,20 +7,27 @@ defmodule GroupherServer.CMS.Model.Community do
 
   import Ecto.Changeset
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
+  alias Helper.Constant.DBPrefix
 
   alias CMS.Model.{
-    Embeds,
-    CommunityDashboard,
-    Category,
-    CommunityCategory,
-    CommunityThread,
-    CommunitySubscriber,
-    CommunityModerator
-  }
 
+    Category,
+
+    CommunityCategory,
+
+    CommunityDashboard,
+
+    CommunityModerator,
+
+    CommunitySubscriber,
+
+    CommunityThread,
+
+    Embeds
+
+  }
   @type t :: %__MODULE__{}
 
   @schema_prefix DBPrefix.cms()

--- a/backend/main/lib/groupher_server/cms/models/community_dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/models/community_dashboard.ex
@@ -13,10 +13,12 @@ defmodule GroupherServer.CMS.Model.CommunityDashboard do
   alias Helper.Constant.DBPrefix
 
   alias CMS.Model.{
-    Embeds,
-    Community
-  }
 
+    Community,
+
+    Embeds
+
+  }
   @schema_prefix DBPrefix.cms()
 
   @required_fields ~w(community_id)a

--- a/backend/main/lib/groupher_server/cms/models/community_dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/models/community_dashboard.ex
@@ -9,7 +9,6 @@ defmodule GroupherServer.CMS.Model.CommunityDashboard do
 
   import Ecto.Changeset
 
-  alias GroupherServer.CMS.Model.CommunityDashboard
   alias GroupherServer.CMS
   alias Helper.Constant.DBPrefix
 

--- a/backend/main/lib/groupher_server/cms/models/community_join_blog.ex
+++ b/backend/main/lib/groupher_server/cms/models/community_join_blog.ex
@@ -6,7 +6,7 @@ defmodule GroupherServer.CMS.Model.CommunityJoinBlog do
   use Accessible
 
   alias GroupherServer.CMS
-  alias CMS.Model.{Community, Blog}
+  alias CMS.Model.{Blog, Community}
   alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()

--- a/backend/main/lib/groupher_server/cms/models/community_join_changelog.ex
+++ b/backend/main/lib/groupher_server/cms/models/community_join_changelog.ex
@@ -6,7 +6,7 @@ defmodule GroupherServer.CMS.Model.CommunityJoinChangelog do
   use Accessible
 
   alias GroupherServer.CMS
-  alias CMS.Model.{Community, Changelog}
+  alias CMS.Model.{Changelog, Community}
   alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()

--- a/backend/main/lib/groupher_server/cms/models/doc.ex
+++ b/backend/main/lib/groupher_server/cms/models/doc.ex
@@ -11,8 +11,8 @@ defmodule GroupherServer.CMS.Model.Doc do
   alias GroupherServer.CMS
   alias CMS.Model.Embeds
 
-  alias Helper.HTML
   alias Helper.Constant.DBPrefix
+  alias Helper.HTML
 
   @schema_prefix DBPrefix.cms()
 

--- a/backend/main/lib/groupher_server/cms/models/embeds/article_meta.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/article_meta.ex
@@ -8,7 +8,8 @@ defmodule GroupherServer.CMS.Model.Embeds.ArticleMeta do
   use Accessible
   import Ecto.Changeset
 
-  alias GroupherServer.CMS.Model.Embeds
+  alias GroupherServer.CMS
+  alias CMS.Model.Embeds
 
   @optional_fields ~w(thread is_edited is_comment_locked upvoted_user_ids collected_user_ids viewed_user_ids comments_participant_user_ids reported_user_ids reported_count is_sunk can_undo_sink last_active_at is_legal illegal_reason illegal_words)a
 

--- a/backend/main/lib/groupher_server/cms/models/embeds/block_task_runner.ex
+++ b/backend/main/lib/groupher_server/cms/models/embeds/block_task_runner.ex
@@ -8,7 +8,8 @@ defmodule GroupherServer.CMS.Model.Embeds.BlockTaskRunner do
   use Accessible
   import Ecto.Changeset
 
-  alias GroupherServer.CMS.Model.Embeds
+  alias GroupherServer.CMS
+  alias CMS.Model.Embeds
 
   @optional_fields ~w(bi_link_tasks)a
   # @optional_fields ~w(bi_link_tasks mention_user_tasks)a

--- a/backend/main/lib/groupher_server/cms/models/passport.ex
+++ b/backend/main/lib/groupher_server/cms/models/passport.ex
@@ -5,9 +5,9 @@ defmodule GroupherServer.CMS.Model.Passport do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.Accounts
   alias Accounts.Model.User
+  alias Helper.Constant.DBPrefix
 
   @required_fields ~w(rules user_id)a
   @optional_fields ~w(rules)a

--- a/backend/main/lib/groupher_server/cms/models/pinned_article.ex
+++ b/backend/main/lib/groupher_server/cms/models/pinned_article.ex
@@ -9,9 +9,9 @@ defmodule GroupherServer.CMS.Model.PinnedArticle do
   import GroupherServer.CMS.Helper.Macros
   import GroupherServer.CMS.Helper.Constraints, only: [articles_foreign_key_constraint: 1]
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.CMS
   alias CMS.Model.Community
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
   @article_threads get_config(:article, :threads)

--- a/backend/main/lib/groupher_server/cms/models/pinned_comment.ex
+++ b/backend/main/lib/groupher_server/cms/models/pinned_comment.ex
@@ -10,9 +10,9 @@ defmodule GroupherServer.CMS.Model.PinnedComment do
   import GroupherServer.CMS.Helper.Macros
   import GroupherServer.CMS.Helper.Constraints, only: [articles_foreign_key_constraint: 1]
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.CMS
   alias CMS.Model.Comment
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
   # alias Helper.HTML

--- a/backend/main/lib/groupher_server/cms/models/post.ex
+++ b/backend/main/lib/groupher_server/cms/models/post.ex
@@ -9,10 +9,10 @@ defmodule GroupherServer.CMS.Model.Post do
   import Ecto.Changeset
   import GroupherServer.CMS.Helper.Macros
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.CMS
   alias CMS.Helper.ArticleEnums
   alias CMS.Model.Embeds
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
   @timestamps_opts [type: :utc_datetime]

--- a/backend/main/lib/groupher_server/cms/models/post_document.ex
+++ b/backend/main/lib/groupher_server/cms/models/post_document.ex
@@ -10,9 +10,9 @@ defmodule GroupherServer.CMS.Model.PostDocument do
   import Ecto.Changeset
   import Helper.Utils, only: [get_config: 2]
 
-  alias Helper.Constant.DBPrefix
   alias GroupherServer.CMS
   alias CMS.Model.Post
+  alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
 

--- a/backend/main/lib/groupher_server/cms/search.ex
+++ b/backend/main/lib/groupher_server/cms/search.ex
@@ -9,9 +9,9 @@ defmodule GroupherServer.CMS.Search do
 
   alias Helper.ORM
   alias Helper.Types, as: T
-
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.Community
+  alias GroupherServer.{Accounts, CMS}
+  alias Accounts.Model.User
+  alias CMS.Model.Community
 
   @search_items_count 15
 

--- a/backend/main/lib/groupher_server/cms/search.ex
+++ b/backend/main/lib/groupher_server/cms/search.ex
@@ -7,11 +7,11 @@ defmodule GroupherServer.CMS.Search do
   import Ecto.Query, warn: false
   import GroupherServer.CMS.Helper.Matcher
 
-  alias Helper.ORM
-  alias Helper.Types, as: T
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
   alias CMS.Model.Community
+  alias Helper.ORM
+  alias Helper.Types, as: T
 
   @search_items_count 15
 

--- a/backend/main/lib/groupher_server/cms/seeds.ex
+++ b/backend/main/lib/groupher_server/cms/seeds.ex
@@ -19,13 +19,13 @@ defmodule GroupherServer.CMS.Seeds do
       insert_community: 3
     ]
 
+  alias GroupherServer.CMS
   alias Helper.ORM
   alias Helper.Types, as: T
-  alias GroupherServer.CMS
 
-  alias CMS.Model.{Community, Category, Post, Comment}
+  alias CMS.Model.{Category, Comment, Community, Post}
 
-  alias __MODULE__.{Domain, Communities}
+  alias __MODULE__.{Communities, Domain}
 
   @article_threads get_config(:article, :threads)
   @community_types [:pl, :framework]

--- a/backend/main/lib/groupher_server/cms/seeds/articles.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/articles.ex
@@ -7,9 +7,9 @@ defmodule GroupherServer.CMS.Seeds.Articles do
   # import Helper.Utils, only: [done: 1, get_config: 2]
   import Ecto.Query, warn: false
 
-  alias Helper.ORM
   alias GroupherServer.{Accounts, CMS}
   alias Accounts.Model.User
+  alias Helper.ORM
 
   alias CMS.Model.{Community}
 

--- a/backend/main/lib/groupher_server/cms/seeds/articles.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/articles.ex
@@ -8,8 +8,8 @@ defmodule GroupherServer.CMS.Seeds.Articles do
   import Ecto.Query, warn: false
 
   alias Helper.ORM
-  alias GroupherServer.CMS
-  alias GroupherServer.Accounts.Model.User
+  alias GroupherServer.{Accounts, CMS}
+  alias Accounts.Model.User
 
   alias CMS.Model.{Community}
 

--- a/backend/main/lib/groupher_server/cms/seeds/domain.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/domain.ex
@@ -15,8 +15,8 @@ defmodule GroupherServer.CMS.Seeds.Domain do
       seed_categories_ifneed: 1
     ]
 
-  alias Helper.ORM
   alias GroupherServer.CMS
+  alias Helper.ORM
 
   alias CMS.Model.Community
 

--- a/backend/main/lib/groupher_server/cms/seeds/helper.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/helper.ex
@@ -6,8 +6,8 @@ defmodule GroupherServer.CMS.Seeds.Helper do
   import ShortMaps
 
   alias GroupherServer.{Accounts, CMS}
+  alias CMS.Model.{Category, Community, Thread}
   alias CMS.Seeds.SeedsConfig
-  alias CMS.Model.{Community, Thread, Category}
 
   alias Accounts.Model.User
   alias Helper.ORM


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored CMS modules to route data access and shared helpers through CMS.FrontDesk, replacing direct ORM calls and scattered utilities. Also tightened error handling in lifecycle, comments, tags, and events to make behaviors more predictable.

- **Refactors**
  - Replaced ORM.find-style calls with FrontDesk.get/article/comment/community helpers across read/moderation/subscribe flows.
  - Unified use of FrontDesk.thread_of, article_of, preload_author, author_of, sync_embed_replies, and mark_viewer_emotion_states in articles, comments, abuse reports, and events.
  - Centralized reaction/emotion logic in FrontDesk: update_emotions_field, load_reaction_users, update_article_reaction_user_list.
  - Hardened edge cases: safer sink/undo, pinned comment limit checks, solution state updates, and consistent error returns in actions/CRUD.
  - Updated event handlers (notify, mention, cite, subscribe_community) to use FrontDesk for fetching and shaping data, and standardized aliases under GroupherServer.{Accounts, CMS}.

<sup>Written for commit 9cd14ddfeeb6847005abeac08043aa356f589f09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal module aliasing and standardized backend access patterns across CMS services for more consistent behavior and maintainability. No public API changes.

* **Chores**
  * General code organization and alias cleanup across many modules to improve readability and reduce internal duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->