### PR TITLE
refactor(be): helper.types -> helper.t & fmt

### DIFF
--- a/backend/main/lib/groupher_server/accounts/achievements.ex
+++ b/backend/main/lib/groupher_server/accounts/achievements.ex
@@ -4,7 +4,7 @@ defmodule GroupherServer.Accounts.Achievements do
   """
 
   alias GroupherServer.Accounts.Model.User
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias __MODULE__.{Membership, Moderatorable, Reputation}
 

--- a/backend/main/lib/groupher_server/accounts/achievements/moderatorable.ex
+++ b/backend/main/lib/groupher_server/accounts/achievements/moderatorable.ex
@@ -4,9 +4,11 @@ defmodule GroupherServer.Accounts.Achievements.Moderatorable do
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]
 
-  alias GroupherServer.Accounts.FrontDesk
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.CommunityModerator
+  alias GroupherServer.{Accounts, CMS}
+
+  alias Accounts.FrontDesk
+  alias Accounts.Model.User
+  alias CMS.Model.CommunityModerator
   alias Helper.ORM
 
   def paged_moderatorable_communities(%User{id: user_id}, %{page: page, size: size}) do

--- a/backend/main/lib/groupher_server/accounts/collect_folders.ex
+++ b/backend/main/lib/groupher_server/accounts/collect_folders.ex
@@ -3,7 +3,7 @@ defmodule GroupherServer.Accounts.CollectFolders do
   Accounts collect folders facade.
   """
   alias GroupherServer.Accounts.Model.User
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias __MODULE__.{Articles, List, Write}
 

--- a/backend/main/lib/groupher_server/accounts/collect_folders/articles.ex
+++ b/backend/main/lib/groupher_server/accounts/collect_folders/articles.ex
@@ -6,11 +6,11 @@ defmodule GroupherServer.Accounts.CollectFolders.Articles do
 
   alias GroupherServer.Accounts.Model.{CollectFolder, User}
   alias GroupherServer.Repo
-  alias Helper.{ORM, Types}
+  alias Helper.{ORM, T}
 
   @article_threads get_config(:article, :threads)
 
-  @spec paged(Types.id(), map()) :: Types.domain_res(Types.paged_data())
+  @spec paged(T.id(), map()) :: T.domain_res(T.paged_data())
   def paged(folder_id, filter) do
     with {:ok, folder} <- ORM.find(CollectFolder, folder_id) do
       case folder.private do
@@ -20,7 +20,7 @@ defmodule GroupherServer.Accounts.CollectFolders.Articles do
     end
   end
 
-  @spec paged(Types.id(), map(), User.t()) :: Types.domain_res(Types.paged_data())
+  @spec paged(T.id(), map(), User.t()) :: T.domain_res(T.paged_data())
   def paged(folder_id, filter, %User{id: cur_user_id}) do
     with {:ok, folder} <- ORM.find(CollectFolder, folder_id) do
       is_valid_request = if folder.private, do: folder.user_id == cur_user_id, else: true

--- a/backend/main/lib/groupher_server/accounts/collect_folders/list.ex
+++ b/backend/main/lib/groupher_server/accounts/collect_folders/list.ex
@@ -2,19 +2,18 @@ defmodule GroupherServer.Accounts.CollectFolders.List do
   @moduledoc false
 
   import Ecto.Query, warn: false
-
   import Helper.Utils, only: [done: 1]
 
   alias GroupherServer.Accounts.Model.{CollectFolder, User}
-  alias Helper.{ORM, QueryBuilder, Types}
+  alias Helper.{ORM, QueryBuilder, T}
 
-  @spec page(Types.id(), map()) :: Types.domain_res(Types.paged_data())
+  @spec page(T.id(), map()) :: T.domain_res(T.paged_data())
   def page(user_id, filter) do
     query = CollectFolder |> where([c], c.user_id == ^user_id and not c.private)
     do_paged(filter, query)
   end
 
-  @spec page(Types.id(), map(), User.t()) :: Types.domain_res(Types.paged_data())
+  @spec page(T.id(), map(), User.t()) :: T.domain_res(T.paged_data())
   def page(user_id, filter, %User{id: cur_user_id}) do
     query =
       if cur_user_id == user_id,

--- a/backend/main/lib/groupher_server/accounts/collect_folders/write.ex
+++ b/backend/main/lib/groupher_server/accounts/collect_folders/write.ex
@@ -7,14 +7,14 @@ defmodule GroupherServer.Accounts.CollectFolders.Write do
   import Helper.ErrorCode
   import ShortMaps
 
-  alias GroupherServer.{CMS, Repo}
+  alias GroupherServer.{Accounts, CMS, Repo}
 
-  alias GroupherServer.Accounts.Model.{CollectFolder, Embeds, User}
+  alias Accounts.Model.{CollectFolder, Embeds, User}
   alias Ecto.Multi
-  alias Helper.{ORM, Types}
+  alias Helper.{ORM, T}
 
   @default_meta Embeds.CollectFolderMeta.default_meta()
-  @spec create(map(), User.t()) :: Types.domain_res(CollectFolder.t())
+  @spec create(map(), User.t()) :: T.domain_res(CollectFolder.t())
   def create(%{title: title} = attrs, %User{id: user_id}) do
     case ORM.find_by(CollectFolder, ~m(user_id title)a) do
       {:error, _} ->
@@ -33,7 +33,7 @@ defmodule GroupherServer.Accounts.CollectFolders.Write do
     end
   end
 
-  @spec update(Types.id(), map()) :: Types.domain_res(CollectFolder.t())
+  @spec update(T.id(), map()) :: T.domain_res(CollectFolder.t())
   def update(folder_id, attrs) do
     with {:ok, folder} <- ORM.find(CollectFolder, folder_id) do
       last_updated = Timex.today() |> Timex.to_datetime()
@@ -41,7 +41,7 @@ defmodule GroupherServer.Accounts.CollectFolders.Write do
     end
   end
 
-  @spec delete(Types.id()) :: Types.domain_res(CollectFolder.t())
+  @spec delete(T.id()) :: T.domain_res(CollectFolder.t())
   def delete(id) do
     with {:ok, folder} <- ORM.find(CollectFolder, id) do
       case Enum.empty?(folder.collects) do
@@ -51,7 +51,7 @@ defmodule GroupherServer.Accounts.CollectFolders.Write do
     end
   end
 
-  @spec add(Types.article(), Types.id(), User.t()) :: Types.domain_res(Types.article())
+  @spec add(T.article(), T.id(), User.t()) :: T.domain_res(T.article())
   def add(article, folder_id, %User{} = user) do
     with {:ok, thread} <- thread_of(article),
          {:ok, folder} <- ORM.find(CollectFolder, folder_id),
@@ -77,7 +77,7 @@ defmodule GroupherServer.Accounts.CollectFolders.Write do
     end
   end
 
-  @spec remove(Types.article(), Types.id(), User.t()) :: Types.domain_res(Types.article())
+  @spec remove(T.article(), T.id(), User.t()) :: T.domain_res(T.article())
   def remove(article, folder_id, %User{} = user) do
     with {:ok, thread} <- thread_of(article),
          {:ok, folder} <- ORM.find(CollectFolder, folder_id),
@@ -105,7 +105,8 @@ defmodule GroupherServer.Accounts.CollectFolders.Write do
   defp article_not_in_folder(article, collects) do
     with {:ok, thread} <- thread_of(article),
          {:ok, info} <- match(thread) do
-      already_collected = Enum.any?(collects, fn c -> article.id == Map.get(c, info.foreign_key) end)
+      already_collected =
+        Enum.any?(collects, fn c -> article.id == Map.get(c, info.foreign_key) end)
 
       case already_collected do
         true -> raise_error(:already_collected_in_folder, "already collected in this folder")

--- a/backend/main/lib/groupher_server/accounts/fans.ex
+++ b/backend/main/lib/groupher_server/accounts/fans.ex
@@ -4,7 +4,7 @@ defmodule GroupherServer.Accounts.Fans do
   """
 
   alias GroupherServer.Accounts.Model.User
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias __MODULE__.{Actions, List, ViewerState}
 

--- a/backend/main/lib/groupher_server/accounts/fans/actions.ex
+++ b/backend/main/lib/groupher_server/accounts/fans/actions.ex
@@ -8,9 +8,9 @@ defmodule GroupherServer.Accounts.Fans.Actions do
   alias Accounts.Model.{User, UserFollower, UserFollowing}
 
   alias Ecto.Multi
-  alias Helper.{Later, ORM, Types}
+  alias Helper.{Later, ORM, T}
 
-  @spec follow(User.t(), User.t()) :: {:ok, User.t()} | Types.gq_error()
+  @spec follow(User.t(), User.t()) :: {:ok, User.t()} | T.gq_error()
   def follow(%User{} = user, %User{} = follower) do
     with true <- to_string(user.id) !== to_string(follower.id),
          {:ok, user} <- FrontDesk.user(user.id),
@@ -44,7 +44,7 @@ defmodule GroupherServer.Accounts.Fans.Actions do
     end
   end
 
-  @spec undo_follow(User.t(), User.t()) :: {:ok, User.t()} | Types.gq_error()
+  @spec undo_follow(User.t(), User.t()) :: {:ok, User.t()} | T.gq_error()
   def undo_follow(%User{} = user, %User{} = follower) do
     with true <- to_string(user.id) !== to_string(follower.id),
          {:ok, user} <- FrontDesk.user(user.id),
@@ -103,7 +103,7 @@ defmodule GroupherServer.Accounts.Fans.Actions do
     end
   end
 
-  @spec result({:ok, map()}) :: Types.done()
+  @spec result({:ok, map()}) :: T.done()
   defp result({:ok, %{create_follower: user_follower}}) do
     User |> ORM.find(user_follower.user_id)
   end

--- a/backend/main/lib/groupher_server/accounts/fans/list.ex
+++ b/backend/main/lib/groupher_server/accounts/fans/list.ex
@@ -5,8 +5,10 @@ defmodule GroupherServer.Accounts.Fans.List do
   import Helper.Utils, only: [done: 1]
   import ShortMaps
 
-  alias GroupherServer.Accounts.Fans.ViewerState
-  alias GroupherServer.Accounts.Model.{User, UserFollower, UserFollowing}
+  alias GroupherServer.Accounts
+
+  alias Accounts.Fans.ViewerState
+  alias Accounts.Model.{User, UserFollower, UserFollowing}
   alias Helper.{ORM, QueryBuilder}
 
   def paged_followers(%User{id: user_id}, filter, %User{} = cur_user) do

--- a/backend/main/lib/groupher_server/accounts/models/achievement.ex
+++ b/backend/main/lib/groupher_server/accounts/models/achievement.ex
@@ -5,7 +5,8 @@ defmodule GroupherServer.Accounts.Model.Achievement do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias GroupherServer.Accounts.Model.{SourceContribute, User}
+  alias GroupherServer.Accounts
+  alias Accounts.Model.{SourceContribute, User}
   alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.account()

--- a/backend/main/lib/groupher_server/accounts/profiles.ex
+++ b/backend/main/lib/groupher_server/accounts/profiles.ex
@@ -4,7 +4,7 @@ defmodule GroupherServer.Accounts.Profiles do
   """
 
   alias GroupherServer.Accounts.Model.User
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias __MODULE__.{List, Oauth, Subscribe, UserRead}
 

--- a/backend/main/lib/groupher_server/accounts/publish.ex
+++ b/backend/main/lib/groupher_server/accounts/publish.ex
@@ -4,7 +4,7 @@ defmodule GroupherServer.Accounts.Publish do
   """
 
   alias GroupherServer.Accounts.Model.User
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias __MODULE__.{Articles, Comments}
 

--- a/backend/main/lib/groupher_server/accounts/publish/articles.ex
+++ b/backend/main/lib/groupher_server/accounts/publish/articles.ex
@@ -3,9 +3,10 @@ defmodule GroupherServer.Accounts.Publish.Articles do
 
   import Helper.Utils, only: [plural: 1]
 
-  alias GroupherServer.Accounts.FrontDesk
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS
+  alias GroupherServer.{Accounts, CMS}
+
+  alias Accounts.FrontDesk
+  alias Accounts.Model.User
   alias Helper.ORM
 
   def paged(%User{id: user_id}, thread, filter) do

--- a/backend/main/lib/groupher_server/accounts/search.ex
+++ b/backend/main/lib/groupher_server/accounts/search.ex
@@ -4,7 +4,7 @@ defmodule GroupherServer.Accounts.Search do
   """
 
   alias __MODULE__.User
-  alias Helper.Types, as: T
+  alias Helper.T
 
   @spec user(String.t()) :: T.domain_res(T.paged_users())
   def user(name) when is_binary(name), do: User.search(name)

--- a/backend/main/lib/groupher_server/cms/abuse_reports.ex
+++ b/backend/main/lib/groupher_server/cms/abuse_reports.ex
@@ -7,7 +7,7 @@ defmodule GroupherServer.CMS.AbuseReports do
 
   alias Accounts.Model.User
   alias CMS.Model.Comment
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias __MODULE__.{List, Report}
 

--- a/backend/main/lib/groupher_server/cms/abuse_reports/list.ex
+++ b/backend/main/lib/groupher_server/cms/abuse_reports/list.ex
@@ -9,8 +9,7 @@ defmodule GroupherServer.CMS.AbuseReports.List do
   alias GroupherServer.CMS
 
   alias CMS.Model.{AbuseReport, Comment}
-  alias Helper.Types, as: T
-  alias Helper.{ORM, QueryBuilder}
+  alias Helper.{ORM, QueryBuilder, T}
 
   import Helper.Utils, only: [done: 1, get_config: 2]
 

--- a/backend/main/lib/groupher_server/cms/abuse_reports/report.ex
+++ b/backend/main/lib/groupher_server/cms/abuse_reports/report.ex
@@ -10,8 +10,7 @@ defmodule GroupherServer.CMS.AbuseReports.Report do
 
   alias CMS.FrontDesk
   alias GroupherServer.{Accounts, CMS, Repo}
-  alias Helper.Types, as: T
-  alias Helper.{ORM, Transaction}
+  alias Helper.{ORM, T, Transaction}
 
   alias Accounts.Model.User
   alias CMS.Model.{AbuseReport, Comment, Embeds}

--- a/backend/main/lib/groupher_server/cms/articles.ex
+++ b/backend/main/lib/groupher_server/cms/articles.ex
@@ -3,7 +3,7 @@ defmodule GroupherServer.CMS.Articles do
   CMS articles facade.
   """
 
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias GroupherServer.{Accounts, CMS}
 

--- a/backend/main/lib/groupher_server/cms/articles/collects.ex
+++ b/backend/main/lib/groupher_server/cms/articles/collects.ex
@@ -12,8 +12,7 @@ defmodule GroupherServer.CMS.Articles.Collects do
   alias CMS.Model.ArticleCollect
   alias CMS.{Events, FrontDesk}
   alias Ecto.Multi
-  alias Helper.Types, as: T
-  alias Helper.{Later, ORM, Transaction}
+  alias Helper.{Later, ORM, T, Transaction}
 
   @spec collected_users(term(), map()) :: T.domain_res(term())
   def collected_users(article, filter),

--- a/backend/main/lib/groupher_server/cms/articles/document.ex
+++ b/backend/main/lib/groupher_server/cms/articles/document.ex
@@ -8,8 +8,7 @@ defmodule GroupherServer.CMS.Articles.Document do
 
   alias CMS.FrontDesk
   alias CMS.Model.ArticleDocument
-  alias Helper.Types, as: T
-  alias Helper.{Converter, ORM}
+  alias Helper.{Converter, ORM, T}
 
   alias Ecto.Multi
 

--- a/backend/main/lib/groupher_server/cms/articles/list.ex
+++ b/backend/main/lib/groupher_server/cms/articles/list.ex
@@ -22,8 +22,7 @@ defmodule GroupherServer.CMS.Articles.List do
   alias CMS.FrontDesk
   alias CMS.Helper.ArticleEnums
   alias CMS.Model.{CitedArtiment, Community, PinnedArticle, Post}
-  alias Helper.Types, as: T
-  alias Helper.{ORM, QueryBuilder}
+  alias Helper.{ORM, QueryBuilder, T}
 
   @article_threads get_config(:article, :threads)
   @article_preloads @article_threads |> Enum.map(&Keyword.new([{&1, [author: :user]}]))

--- a/backend/main/lib/groupher_server/cms/articles/moderation.ex
+++ b/backend/main/lib/groupher_server/cms/articles/moderation.ex
@@ -15,8 +15,7 @@ defmodule GroupherServer.CMS.Articles.Moderation do
   alias GroupherServer.FrontDesk, as: UserFrontDesk
 
   alias Ecto.Multi
-  alias Helper.{Constant, ORM, QueryBuilder}
-  alias Helper.Types, as: T
+  alias Helper.{Constant, ORM, QueryBuilder, T}
 
   @audit_legal Constant.CMS.pending(:legal)
   @audit_illegal Constant.CMS.pending(:illegal)

--- a/backend/main/lib/groupher_server/cms/articles/reactions.ex
+++ b/backend/main/lib/groupher_server/cms/articles/reactions.ex
@@ -13,8 +13,7 @@ defmodule GroupherServer.CMS.Articles.Reactions do
   alias CMS.Model.ArticleUserEmotion
 
   alias Ecto.Multi
-  alias Helper.Types, as: T
-  alias Helper.{ORM, Transaction}
+  alias Helper.{ORM, T, Transaction}
 
   import Ecto.Query
 

--- a/backend/main/lib/groupher_server/cms/articles/read.ex
+++ b/backend/main/lib/groupher_server/cms/articles/read.ex
@@ -18,8 +18,7 @@ defmodule GroupherServer.CMS.Articles.Read do
   alias CMS.Model.{Community, PinnedArticle}
 
   alias Ecto.Multi
-  alias Helper.Types, as: T
-  alias Helper.{Constant, ORM}
+  alias Helper.{Constant, ORM, T}
 
   @active_period get_config(:article, :active_period_days)
   @article_threads get_config(:article, :threads)

--- a/backend/main/lib/groupher_server/cms/articles/states.ex
+++ b/backend/main/lib/groupher_server/cms/articles/states.ex
@@ -16,8 +16,7 @@ defmodule GroupherServer.CMS.Articles.States do
   alias CMS.{Communities, FrontDesk}
 
   alias Ecto.Multi
-  alias Helper.{ORM, Transaction}
-  alias Helper.Types, as: T
+  alias Helper.{ORM, T, Transaction}
 
   @active_period get_config(:article, :active_period_days)
   @archive_threshold get_config(:article, :archive_threshold)

--- a/backend/main/lib/groupher_server/cms/articles/upvotes.ex
+++ b/backend/main/lib/groupher_server/cms/articles/upvotes.ex
@@ -13,8 +13,7 @@ defmodule GroupherServer.CMS.Articles.Upvotes do
   alias CMS.{Events, FrontDesk}
 
   alias Ecto.Multi
-  alias Helper.Types, as: T
-  alias Helper.{Later, ORM, Transaction}
+  alias Helper.{Later, ORM, T, Transaction}
 
   @spec upvoted_users(term(), map()) :: T.domain_res(term())
   def upvoted_users(article, filter),

--- a/backend/main/lib/groupher_server/cms/articles/write.ex
+++ b/backend/main/lib/groupher_server/cms/articles/write.ex
@@ -25,8 +25,7 @@ import Helper.Utils,
   alias CMS.{Communities, Events, FrontDesk}
 
   alias Ecto.Multi
-  alias Helper.{Converter, Later, ORM, Transaction}
-  alias Helper.Types, as: T
+  alias Helper.{Converter, Later, ORM, T, Transaction}
 
   @default_emotions Embeds.ArticleEmotion.default_emotions()
   @default_article_meta Embeds.ArticleMeta.default_meta()

--- a/backend/main/lib/groupher_server/cms/comments.ex
+++ b/backend/main/lib/groupher_server/cms/comments.ex
@@ -7,7 +7,7 @@ defmodule GroupherServer.CMS.Comments do
 
   alias Accounts.Model.User
   alias CMS.Model.{Comment, Community}
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias __MODULE__.{
     States,

--- a/backend/main/lib/groupher_server/cms/comments/emotion.ex
+++ b/backend/main/lib/groupher_server/cms/comments/emotion.ex
@@ -13,8 +13,7 @@ defmodule GroupherServer.CMS.Comments.Emotion do
   alias CMS.Model.{Comment, CommentUserEmotion}
   alias CMS.{Events, FrontDesk}
 
-  alias Helper.Types, as: T
-  alias Helper.{Later, ORM}
+  alias Helper.{Later, ORM, T}
 
   alias Ecto.Multi
 

--- a/backend/main/lib/groupher_server/cms/comments/list.ex
+++ b/backend/main/lib/groupher_server/cms/comments/list.ex
@@ -15,8 +15,7 @@ defmodule GroupherServer.CMS.Comments.List do
   alias Accounts.Model.User
   alias CMS.FrontDesk
   alias CMS.Model.{Comment, PinnedComment}
-  alias Helper.Types, as: T
-  alias Helper.{Later, ORM, QueryBuilder}
+  alias Helper.{Later, ORM, QueryBuilder, T}
 
   @pinned_comment_limit Comment.pinned_comment_limit()
 

--- a/backend/main/lib/groupher_server/cms/comments/moderation.ex
+++ b/backend/main/lib/groupher_server/cms/comments/moderation.ex
@@ -13,8 +13,7 @@ defmodule GroupherServer.CMS.Comments.Moderation do
   alias CMS.FrontDesk
   alias CMS.Model.Comment
   alias GroupherServer.FrontDesk, as: GlobalFrontDesk
-  alias Helper.Types, as: T
-  alias Helper.{ORM, QueryBuilder}
+  alias Helper.{ORM, QueryBuilder, T}
 
   alias Ecto.Multi
 

--- a/backend/main/lib/groupher_server/cms/comments/read.ex
+++ b/backend/main/lib/groupher_server/cms/comments/read.ex
@@ -12,7 +12,7 @@ defmodule GroupherServer.CMS.Comments.Read do
   alias Accounts.Model.User
   alias CMS.FrontDesk
   alias CMS.Model.Comment
-  alias Helper.Types, as: T
+  alias Helper.T
 
   @article_threads get_config(:article, :threads)
 

--- a/backend/main/lib/groupher_server/cms/comments/states.ex
+++ b/backend/main/lib/groupher_server/cms/comments/states.ex
@@ -18,8 +18,7 @@ defmodule GroupherServer.CMS.Comments.States do
 
   alias GroupherServer.{Accounts, CMS, Repo}
 
-  alias Helper.Types, as: T
-  alias Helper.{Later, ORM}
+  alias Helper.{Later, ORM, T}
 
   alias Accounts.Model.User
   alias CMS.FrontDesk

--- a/backend/main/lib/groupher_server/cms/comments/write.ex
+++ b/backend/main/lib/groupher_server/cms/comments/write.ex
@@ -20,8 +20,7 @@ defmodule GroupherServer.CMS.Comments.Write do
   alias CMS.Helper.ArticleEnums
   alias CMS.Model.{Comment, Community, Embeds, PinnedComment, Post}
 
-  alias Helper.{Later, ORM}
-  alias Helper.Types, as: T
+  alias Helper.{Later, ORM, T}
 
   alias Ecto.Multi
 

--- a/backend/main/lib/groupher_server/cms/communities.ex
+++ b/backend/main/lib/groupher_server/cms/communities.ex
@@ -7,7 +7,7 @@ defmodule GroupherServer.CMS.Communities do
 
   alias Accounts.Model.User
   alias CMS.Model.{Category, Community, CommunityTag, Thread}
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias __MODULE__.{
     Apply,

--- a/backend/main/lib/groupher_server/cms/communities/apply.ex
+++ b/backend/main/lib/groupher_server/cms/communities/apply.ex
@@ -11,8 +11,7 @@ defmodule GroupherServer.CMS.Communities.Apply do
   alias Accounts.Model.User
   alias CMS.Communities
   alias CMS.Model.Community
-  alias Helper.Types, as: T
-  alias Helper.{Constant, ORM}
+  alias Helper.{Constant, ORM, T}
 
   @community_normal Constant.CMS.pending(:normal)
   @community_applying Constant.CMS.pending(:applying)

--- a/backend/main/lib/groupher_server/cms/communities/categories.ex
+++ b/backend/main/lib/groupher_server/cms/communities/categories.ex
@@ -9,8 +9,7 @@ defmodule GroupherServer.CMS.Communities.Categories do
 
   alias Accounts.Model.User
   alias CMS.Model.{Category, Community, CommunityCategory}
-  alias Helper.ORM
-  alias Helper.Types, as: T
+  alias Helper.{ORM, T}
 
   @spec create(map(), User.t()) :: T.domain_res(term())
   def create(attrs, %User{id: user_id}) do

--- a/backend/main/lib/groupher_server/cms/communities/count.ex
+++ b/backend/main/lib/groupher_server/cms/communities/count.ex
@@ -10,8 +10,7 @@ defmodule GroupherServer.CMS.Communities.Count do
 
   alias Accounts.Model.User
   alias CMS.Model.{Community, CommunityTag}
-  alias Helper.Types, as: T
-  alias Helper.{Constant, ORM, Transaction}
+  alias Helper.{Constant, ORM, T, Transaction}
 
   @article_threads get_config(:article, :threads)
 

--- a/backend/main/lib/groupher_server/cms/communities/dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/communities/dashboard.ex
@@ -6,8 +6,7 @@ defmodule GroupherServer.CMS.Communities.Dashboard do
   alias GroupherServer.CMS
 
   alias CMS.Model.{Community, CommunityDashboard}
-  alias Helper.Types, as: T
-  alias Helper.{ORM, OSS}
+  alias Helper.{ORM, OSS, T}
 
   @default_dashboard CommunityDashboard.default()
 

--- a/backend/main/lib/groupher_server/cms/communities/list.ex
+++ b/backend/main/lib/groupher_server/cms/communities/list.ex
@@ -9,8 +9,7 @@ defmodule GroupherServer.CMS.Communities.List do
 
   alias Accounts.Model.User
   alias CMS.Model.Community
-  alias Helper.ORM
-  alias Helper.Types, as: T
+  alias Helper.{ORM, T}
 
   @spec page(map(), User.t()) :: T.domain_res(term())
   def page(filter, %User{meta: meta}) do

--- a/backend/main/lib/groupher_server/cms/communities/members.ex
+++ b/backend/main/lib/groupher_server/cms/communities/members.ex
@@ -10,8 +10,7 @@ defmodule GroupherServer.CMS.Communities.Members do
 
   alias Accounts.Model.User
   alias CMS.Model.{Community, CommunityModerator, CommunitySubscriber}
-  alias Helper.Types, as: T
-  alias Helper.{ORM, QueryBuilder}
+  alias Helper.{ORM, QueryBuilder, T}
 
   @doc """
   return paged community subscribers

--- a/backend/main/lib/groupher_server/cms/communities/moderator.ex
+++ b/backend/main/lib/groupher_server/cms/communities/moderator.ex
@@ -11,8 +11,7 @@ defmodule GroupherServer.CMS.Communities.Moderator do
   alias CMS.Communities.Passport
   alias CMS.Model.{Community, CommunityModerator}
   alias CMS.{Communities, FrontDesk}
-  alias Helper.{Certification, ORM, Transaction}
-  alias Helper.Types, as: T
+  alias Helper.{Certification, ORM, T, Transaction}
 
   @doc """
   set a community moderator

--- a/backend/main/lib/groupher_server/cms/communities/passport.ex
+++ b/backend/main/lib/groupher_server/cms/communities/passport.ex
@@ -11,8 +11,7 @@ defmodule GroupherServer.CMS.Communities.Passport do
   alias Accounts.Model.User
   alias CMS.Model.Passport, as: UserPassport
 
-  alias Helper.Types, as: T
-  alias Helper.{Certification, NestedFilter, ORM}
+  alias Helper.{Certification, NestedFilter, ORM, T}
 
   # https://medium.com/front-end-hacking/use-github-oauth-as-your-sso-seamlessly-with-react-3e2e3b358fa1
   # http://www.ubazu.com/using-postgres-jsonb-columns-in-ecto

--- a/backend/main/lib/groupher_server/cms/communities/read.ex
+++ b/backend/main/lib/groupher_server/cms/communities/read.ex
@@ -10,8 +10,7 @@ defmodule GroupherServer.CMS.Communities.Read do
   alias Accounts.Model.User
   alias CMS.FrontDesk
   alias CMS.Model.{Community, CommunityDashboard}
-  alias Helper.ORM
-  alias Helper.Types, as: T
+  alias Helper.{ORM, T}
 
   @default_dashboard CommunityDashboard.default()
   @default_read_opt [inc_views: true]

--- a/backend/main/lib/groupher_server/cms/communities/subscribe.ex
+++ b/backend/main/lib/groupher_server/cms/communities/subscribe.ex
@@ -9,8 +9,7 @@ defmodule GroupherServer.CMS.Communities.Subscribe do
   alias Accounts.Model.User
   alias CMS.Communities
   alias CMS.Model.{Community, CommunitySubscriber}
-  alias Helper.ORM
-  alias Helper.Types, as: T
+  alias Helper.{ORM, T}
 
   @doc """
   subscribe a community. (ONLY community, post etc use watch )

--- a/backend/main/lib/groupher_server/cms/communities/tags.ex
+++ b/backend/main/lib/groupher_server/cms/communities/tags.ex
@@ -15,8 +15,7 @@ defmodule GroupherServer.CMS.Communities.Tags do
 
   alias Accounts.Model.User
   alias CMS.Model.{Community, CommunityTag}
-  alias Helper.Types, as: T
-  alias Helper.{ORM, QueryBuilder}
+  alias Helper.{ORM, QueryBuilder, T}
 
   alias Ecto.Multi
 

--- a/backend/main/lib/groupher_server/cms/communities/threads.ex
+++ b/backend/main/lib/groupher_server/cms/communities/threads.ex
@@ -7,8 +7,7 @@ defmodule GroupherServer.CMS.Communities.Threads do
   alias GroupherServer.CMS
 
   alias CMS.Model.{Community, CommunityThread, Thread}
-  alias Helper.ORM
-  alias Helper.Types, as: T
+  alias Helper.{ORM, T}
 
   @spec create(map()) :: T.domain_res(term())
   def create(attrs) do

--- a/backend/main/lib/groupher_server/cms/communities/write.ex
+++ b/backend/main/lib/groupher_server/cms/communities/write.ex
@@ -12,8 +12,7 @@ defmodule GroupherServer.CMS.Communities.Write do
   alias Accounts.Model.User
   alias CMS.Communities
   alias CMS.Model.{Community, CommunityDashboard, Embeds, Thread}
-  alias Helper.ORM
-  alias Helper.Types, as: T
+  alias Helper.{ORM, T}
 
   @default_meta Embeds.CommunityMeta.default_meta()
   @default_dashboard CommunityDashboard.default()

--- a/backend/main/lib/groupher_server/cms/events/cited_artiment.ex
+++ b/backend/main/lib/groupher_server/cms/events/cited_artiment.ex
@@ -20,8 +20,7 @@ defmodule GroupherServer.CMS.Events.CitedArtiment do
   alias CMS.FrontDesk
   alias CMS.Model.{CitedArtiment, Comment}
 
-  alias Helper.{ORM, QueryBuilder}
-  alias Helper.Types, as: T
+  alias Helper.{ORM, QueryBuilder, T}
 
   @article_threads get_config(:article, :threads)
 

--- a/backend/main/lib/groupher_server/cms/front_desk.ex
+++ b/backend/main/lib/groupher_server/cms/front_desk.ex
@@ -10,8 +10,7 @@ defmodule GroupherServer.CMS.FrontDesk do
 
   alias Accounts.Model.User
   alias CMS.Model.{Comment, Community, Thread}
-  alias Helper.Types, as: T
-  alias Helper.{ORM, QueryBuilder}
+  alias Helper.{ORM, QueryBuilder, T}
 
   @article_threads Application.compile_env(:groupher_server, :article, [])
                    |> Keyword.get(:threads, [])

--- a/backend/main/lib/groupher_server/cms/helper/matcher.ex
+++ b/backend/main/lib/groupher_server/cms/helper/matcher.ex
@@ -8,7 +8,7 @@ defmodule GroupherServer.CMS.Helper.Matcher do
 
   alias GroupherServer.{Accounts, CMS}
 
-  alias GroupherServer.Accounts.Model.User
+  alias Accounts.Model.User
 
   @type match_info :: %{
           model: module(),

--- a/backend/main/lib/groupher_server/cms/models/community.ex
+++ b/backend/main/lib/groupher_server/cms/models/community.ex
@@ -7,10 +7,9 @@ defmodule GroupherServer.CMS.Model.Community do
 
   import Ecto.Changeset
 
-  alias GroupherServer.Accounts.Model.User
-  alias Helper.Constant.DBPrefix
+  alias GroupherServer.{Accounts, CMS}
 
-  alias GroupherServer.CMS
+  alias Accounts.Model.User
 
   alias CMS.Model.{
     Category,
@@ -21,6 +20,8 @@ defmodule GroupherServer.CMS.Model.Community do
     CommunityThread,
     Embeds
   }
+
+  alias Helper.Constant.DBPrefix
 
   @type t :: %__MODULE__{}
 

--- a/backend/main/lib/groupher_server/cms/search.ex
+++ b/backend/main/lib/groupher_server/cms/search.ex
@@ -4,7 +4,7 @@ defmodule GroupherServer.CMS.Search do
   """
 
   alias GroupherServer.Accounts.Model.User
-  alias Helper.Types, as: T
+  alias Helper.T
 
   alias __MODULE__.{Article, Community}
 

--- a/backend/main/lib/groupher_server/cms/search/community.ex
+++ b/backend/main/lib/groupher_server/cms/search/community.ex
@@ -4,8 +4,10 @@ defmodule GroupherServer.CMS.Search.Community do
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]
 
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.Community
+  alias GroupherServer.{Accounts, CMS}
+
+  alias Accounts.Model.User
+  alias CMS.Model.Community
   alias Helper.ORM
 
   @search_items_count 15

--- a/backend/main/lib/groupher_server/cms/seeds.ex
+++ b/backend/main/lib/groupher_server/cms/seeds.ex
@@ -20,8 +20,7 @@ defmodule GroupherServer.CMS.Seeds do
     ]
 
   alias GroupherServer.CMS
-  alias Helper.ORM
-  alias Helper.Types, as: T
+  alias Helper.{ORM, T}
 
   alias CMS.Model.{Category, Comment, Community, Post}
 

--- a/backend/main/lib/groupher_server/delivery/delegates/notification.ex
+++ b/backend/main/lib/groupher_server/delivery/delegates/notification.ex
@@ -9,9 +9,10 @@ defmodule GroupherServer.Delivery.Delegate.Notification do
 
   import ShortMaps
 
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.Delivery.Model.Notification
-  alias GroupherServer.{Accounts, Repo}
+  alias GroupherServer.{Accounts, Delivery, Repo}
+
+  alias Accounts.Model.User
+  alias Delivery.Model.Notification
 
   alias Ecto.Multi
   alias Helper.ORM

--- a/backend/main/lib/groupher_server/payment/delegates/actions.ex
+++ b/backend/main/lib/groupher_server/payment/delegates/actions.ex
@@ -1,16 +1,15 @@
 defmodule GroupherServer.Payment.Delegate.Actions do
   @moduledoc """
-  actions after biling state success
+  actions after billing state success
   """
   import Helper.Utils, only: [get_config: 2]
 
   alias Helper.ORM
 
-  alias GroupherServer.Accounts
-  alias GroupherServer.Email
-  alias GroupherServer.Payment.Model.BillRecord
+  alias GroupherServer.{Accounts, Email, Payment}
 
-  alias GroupherServer.Accounts.Model.User
+  alias Accounts.Model.User
+  alias Payment.Model.BillRecord
 
   @senior_amount_threshold get_config(:general, :senior_amount_threshold)
 

--- a/backend/main/lib/groupher_server/payment/delegates/crud.ex
+++ b/backend/main/lib/groupher_server/payment/delegates/crud.ex
@@ -9,11 +9,11 @@ defmodule GroupherServer.Payment.Delegate.CRUD do
 
   alias Helper.ORM
 
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.Email
-  alias GroupherServer.Payment.Delegate.Actions
-  alias GroupherServer.Payment.Model.BillRecord
-  alias GroupherServer.Repo
+  alias GroupherServer.{Accounts, Email, Payment, Repo}
+
+  alias Accounts.Model.User
+  alias Payment.Delegate.Actions
+  alias Payment.Model.BillRecord
 
   alias Ecto.Multi
 
@@ -30,7 +30,7 @@ defmodule GroupherServer.Payment.Delegate.CRUD do
   end
 
   @doc """
-  create bill recoard with pending state
+  create bill record with pending state
   """
   def create_record(%User{id: user_id}, attrs) do
     with {:ok, user} <- ORM.find(User, user_id) do

--- a/backend/main/lib/groupher_server/statistics/delegates/throttle.ex
+++ b/backend/main/lib/groupher_server/statistics/delegates/throttle.ex
@@ -6,8 +6,10 @@ defmodule GroupherServer.Statistics.Delegate.Throttle do
   import Ecto.Query, warn: false
   import ShortMaps
 
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.Statistics.Model.PublishThrottle
+  alias GroupherServer.{Accounts, Statistics}
+
+  alias Accounts.Model.User
+  alias Statistics.Model.PublishThrottle
 
   alias Helper.ORM
 

--- a/backend/main/lib/groupher_server_web/context.ex
+++ b/backend/main/lib/groupher_server_web/context.ex
@@ -9,8 +9,9 @@ defmodule GroupherServerWeb.Context do
   import Plug.Conn
   # import Ecto.Query, only: [first: 1]
 
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS
+  alias GroupherServer.{Accounts, CMS}
+
+  alias Accounts.Model.User
   alias Helper.{Guardian, ORM}
 
   def init(opts), do: opts

--- a/backend/main/lib/groupher_server_web/middleware/publish_throttle.ex
+++ b/backend/main/lib/groupher_server_web/middleware/publish_throttle.ex
@@ -7,9 +7,10 @@ defmodule GroupherServerWeb.Middleware.PublishThrottle do
   import Helper.Utils, only: [handle_absinthe_error: 3, get_config: 2]
   import Helper.ErrorCode
 
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.Statistics
-  alias GroupherServer.Statistics.Model.PublishThrottle
+  alias GroupherServer.{Accounts, Statistics}
+
+  alias Accounts.Model.User
+  alias Statistics.Model.PublishThrottle
 
   @interval_minutes get_config(:general, :publish_throttle_interval_minutes)
   @hour_limit get_config(:general, :publish_throttle_hour_limit)

--- a/backend/main/lib/groupher_server_web/middleware/statistics/make_contribute.ex
+++ b/backend/main/lib/groupher_server_web/middleware/statistics/make_contribute.ex
@@ -7,8 +7,9 @@ defmodule GroupherServerWeb.Middleware.Statistics.MakeContribute do
 
   @behaviour Absinthe.Middleware
   # google: must appear in the GROUP BY clause or be used in an aggregate function
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.Statistics
+  alias GroupherServer.{Accounts, Statistics}
+
+  alias Accounts.Model.User
 
   def call(%{errors: errors} = resolution, _) when length(errors) > 0, do: resolution
 

--- a/backend/main/lib/groupher_server_web/resolvers/accounts_resolver.ex
+++ b/backend/main/lib/groupher_server_web/resolvers/accounts_resolver.ex
@@ -7,7 +7,7 @@ defmodule GroupherServerWeb.Resolvers.Accounts do
 
   alias GroupherServer.{Accounts, CMS}
 
-  alias GroupherServer.Accounts.Model.User
+  alias Accounts.Model.User
   alias Helper.Certification
 
   def me(_root, _args, %{context: %{cur_user: cur_user}}), do: {:ok, cur_user}
@@ -199,7 +199,8 @@ defmodule GroupherServerWeb.Resolvers.Accounts do
       {:ok, user_id} ->
         Accounts.Achievements.paged_moderatorable_communities(%User{id: user_id}, filter)
 
-      _ -> raise_error(:not_exist, "#{login} not found")
+      _ ->
+        raise_error(:not_exist, "#{login} not found")
     end
   end
 

--- a/backend/main/lib/helper/converter/editor_to_html/frags/header.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/frags/header.ex
@@ -5,7 +5,7 @@ defmodule Helper.Converter.EditorToHTML.Frags.Header do
   see https://editorjs.io/
   """
   alias Helper.Converter.EditorToHTML.Class
-  alias Helper.Types, as: T
+  alias Helper.T
 
   @class get_in(Class.article(), ["header"])
 

--- a/backend/main/lib/helper/converter/editor_to_html/frags/image.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/frags/image.ex
@@ -7,7 +7,7 @@ defmodule Helper.Converter.EditorToHTML.Frags.Image do
   import Helper.Validator.Guards, only: [g_none_empty_str: 1]
 
   alias Helper.Converter.EditorToHTML.Class
-  alias Helper.Types, as: T
+  alias Helper.T
 
   @class get_in(Class.article(), ["image"])
 

--- a/backend/main/lib/helper/converter/editor_to_html/frags/list.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/frags/list.ex
@@ -5,7 +5,7 @@ defmodule Helper.Converter.EditorToHTML.Frags.List do
   see https://editorjs.io/
   """
   alias Helper.Converter.EditorToHTML.Class
-  alias Helper.Types, as: T
+  alias Helper.T
 
   @class get_in(Class.article(), ["list"])
 

--- a/backend/main/lib/helper/converter/editor_to_html/frags/people.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/frags/people.ex
@@ -7,7 +7,7 @@ defmodule Helper.Converter.EditorToHTML.Frags.People do
   import Helper.Utils, only: [get_config: 2]
 
   alias Helper.Converter.EditorToHTML.Class
-  alias Helper.Types, as: T
+  alias Helper.T
 
   @static_icon get_config(:cloud_assets, :static_icon)
 

--- a/backend/main/lib/helper/converter/editor_to_html/frags/quote.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/frags/quote.ex
@@ -7,7 +7,7 @@ defmodule Helper.Converter.EditorToHTML.Frags.Quote do
   import Helper.Validator.Guards, only: [g_none_empty_str: 1]
 
   alias Helper.Converter.EditorToHTML.Class
-  alias Helper.Types, as: T
+  alias Helper.T
 
   @class get_in(Class.article(), ["quote"])
 

--- a/backend/main/lib/helper/converter/editor_to_html/frags/table.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/frags/table.ex
@@ -5,7 +5,7 @@ defmodule Helper.Converter.EditorToHTML.Frags.Table do
   see https://editorjs.io/
   """
   alias Helper.Converter.EditorToHTML.Class
-  alias Helper.Types, as: T
+  alias Helper.T
 
   @class get_in(Class.article(), ["table"])
 

--- a/backend/main/lib/helper/converter/editor_to_html/index.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/index.ex
@@ -5,8 +5,7 @@ defmodule Helper.Converter.EditorToHTML do
   see https://editorjs.io/
   """
 
-  alias Helper.Types, as: T
-  alias Helper.Utils
+  alias Helper.{T, Utils}
 
   alias Helper.Converter.EditorToHTML.{Class, Frags}
   alias Helper.Converter.{Article, HtmlSanitizer}

--- a/backend/main/lib/helper/gq_error.ex
+++ b/backend/main/lib/helper/gq_error.ex
@@ -3,9 +3,9 @@ defmodule Helper.GQLError do
   Encode domain errors into GraphQL error shape.
   """
 
-  alias Helper.{ErrorCode, Types}
+  alias Helper.{ErrorCode, T}
 
-  @spec encode(Types.error() | Types.gq_error() | {:error, Types.error()}) :: Types.gq_error()
+  @spec encode(T.error() | T.gq_error() | {:error, T.error()}) :: T.gq_error()
   def encode({:error, [message: _message, code: _code]} = error), do: error
   def encode({:error, error}), do: encode(error)
 

--- a/backend/main/lib/helper/gql.ex
+++ b/backend/main/lib/helper/gql.ex
@@ -3,10 +3,10 @@ defmodule Helper.GQL do
   GraphQL boundary helpers for transforming domain results.
   """
 
-  alias Helper.Types
+  alias Helper.T
 
-  @spec result(Types.result(term(), Types.error()) | Types.gq_result(term())) ::
-          Types.gq_result(term())
+  @spec result(T.result(term(), T.error()) | T.gq_result(term())) ::
+          T.gq_result(term())
   def result({:ok, _} = ok), do: ok
   def result({:error, {:changeset, %Ecto.Changeset{} = changeset}}), do: {:error, changeset}
   def result({:error, [message: _, code: _]} = gq_error), do: gq_error

--- a/backend/main/lib/helper/orm.ex
+++ b/backend/main/lib/helper/orm.ex
@@ -12,9 +12,7 @@ defmodule Helper.ORM do
 
   alias Accounts.Model.User
   alias CMS.Model.{Community, CommunityDashboard}
-  alias Helper.ORMAtom
-  alias Helper.QueryBuilder
-  alias Helper.Types, as: T
+  alias Helper.{ORMAtom, QueryBuilder, T}
 
   @article_threads get_config(:article, :threads)
 

--- a/backend/main/lib/helper/t.ex
+++ b/backend/main/lib/helper/t.ex
@@ -1,4 +1,4 @@
-defmodule Helper.Types do
+defmodule Helper.T do
   @moduledoc """
   custom @types
   """

--- a/backend/main/lib/support/conn_simulator.ex
+++ b/backend/main/lib/support/conn_simulator.ex
@@ -8,8 +8,9 @@ defmodule GroupherServer.Test.ConnSimulator do
 
   import GroupherServer.CMS.FrontDesk, only: [author_of: 1]
 
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS
+  alias GroupherServer.{Accounts, CMS}
+
+  alias Accounts.Model.User
   alias Helper.{Guardian, ORM}
 
   @spec simu_conn(:guest | :invalid_token | :user) :: Plug.Conn.t()

--- a/backend/main/priv/mock/populator/user.ex
+++ b/backend/main/priv/mock/populator/user.ex
@@ -5,8 +5,9 @@
 #
 
 defmodule GroupherServer.Mock.User do
-  alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.Repo
+  alias GroupherServer.{Accounts, Repo}
+
+  alias Accounts.Model.User
 
   def random_attrs do
     %{

--- a/backend/main/test/groupher_server_web/mutation/accounts/oauth_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/accounts/oauth_test.exs
@@ -3,8 +3,10 @@ defmodule GroupherServer.Test.Mutation.Account.Oauth do
 
   use GroupherServer.TestTools
   import Helper.Utils
-  alias GroupherServer.Accounts.Model.OauthProvider
-  alias GroupherServer.Repo
+
+  alias GroupherServer.{Accounts, Repo}
+
+  alias Accounts.Model.OauthProvider
 
   @oauth_trust_code get_config(:oauth, :oauth_trust_code)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed Helper.Types to Helper.T across the backend and cleaned up alias usage and formatting. No behavior changes; only type/module alias updates and minor comment fixes.

- **Refactors**
  - Renamed helper/types.ex to helper/t.ex and replaced alias Helper.Types with alias Helper.T.
  - Updated @specs and type references to use T.* (e.g., T.id, T.domain_res, T.gq_error).
  - Consolidated and simplified aliases (e.g., alias GroupherServer.{Accounts, CMS}) and reorganized nested module aliases.
  - Fixed minor typos in comments/strings (“billing”, “record”) and applied small formatting tweaks.

<sup>Written for commit 496a63387dbc35cd387121c66724f4f0e1b51cea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal module alias declarations have been reorganized and consolidated throughout the codebase for improved maintainability and consistency. These changes do not affect application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->