### PR TITLE
refactor(workflow): use article input/args for gq workflow

### DIFF
--- a/backend/main/lib/groupher_server_web/middleware/article_args.ex
+++ b/backend/main/lib/groupher_server_web/middleware/article_args.ex
@@ -1,0 +1,65 @@
+defmodule GroupherServerWeb.Middleware.ArticleArgs do
+  @moduledoc """
+  Normalize `article` input into common args (`id`, `community`, `thread`).
+
+  - with `thread: <fixed_thread>` option: thread is constrained to the fixed value
+  - without `thread` option: thread comes from input and defaults to `:post`
+  """
+
+  @behaviour Absinthe.Middleware
+
+  import Helper.ErrorCode
+  import Helper.Utils, only: [handle_absinthe_error: 3]
+
+  def call(%{errors: errors} = resolution, _) when length(errors) > 0 do
+    resolution
+  end
+
+  def call(%{arguments: %{article: article_ref} = arguments} = resolution, opts) do
+    fixed_thread = Keyword.get(List.wrap(opts), :thread)
+
+    with {:ok, inner_id} <- fetch_required(article_ref, :inner_id),
+         {:ok, community} <- fetch_required(article_ref, :community),
+         {:ok, thread} <- fetch_thread(article_ref, fixed_thread) do
+      normalized_arguments =
+        arguments
+        |> Map.merge(%{id: inner_id, community: community, thread: thread})
+
+      %{resolution | arguments: normalized_arguments}
+    else
+      :error ->
+        resolution
+        |> handle_absinthe_error("invalid article input", ecode(:custom))
+    end
+  end
+
+  def call(resolution, _) do
+    resolution
+    |> handle_absinthe_error("missing article input", ecode(:custom))
+  end
+
+  defp fetch_required(map, key) do
+    case Map.fetch(map, key) do
+      {:ok, nil} -> :error
+      {:ok, value} -> {:ok, value}
+      :error -> :error
+    end
+  end
+
+  defp fetch_thread(map, fixed_thread) do
+    case Map.fetch(map, :thread) do
+      {:ok, nil} ->
+        if is_nil(fixed_thread), do: {:ok, :post}, else: {:ok, fixed_thread}
+
+      {:ok, value} ->
+        cond do
+          is_nil(fixed_thread) -> {:ok, value}
+          value == fixed_thread -> {:ok, value}
+          true -> :error
+        end
+
+      :error ->
+        if is_nil(fixed_thread), do: {:ok, :post}, else: {:ok, fixed_thread}
+    end
+  end
+end

--- a/backend/main/lib/groupher_server_web/middleware/article_loader.ex
+++ b/backend/main/lib/groupher_server_web/middleware/article_loader.ex
@@ -1,0 +1,23 @@
+defmodule GroupherServerWeb.Middleware.ArticleLoader do
+  @moduledoc """
+  Load article entity from normalized args (`community`, `thread`, `id`).
+
+  Skip loading if article is already present in arguments.
+  """
+
+  @behaviour Absinthe.Middleware
+
+  alias GroupherServerWeb.Middleware.FrontDesk
+
+  def call(%{errors: errors} = resolution, _) when length(errors) > 0 do
+    resolution
+  end
+
+  def call(%{arguments: %{article: %{__struct__: _}}} = resolution, _) do
+    resolution
+  end
+
+  def call(resolution, _) do
+    FrontDesk.call(resolution, :article)
+  end
+end

--- a/backend/main/lib/groupher_server_web/middleware/front_desk.ex
+++ b/backend/main/lib/groupher_server_web/middleware/front_desk.ex
@@ -63,24 +63,34 @@ defmodule GroupherServerWeb.Middleware.FrontDesk do
          } = resolution,
          community
        ) do
-    {:ok, article} = FrontDesk.article(community, thread, inner_id)
-    passport_is_owner = article.author.user.id == cur_user.id
+    case FrontDesk.article(community, thread, inner_id) do
+      {:ok, article} ->
+        passport_is_owner = article.author.user.id == cur_user.id
 
-    updated_arguments =
-      arguments
-      |> Map.put(:article, article)
-      |> Map.put(:passport_is_owner, passport_is_owner)
+        updated_arguments =
+          arguments
+          |> Map.put(:article, article)
+          |> Map.put(:passport_is_owner, passport_is_owner)
 
-    %{resolution | arguments: updated_arguments}
+        %{resolution | arguments: updated_arguments}
+
+      {:error, err_msg} ->
+        resolution |> handle_absinthe_error(err_msg, ecode(:not_exist))
+    end
   end
 
   defp fetch_article(
          %{arguments: %{thread: thread, id: inner_id} = arguments} = resolution,
          community
        ) do
-    {:ok, article} = FrontDesk.article(community, thread, inner_id)
-    updated_arguments = arguments |> Map.put(:article, article)
-    %{resolution | arguments: updated_arguments}
+    case FrontDesk.article(community, thread, inner_id) do
+      {:ok, article} ->
+        updated_arguments = arguments |> Map.put(:article, article)
+        %{resolution | arguments: updated_arguments}
+
+      {:error, err_msg} ->
+        resolution |> handle_absinthe_error(err_msg, ecode(:not_exist))
+    end
   end
 
   defp fetch_comment(

--- a/backend/main/lib/groupher_server_web/middleware/passport.ex
+++ b/backend/main/lib/groupher_server_web/middleware/passport.ex
@@ -16,6 +16,8 @@ defmodule GroupherServerWeb.Middleware.Passport do
   import Helper.Utils
   import Helper.ErrorCode
 
+  alias GroupherServerWeb.Middleware.ArticleLoader
+
   def call(%{errors: errors} = resolution, _) when length(errors) > 0 do
     resolution
   end
@@ -72,7 +74,8 @@ defmodule GroupherServerWeb.Middleware.Passport do
         } = resolution,
         claim: "owner;" <> claim
       ) do
-    resolution |> check_passport_stamp(claim)
+    resolution
+    |> check_or_owner(claim)
   end
 
   def call(
@@ -105,6 +108,29 @@ defmodule GroupherServerWeb.Middleware.Passport do
       true ->
         resolution
         |> handle_absinthe_error("PassportError: Passport not qualified.", ecode(:passport))
+    end
+  end
+
+  defp check_or_owner(resolution, claim) do
+    case check_passport_stamp(resolution, claim) do
+      %{errors: []} = ok_resolution ->
+        ok_resolution
+
+      _failed_resolution ->
+        case ArticleLoader.call(resolution, []) do
+          %{arguments: %{passport_is_owner: true}} = loaded_resolution ->
+            loaded_resolution
+
+          %{errors: errors} = failed_resolution when errors != [] ->
+            failed_resolution
+
+          _ ->
+            resolution
+            |> handle_absinthe_error(
+              "PassportError: your passport not qualified.",
+              ecode(:passport)
+            )
+        end
     end
   end
 

--- a/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
+++ b/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
@@ -136,11 +136,11 @@ defmodule GroupherServerWeb.Resolvers.CMS do
   # #######################
   # article actions
   # #######################
-  def pin_article(_root, ~m(community article)a, _info),
-    do: CMS.Articles.pin(community, article)
+  def pin_article(_root, ~m(article)a, _info),
+    do: CMS.Articles.pin(article.community, article)
 
-  def undo_pin_article(_root, ~m(community article)a, _info) do
-    CMS.Articles.undo_pin(community, article)
+  def undo_pin_article(_root, ~m(article)a, _info) do
+    CMS.Articles.undo_pin(article.community, article)
   end
 
   def mark_delete_article(_root, ~m(article)a, _info) do

--- a/backend/main/lib/groupher_server_web/schema/Helper/mutations.ex
+++ b/backend/main/lib/groupher_server_web/schema/Helper/mutations.ex
@@ -52,24 +52,22 @@ defmodule GroupherServerWeb.Schema.Helper.Mutations do
     quote do
       @desc unquote("upvote to #{thread}")
       field unquote(:"upvote_#{thread}"), :article do
-        arg(:id, non_null(:id))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
-        arg(:community, non_null(:string))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleArgs, thread: unquote(thread))
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.upvote_article/3)
       end
 
       @desc unquote("undo upvote to #{thread}")
       field unquote(:"undo_upvote_#{thread}"), :article do
-        arg(:id, non_null(:id))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
-        arg(:community, non_null(:string))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleArgs, thread: unquote(thread))
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.undo_upvote_article/3)
       end
@@ -88,28 +86,24 @@ defmodule GroupherServerWeb.Schema.Helper.Mutations do
     quote do
       @desc unquote("pin to #{thread}")
       field unquote(:"pin_#{thread}"), unquote(thread) do
-        arg(:id, non_null(:id))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
+        middleware(M.ArticleArgs, thread: unquote(thread))
         middleware(M.Passport, claim: unquote("cms->c?->#{to_string(thread)}.pin"))
-        middleware(M.FrontDesk, :community)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.pin_article/3)
       end
 
       @desc unquote("undo pin to #{thread}")
       field unquote(:"undo_pin_#{thread}"), unquote(thread) do
-        arg(:id, non_null(:id))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
+        middleware(M.ArticleArgs, thread: unquote(thread))
         middleware(M.Passport, claim: unquote("cms->c?->#{to_string(thread)}.undo_pin"))
-        middleware(M.FrontDesk, :community)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.undo_pin_article/3)
       end
@@ -128,26 +122,24 @@ defmodule GroupherServerWeb.Schema.Helper.Mutations do
     quote do
       @desc unquote("mark delete a #{thread} type article, aka soft-delete")
       field unquote(:"mark_delete_#{thread}"), unquote(thread) do
-        arg(:id, non_null(:id))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
+        middleware(M.ArticleArgs, thread: unquote(thread))
         middleware(M.Passport, claim: unquote("cms->#{to_string(thread)}.mark_delete"))
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.mark_delete_article/3)
       end
 
       @desc unquote("undo mark delete a #{thread} type article")
       field unquote(:"undo_mark_delete_#{thread}"), unquote(thread) do
-        arg(:id, non_null(:id))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
-        arg(:community, non_null(:string))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
+        middleware(M.ArticleArgs, thread: unquote(thread))
         middleware(M.Passport, claim: unquote("cms->#{to_string(thread)}.undo_mark_delete"))
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.undo_mark_delete_article/3)
       end
@@ -191,13 +183,12 @@ defmodule GroupherServerWeb.Schema.Helper.Mutations do
     quote do
       @desc unquote("delete a #{thread}, not delete")
       field unquote(:"delete_#{thread}"), unquote(thread) do
-        arg(:id, non_null(:id))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleArgs, thread: unquote(thread))
         middleware(M.Passport, claim: unquote("owner;cms->c?->#{to_string(thread)}.delete"))
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.delete_article/3)
       end
@@ -216,26 +207,24 @@ defmodule GroupherServerWeb.Schema.Helper.Mutations do
     quote do
       @desc unquote("emotion to #{thread}")
       field unquote(:"emotion_to_#{thread}"), unquote(thread) do
-        arg(:id, non_null(:id))
+        arg(:article, non_null(:article_ref_input))
         arg(:emotion, non_null(:article_emotion))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
 
         middleware(M.Authorize, :login)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleArgs, thread: unquote(thread))
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.emotion_to_article/3)
       end
 
       @desc unquote("undo emotion to #{thread}")
       field unquote(:"undo_emotion_to_#{thread}"), unquote(thread) do
-        arg(:id, non_null(:id))
+        arg(:article, non_null(:article_ref_input))
         arg(:emotion, non_null(:article_emotion))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
 
         middleware(M.Authorize, :login)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleArgs, thread: unquote(thread))
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.undo_emotion_to_article/3)
       end
@@ -254,26 +243,24 @@ defmodule GroupherServerWeb.Schema.Helper.Mutations do
     quote do
       @desc unquote("report a #{thread}")
       field unquote(:"report_#{thread}"), unquote(thread) do
-        arg(:id, non_null(:id))
+        arg(:article, non_null(:article_ref_input))
         arg(:reason, non_null(:string))
         arg(:attr, :string, default_value: "")
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
-        arg(:community, non_null(:string))
 
         middleware(M.Authorize, :login)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleArgs, thread: unquote(thread))
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.report_article/3)
       end
 
       @desc unquote("undo report a #{thread}")
       field unquote(:"undo_report_#{thread}"), unquote(thread) do
-        arg(:id, non_null(:id))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
-        arg(:community, non_null(:string))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleArgs, thread: unquote(thread))
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.undo_report_article/3)
       end
@@ -292,26 +279,24 @@ defmodule GroupherServerWeb.Schema.Helper.Mutations do
     quote do
       @desc unquote("sink a #{thread}")
       field unquote(:"sink_#{thread}"), :article do
-        arg(:id, non_null(:id))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
+        middleware(M.ArticleArgs, thread: unquote(thread))
         middleware(M.Passport, claim: unquote("cms->c?->#{to_string(thread)}.sink"))
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.sink_article/3)
       end
 
       @desc unquote("undo sink to #{thread}")
       field unquote(:"undo_sink_#{thread}"), :article do
-        arg(:id, non_null(:id))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
+        middleware(M.ArticleArgs, thread: unquote(thread))
         middleware(M.Passport, claim: unquote("cms->c?->#{to_string(thread)}.undo_sink"))
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.undo_sink_article/3)
       end
@@ -330,26 +315,24 @@ defmodule GroupherServerWeb.Schema.Helper.Mutations do
     quote do
       @desc unquote("lock comment of a #{thread}")
       field unquote(:"lock_#{thread}_comment"), :article do
-        arg(:id, non_null(:id))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
+        middleware(M.ArticleArgs, thread: unquote(thread))
         middleware(M.Passport, claim: unquote("cms->c?->#{to_string(thread)}.lock_comment"))
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.lock_article_comments/3)
       end
 
       @desc unquote("undo lock to a #{thread}")
       field unquote(:"undo_lock_#{thread}_comment"), :article do
-        arg(:id, non_null(:id))
-        arg(:community, non_null(:string))
-        arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
+        arg(:article, non_null(:article_ref_input))
 
         middleware(M.Authorize, :login)
+        middleware(M.ArticleArgs, thread: unquote(thread))
         middleware(M.Passport, claim: unquote("cms->c?->#{to_string(thread)}.undo_lock_comment"))
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleLoader)
 
         resolve(&R.CMS.undo_lock_article_comments/3)
       end

--- a/backend/main/lib/groupher_server_web/schema/Helper/queries.ex
+++ b/backend/main/lib/groupher_server_web/schema/Helper/queries.ex
@@ -54,9 +54,9 @@ defmodule GroupherServerWeb.Schema.Helper.Queries do
       quote do
         @desc unquote("get #{thread} by id")
         field unquote(thread), non_null(unquote(thread)) do
-          arg(:id, non_null(:id))
-          arg(:community, non_null(:string))
-          arg(:thread, unquote(:"#{thread}_thread"), default_value: unquote(thread))
+          arg(:article, non_null(:article_ref_input))
+
+          middleware(M.ArticleArgs, thread: unquote(thread))
 
           resolve(&R.CMS.read_article/3)
         end
@@ -77,13 +77,12 @@ defmodule GroupherServerWeb.Schema.Helper.Queries do
     quote do
       @desc unquote("get paged #{past_verb(action)} users of an article")
       field unquote(:"#{past_verb(action)}_users"), :paged_users do
-        arg(:id, non_null(:id))
-        arg(:community, non_null(:string))
-        arg(:thread, :thread, default_value: :post)
+        arg(:article, non_null(:article_ref_input))
         arg(:filter, non_null(:pagi_filter))
 
         middleware(M.PageSizeProof)
-        middleware(M.FrontDesk, :article)
+        middleware(M.ArticleArgs)
+        middleware(M.ArticleLoader)
 
         resolve(unquote(resolver))
       end

--- a/backend/main/lib/groupher_server_web/schema/account/account_mutations.ex
+++ b/backend/main/lib/groupher_server_web/schema/account/account_mutations.ex
@@ -89,26 +89,24 @@ defmodule GroupherServerWeb.Schema.Account.Mutations do
 
     @desc "add article into a collect folder"
     field :add_to_collect, :collect_folder do
-      arg(:id, non_null(:id))
+      arg(:article, non_null(:article_ref_input))
       arg(:folder_id, non_null(:id))
-      arg(:community, non_null(:string))
-      arg(:thread, :thread, default_value: :post)
 
       middleware(M.Authorize, :login)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleArgs)
+      middleware(M.ArticleLoader)
 
       resolve(&R.Accounts.add_to_collect/3)
     end
 
     @desc "remove article from a collect folder"
     field :remove_from_collect, :collect_folder do
-      arg(:id, non_null(:id))
+      arg(:article, non_null(:article_ref_input))
       arg(:folder_id, non_null(:id))
-      arg(:community, non_null(:string))
-      arg(:thread, :thread, default_value: :post)
 
       middleware(M.Authorize, :login)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleArgs)
+      middleware(M.ArticleLoader)
 
       resolve(&R.Accounts.remove_from_collect/3)
     end

--- a/backend/main/lib/groupher_server_web/schema/cms/cms_metrics.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/cms_metrics.ex
@@ -163,6 +163,12 @@ defmodule GroupherServerWeb.Schema.CMS.Metrics do
     field(:index, :integer)
   end
 
+  input_object :article_ref_input do
+    field(:inner_id, non_null(:id))
+    field(:community, non_null(:string))
+    field(:thread, :thread)
+  end
+
   input_object :pagi_filter do
     @desc "limit of records (default 20), if first > 30, only return 30 at most"
     pagination_args()

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/blog.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/blog.ex
@@ -26,19 +26,18 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Blog do
 
     @desc "update a cms/blog"
     field :update_blog, :blog do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
+      arg(:article, non_null(:article_ref_input))
       arg(:title, :string)
       arg(:body, :string)
       arg(:digest, :string)
       arg(:copy_right, :string)
       arg(:link_addr, :string)
       arg(:community_tags, list_of(:id))
-      arg(:thread, :thread, default_value: :blog)
 
       middleware(M.Authorize, :login)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleArgs, thread: :blog)
       middleware(M.Passport, claim: "owner;cms->c?->blog.edit")
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.update_article/3)
     end

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/changelog.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/changelog.ex
@@ -26,19 +26,18 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Changelog do
 
     @desc "update a cms/changelog"
     field :update_changelog, :changelog do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
+      arg(:article, non_null(:article_ref_input))
       arg(:title, :string)
       arg(:body, :string)
       arg(:digest, :string)
       arg(:copy_right, :string)
       arg(:link_addr, :string)
       arg(:community_tags, list_of(:id))
-      arg(:thread, :thread, default_value: :changelog)
 
       middleware(M.Authorize, :login)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleArgs, thread: :changelog)
       middleware(M.Passport, claim: "owner;cms->c?->changelog.edit")
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.update_article/3)
     end

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/doc.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/doc.ex
@@ -26,19 +26,18 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Doc do
 
     @desc "update a cms/doc"
     field :update_doc, :doc do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
+      arg(:article, non_null(:article_ref_input))
       arg(:title, :string)
       arg(:body, :string)
       arg(:digest, :string)
       arg(:copy_right, :string)
       arg(:link_addr, :string)
       arg(:community_tags, list_of(:id))
-      arg(:thread, :thread, default_value: :doc)
 
       middleware(M.Authorize, :login)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleArgs, thread: :doc)
       middleware(M.Passport, claim: "owner;cms->c?->doc.edit")
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.update_article/3)
     end

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/operation.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/operation.ex
@@ -77,29 +77,26 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Operation do
 
     @desc "set a community_tag to content"
     field :set_community_tag, :article do
-      arg(:id, non_null(:id))
+      arg(:article, non_null(:article_ref_input))
       arg(:community_tag_id, non_null(:id))
-      # community_id only use for passport check
-      arg(:community, non_null(:string))
-      arg(:thread, :thread, default_value: :post)
 
       middleware(M.Authorize, :login)
+      middleware(M.ArticleArgs)
       middleware(M.Passport, claim: "cms->c?->t?.community_tag.set")
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.set_community_tag/3)
     end
 
     @desc "unset a tag to content"
     field :unset_community_tag, :article do
-      arg(:id, non_null(:id))
+      arg(:article, non_null(:article_ref_input))
       arg(:community_tag_id, non_null(:id))
-      arg(:community, non_null(:string))
-      arg(:thread, :thread, default_value: :post)
 
       middleware(M.Authorize, :login)
+      middleware(M.ArticleArgs)
       middleware(M.Passport, claim: "cms->c?->t?.community_tag.unset")
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.unset_community_tag/3)
     end
@@ -119,77 +116,72 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Operation do
 
     @desc "mirror article to other community"
     field :mirror_article, :article do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
+      arg(:article, non_null(:article_ref_input))
       arg(:target_community, non_null(:string))
-      arg(:thread, :thread, default_value: :post)
       arg(:community_tags, list_of(:id), default_value: [])
 
       middleware(M.Authorize, :login)
+      middleware(M.ArticleArgs)
       middleware(M.Passport, claim: "cms->t?.community.mirror")
       middleware(M.FrontDesk, :target_community)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.mirror_article/3)
     end
 
     @desc "unmirror article for community"
     field :unmirror_article, :article do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
+      arg(:article, non_null(:article_ref_input))
       arg(:target_community, non_null(:string))
-      arg(:thread, :thread, default_value: :post)
 
       middleware(M.Authorize, :login)
+      middleware(M.ArticleArgs)
       middleware(M.Passport, claim: "cms->t?.community.unmirror")
       middleware(M.FrontDesk, :target_community)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.unmirror_article/3)
     end
 
     @desc "move article to other community"
     field :move_article, :article do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
+      arg(:article, non_null(:article_ref_input))
       arg(:target_community, non_null(:string))
-      arg(:thread, :thread, default_value: :post)
       arg(:community_tags, list_of(:id), default_value: [])
 
       middleware(M.Authorize, :login)
+      middleware(M.ArticleArgs)
       middleware(M.Passport, claim: "cms->t?.community.move")
       middleware(M.FrontDesk, :target_community)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.move_article/3)
     end
 
     @desc "mirror article to home community"
     field :mirror_to_home, :article do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
-      arg(:thread, :thread, default_value: :post)
+      arg(:article, non_null(:article_ref_input))
       arg(:community_tags, list_of(:id), default_value: [])
 
       middleware(M.Authorize, :login)
+      middleware(M.ArticleArgs)
       middleware(M.Passport, claim: "cms->homemirror")
-      middleware(M.FrontDesk, :article)
       middleware(M.FrontDesk, target_community: :home)
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.mirror_to_home/3)
     end
 
     @desc "move article to other community"
     field :move_to_blackhole, :article do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
-      arg(:thread, :thread, default_value: :post)
+      arg(:article, non_null(:article_ref_input))
       arg(:community_tags, list_of(:id), default_value: [])
 
       middleware(M.Authorize, :login)
+      middleware(M.ArticleArgs)
       middleware(M.Passport, claim: "cms->blackeye")
-      middleware(M.FrontDesk, :article)
       middleware(M.FrontDesk, target_community: :blackhole)
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.move_to_blackhole/3)
     end

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/post.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/post.ex
@@ -26,47 +26,44 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Post do
 
     @desc "update a cms/post"
     field :update_post, :post do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
+      arg(:article, non_null(:article_ref_input))
       arg(:title, :string)
       arg(:body, :string)
       arg(:digest, :string)
       arg(:copy_right, :string)
       arg(:link_addr, :string)
       arg(:community_tags, list_of(:id))
-      arg(:thread, :thread, default_value: :post)
 
       middleware(M.Authorize, :login)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleArgs, thread: :post)
       middleware(M.Passport, claim: "owner;cms->c?->post.edit")
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.update_article/3)
     end
 
     @desc "set cat for a post"
     field :set_post_cat, :post do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
+      arg(:article, non_null(:article_ref_input))
       arg(:cat, non_null(:article_cat_enum))
-      arg(:thread, :thread, default_value: :post)
 
       middleware(M.Authorize, :login)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleArgs, thread: :post)
       middleware(M.Passport, claim: "owner;cms->c?->post.edit")
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.set_post_cat/3)
     end
 
     @desc "set cat for a post"
     field :set_post_state, :post do
-      arg(:id, non_null(:id))
-      arg(:community, non_null(:string))
+      arg(:article, non_null(:article_ref_input))
       arg(:state, non_null(:article_state_enum))
-      arg(:thread, :thread, default_value: :post)
 
       middleware(M.Authorize, :login)
-      middleware(M.FrontDesk, :article)
+      middleware(M.ArticleArgs, thread: :post)
       middleware(M.Passport, claim: "owner;cms->c?->post.edit")
+      middleware(M.ArticleLoader)
 
       resolve(&R.CMS.set_post_state/3)
     end

--- a/backend/main/schema.graphql
+++ b/backend/main/schema.graphql
@@ -130,7 +130,7 @@ type RootQueryType {
   searchCommunities(title: String!, category: String): PagedCommunities
 
   "kanban posts grouped by backlog\/todo\/wip\/done\/rejected"
-  groupedKanbanPosts(community: String!): GroupedPosts
+  groupedKanbanPosts(community: String!): KanbanPosts
 
   "get open graph info by url"
   openGraphInfo(url: String!): OpenGraph
@@ -151,31 +151,31 @@ type RootQueryType {
   searchDocs(title: String!, thread: DocThread): PagedDocs
 
   "get paged upvoted users of an article"
-  upvotedUsers(id: ID!, community: String!, thread: Thread, filter: PagiFilter!): PagedUsers
+  upvotedUsers(article: ArticleRefInput!, filter: PagiFilter!): PagedUsers
 
   "get paged collected users of an article"
-  collectedUsers(id: ID!, community: String!, thread: Thread, filter: PagiFilter!): PagedUsers
+  collectedUsers(article: ArticleRefInput!, filter: PagiFilter!): PagedUsers
 
   "get post by id"
-  post(id: ID!, community: String!, thread: PostThread): Post!
+  post(article: ArticleRefInput!): Post!
 
   "get paged posts"
   pagedPosts(thread: PostThread, filter: PagedPostsFilter!): PagedPosts
 
   "get blog by id"
-  blog(id: ID!, community: String!, thread: BlogThread): Blog!
+  blog(article: ArticleRefInput!): Blog!
 
   "get paged blogs"
   pagedBlogs(thread: BlogThread, filter: PagedBlogsFilter!): PagedBlogs
 
   "get changelog by id"
-  changelog(id: ID!, community: String!, thread: ChangelogThread): Changelog!
+  changelog(article: ArticleRefInput!): Changelog!
 
   "get paged changelogs"
   pagedChangelogs(thread: ChangelogThread, filter: PagedChangelogsFilter!): PagedChangelogs
 
   "get doc by id"
-  doc(id: ID!, community: String!, thread: DocThread): Doc!
+  doc(article: ArticleRefInput!): Doc!
 
   "get paged docs"
   pagedDocs(thread: DocThread, filter: PagedDocsFilter!): PagedDocs
@@ -207,10 +207,10 @@ type RootMutationType {
   deleteCollectFolder(id: ID!): CollectFolder
 
   "add article into a collect folder"
-  addToCollect(id: ID!, folderId: ID!, community: String!, thread: Thread): CollectFolder
+  addToCollect(article: ArticleRefInput!, folderId: ID!): CollectFolder
 
   "remove article from a collect folder"
-  removeFromCollect(id: ID!, folderId: ID!, community: String!, thread: Thread): CollectFolder
+  removeFromCollect(article: ArticleRefInput!, folderId: ID!): CollectFolder
 
   "set user's customization"
   setCustomization(userId: ID, customization: CustomizationInput!, sidebarCommunitiesIndex: [CommunityIndex]): User
@@ -302,28 +302,28 @@ type RootMutationType {
   unsubscribeCommunity(community: String!): Community
 
   "set a community_tag to content"
-  setCommunityTag(id: ID!, communityTagId: ID!, community: String!, thread: Thread): Article
+  setCommunityTag(article: ArticleRefInput!, communityTagId: ID!): Article
 
   "unset a tag to content"
-  unsetCommunityTag(id: ID!, communityTagId: ID!, community: String!, thread: Thread): Article
+  unsetCommunityTag(article: ArticleRefInput!, communityTagId: ID!): Article
 
   "reindex tags in given group"
   reindexTagsInGroup(community: String!, thread: Thread, group: String!, tags: [ReindexTagInput]): Done
 
   "mirror article to other community"
-  mirrorArticle(id: ID!, community: String!, targetCommunity: String!, thread: Thread, communityTags: [ID]): Article
+  mirrorArticle(article: ArticleRefInput!, targetCommunity: String!, communityTags: [ID]): Article
 
   "unmirror article for community"
-  unmirrorArticle(id: ID!, community: String!, targetCommunity: String!, thread: Thread): Article
+  unmirrorArticle(article: ArticleRefInput!, targetCommunity: String!): Article
 
   "move article to other community"
-  moveArticle(id: ID!, community: String!, targetCommunity: String!, thread: Thread, communityTags: [ID]): Article
+  moveArticle(article: ArticleRefInput!, targetCommunity: String!, communityTags: [ID]): Article
 
   "mirror article to home community"
-  mirrorToHome(id: ID!, community: String!, thread: Thread, communityTags: [ID]): Article
+  mirrorToHome(article: ArticleRefInput!, communityTags: [ID]): Article
 
   "move article to other community"
-  moveToBlackhole(id: ID!, community: String!, thread: Thread, communityTags: [ID]): Article
+  moveToBlackhole(article: ArticleRefInput!, communityTags: [ID]): Article
 
   "create a post"
   createPost(
@@ -332,32 +332,32 @@ type RootMutationType {
 
   "update a cms\/post"
   updatePost(
-    id: ID!, community: String!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], thread: Thread
+    article: ArticleRefInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID]
   ): Post
 
   "set cat for a post"
-  setPostCat(id: ID!, community: String!, cat: ArticleCatEnum!, thread: Thread): Post
+  setPostCat(article: ArticleRefInput!, cat: ArticleCatEnum!): Post
 
   "set cat for a post"
-  setPostState(id: ID!, community: String!, state: ArticleStateEnum!, thread: Thread): Post
+  setPostState(article: ArticleRefInput!, state: ArticleStateEnum!): Post
 
   "upvote to post"
-  upvotePost(id: ID!, thread: PostThread, community: String!): Article
+  upvotePost(article: ArticleRefInput!): Article
 
   "undo upvote to post"
-  undoUpvotePost(id: ID!, thread: PostThread, community: String!): Article
+  undoUpvotePost(article: ArticleRefInput!): Article
 
   "pin to post"
-  pinPost(id: ID!, community: String!, thread: PostThread): Post
+  pinPost(article: ArticleRefInput!): Post
 
   "undo pin to post"
-  undoPinPost(id: ID!, community: String!, thread: PostThread): Post
+  undoPinPost(article: ArticleRefInput!): Post
 
   "mark delete a post type article, aka soft-delete"
-  markDeletePost(id: ID!, community: String!, thread: PostThread): Post
+  markDeletePost(article: ArticleRefInput!): Post
 
   "undo mark delete a post type article"
-  undoMarkDeletePost(id: ID!, thread: PostThread, community: String!): Post
+  undoMarkDeletePost(article: ArticleRefInput!): Post
 
   "batch mark delete posts type article, aka soft-delete"
   batchMarkDeletePosts(community: String!, ids: [ID], thread: PostThread): DoneState
@@ -366,31 +366,31 @@ type RootMutationType {
   batchUndoMarkDeletePosts(community: String!, ids: [ID], thread: PostThread): DoneState
 
   "delete a post, not delete"
-  deletePost(id: ID!, community: String!, thread: PostThread): Post
+  deletePost(article: ArticleRefInput!): Post
 
   "emotion to post"
-  emotionToPost(id: ID!, emotion: ArticleEmotion!, community: String!, thread: PostThread): Post
+  emotionToPost(article: ArticleRefInput!, emotion: ArticleEmotion!): Post
 
   "undo emotion to post"
-  undoEmotionToPost(id: ID!, emotion: ArticleEmotion!, community: String!, thread: PostThread): Post
+  undoEmotionToPost(article: ArticleRefInput!, emotion: ArticleEmotion!): Post
 
   "report a post"
-  reportPost(id: ID!, reason: String!, attr: String, thread: PostThread, community: String!): Post
+  reportPost(article: ArticleRefInput!, reason: String!, attr: String): Post
 
   "undo report a post"
-  undoReportPost(id: ID!, thread: PostThread, community: String!): Post
+  undoReportPost(article: ArticleRefInput!): Post
 
   "sink a post"
-  sinkPost(id: ID!, community: String!, thread: PostThread): Article
+  sinkPost(article: ArticleRefInput!): Article
 
   "undo sink to post"
-  undoSinkPost(id: ID!, community: String!, thread: PostThread): Article
+  undoSinkPost(article: ArticleRefInput!): Article
 
   "lock comment of a post"
-  lockPostComment(id: ID!, community: String!, thread: PostThread): Article
+  lockPostComment(article: ArticleRefInput!): Article
 
   "undo lock to a post"
-  undoLockPostComment(id: ID!, community: String!, thread: PostThread): Article
+  undoLockPostComment(article: ArticleRefInput!): Article
 
   "create a blog"
   createBlog(
@@ -399,26 +399,26 @@ type RootMutationType {
 
   "update a cms\/blog"
   updateBlog(
-    id: ID!, community: String!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], thread: Thread
+    article: ArticleRefInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID]
   ): Blog
 
   "upvote to blog"
-  upvoteBlog(id: ID!, thread: BlogThread, community: String!): Article
+  upvoteBlog(article: ArticleRefInput!): Article
 
   "undo upvote to blog"
-  undoUpvoteBlog(id: ID!, thread: BlogThread, community: String!): Article
+  undoUpvoteBlog(article: ArticleRefInput!): Article
 
   "pin to blog"
-  pinBlog(id: ID!, community: String!, thread: BlogThread): Blog
+  pinBlog(article: ArticleRefInput!): Blog
 
   "undo pin to blog"
-  undoPinBlog(id: ID!, community: String!, thread: BlogThread): Blog
+  undoPinBlog(article: ArticleRefInput!): Blog
 
   "mark delete a blog type article, aka soft-delete"
-  markDeleteBlog(id: ID!, community: String!, thread: BlogThread): Blog
+  markDeleteBlog(article: ArticleRefInput!): Blog
 
   "undo mark delete a blog type article"
-  undoMarkDeleteBlog(id: ID!, thread: BlogThread, community: String!): Blog
+  undoMarkDeleteBlog(article: ArticleRefInput!): Blog
 
   "batch mark delete blogs type article, aka soft-delete"
   batchMarkDeleteBlogs(community: String!, ids: [ID], thread: BlogThread): DoneState
@@ -427,31 +427,31 @@ type RootMutationType {
   batchUndoMarkDeleteBlogs(community: String!, ids: [ID], thread: BlogThread): DoneState
 
   "delete a blog, not delete"
-  deleteBlog(id: ID!, community: String!, thread: BlogThread): Blog
+  deleteBlog(article: ArticleRefInput!): Blog
 
   "emotion to blog"
-  emotionToBlog(id: ID!, emotion: ArticleEmotion!, community: String!, thread: BlogThread): Blog
+  emotionToBlog(article: ArticleRefInput!, emotion: ArticleEmotion!): Blog
 
   "undo emotion to blog"
-  undoEmotionToBlog(id: ID!, emotion: ArticleEmotion!, community: String!, thread: BlogThread): Blog
+  undoEmotionToBlog(article: ArticleRefInput!, emotion: ArticleEmotion!): Blog
 
   "report a blog"
-  reportBlog(id: ID!, reason: String!, attr: String, thread: BlogThread, community: String!): Blog
+  reportBlog(article: ArticleRefInput!, reason: String!, attr: String): Blog
 
   "undo report a blog"
-  undoReportBlog(id: ID!, thread: BlogThread, community: String!): Blog
+  undoReportBlog(article: ArticleRefInput!): Blog
 
   "sink a blog"
-  sinkBlog(id: ID!, community: String!, thread: BlogThread): Article
+  sinkBlog(article: ArticleRefInput!): Article
 
   "undo sink to blog"
-  undoSinkBlog(id: ID!, community: String!, thread: BlogThread): Article
+  undoSinkBlog(article: ArticleRefInput!): Article
 
   "lock comment of a blog"
-  lockBlogComment(id: ID!, community: String!, thread: BlogThread): Article
+  lockBlogComment(article: ArticleRefInput!): Article
 
   "undo lock to a blog"
-  undoLockBlogComment(id: ID!, community: String!, thread: BlogThread): Article
+  undoLockBlogComment(article: ArticleRefInput!): Article
 
   "create a changelog"
   createChangelog(
@@ -460,26 +460,26 @@ type RootMutationType {
 
   "update a cms\/changelog"
   updateChangelog(
-    id: ID!, community: String!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], thread: Thread
+    article: ArticleRefInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID]
   ): Changelog
 
   "upvote to changelog"
-  upvoteChangelog(id: ID!, thread: ChangelogThread, community: String!): Article
+  upvoteChangelog(article: ArticleRefInput!): Article
 
   "undo upvote to changelog"
-  undoUpvoteChangelog(id: ID!, thread: ChangelogThread, community: String!): Article
+  undoUpvoteChangelog(article: ArticleRefInput!): Article
 
   "pin to changelog"
-  pinChangelog(id: ID!, community: String!, thread: ChangelogThread): Changelog
+  pinChangelog(article: ArticleRefInput!): Changelog
 
   "undo pin to changelog"
-  undoPinChangelog(id: ID!, community: String!, thread: ChangelogThread): Changelog
+  undoPinChangelog(article: ArticleRefInput!): Changelog
 
   "mark delete a changelog type article, aka soft-delete"
-  markDeleteChangelog(id: ID!, community: String!, thread: ChangelogThread): Changelog
+  markDeleteChangelog(article: ArticleRefInput!): Changelog
 
   "undo mark delete a changelog type article"
-  undoMarkDeleteChangelog(id: ID!, thread: ChangelogThread, community: String!): Changelog
+  undoMarkDeleteChangelog(article: ArticleRefInput!): Changelog
 
   "batch mark delete changelogs type article, aka soft-delete"
   batchMarkDeleteChangelogs(community: String!, ids: [ID], thread: ChangelogThread): DoneState
@@ -488,31 +488,31 @@ type RootMutationType {
   batchUndoMarkDeleteChangelogs(community: String!, ids: [ID], thread: ChangelogThread): DoneState
 
   "delete a changelog, not delete"
-  deleteChangelog(id: ID!, community: String!, thread: ChangelogThread): Changelog
+  deleteChangelog(article: ArticleRefInput!): Changelog
 
   "emotion to changelog"
-  emotionToChangelog(id: ID!, emotion: ArticleEmotion!, community: String!, thread: ChangelogThread): Changelog
+  emotionToChangelog(article: ArticleRefInput!, emotion: ArticleEmotion!): Changelog
 
   "undo emotion to changelog"
-  undoEmotionToChangelog(id: ID!, emotion: ArticleEmotion!, community: String!, thread: ChangelogThread): Changelog
+  undoEmotionToChangelog(article: ArticleRefInput!, emotion: ArticleEmotion!): Changelog
 
   "report a changelog"
-  reportChangelog(id: ID!, reason: String!, attr: String, thread: ChangelogThread, community: String!): Changelog
+  reportChangelog(article: ArticleRefInput!, reason: String!, attr: String): Changelog
 
   "undo report a changelog"
-  undoReportChangelog(id: ID!, thread: ChangelogThread, community: String!): Changelog
+  undoReportChangelog(article: ArticleRefInput!): Changelog
 
   "sink a changelog"
-  sinkChangelog(id: ID!, community: String!, thread: ChangelogThread): Article
+  sinkChangelog(article: ArticleRefInput!): Article
 
   "undo sink to changelog"
-  undoSinkChangelog(id: ID!, community: String!, thread: ChangelogThread): Article
+  undoSinkChangelog(article: ArticleRefInput!): Article
 
   "lock comment of a changelog"
-  lockChangelogComment(id: ID!, community: String!, thread: ChangelogThread): Article
+  lockChangelogComment(article: ArticleRefInput!): Article
 
   "undo lock to a changelog"
-  undoLockChangelogComment(id: ID!, community: String!, thread: ChangelogThread): Article
+  undoLockChangelogComment(article: ArticleRefInput!): Article
 
   "create a doc"
   createDoc(
@@ -521,26 +521,26 @@ type RootMutationType {
 
   "update a cms\/doc"
   updateDoc(
-    id: ID!, community: String!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], thread: Thread
+    article: ArticleRefInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID]
   ): Doc
 
   "upvote to doc"
-  upvoteDoc(id: ID!, thread: DocThread, community: String!): Article
+  upvoteDoc(article: ArticleRefInput!): Article
 
   "undo upvote to doc"
-  undoUpvoteDoc(id: ID!, thread: DocThread, community: String!): Article
+  undoUpvoteDoc(article: ArticleRefInput!): Article
 
   "pin to doc"
-  pinDoc(id: ID!, community: String!, thread: DocThread): Doc
+  pinDoc(article: ArticleRefInput!): Doc
 
   "undo pin to doc"
-  undoPinDoc(id: ID!, community: String!, thread: DocThread): Doc
+  undoPinDoc(article: ArticleRefInput!): Doc
 
   "mark delete a doc type article, aka soft-delete"
-  markDeleteDoc(id: ID!, community: String!, thread: DocThread): Doc
+  markDeleteDoc(article: ArticleRefInput!): Doc
 
   "undo mark delete a doc type article"
-  undoMarkDeleteDoc(id: ID!, thread: DocThread, community: String!): Doc
+  undoMarkDeleteDoc(article: ArticleRefInput!): Doc
 
   "batch mark delete docs type article, aka soft-delete"
   batchMarkDeleteDocs(community: String!, ids: [ID], thread: DocThread): DoneState
@@ -549,31 +549,31 @@ type RootMutationType {
   batchUndoMarkDeleteDocs(community: String!, ids: [ID], thread: DocThread): DoneState
 
   "delete a doc, not delete"
-  deleteDoc(id: ID!, community: String!, thread: DocThread): Doc
+  deleteDoc(article: ArticleRefInput!): Doc
 
   "emotion to doc"
-  emotionToDoc(id: ID!, emotion: ArticleEmotion!, community: String!, thread: DocThread): Doc
+  emotionToDoc(article: ArticleRefInput!, emotion: ArticleEmotion!): Doc
 
   "undo emotion to doc"
-  undoEmotionToDoc(id: ID!, emotion: ArticleEmotion!, community: String!, thread: DocThread): Doc
+  undoEmotionToDoc(article: ArticleRefInput!, emotion: ArticleEmotion!): Doc
 
   "report a doc"
-  reportDoc(id: ID!, reason: String!, attr: String, thread: DocThread, community: String!): Doc
+  reportDoc(article: ArticleRefInput!, reason: String!, attr: String): Doc
 
   "undo report a doc"
-  undoReportDoc(id: ID!, thread: DocThread, community: String!): Doc
+  undoReportDoc(article: ArticleRefInput!): Doc
 
   "sink a doc"
-  sinkDoc(id: ID!, community: String!, thread: DocThread): Article
+  sinkDoc(article: ArticleRefInput!): Article
 
   "undo sink to doc"
-  undoSinkDoc(id: ID!, community: String!, thread: DocThread): Article
+  undoSinkDoc(article: ArticleRefInput!): Article
 
   "lock comment of a doc"
-  lockDocComment(id: ID!, community: String!, thread: DocThread): Article
+  lockDocComment(article: ArticleRefInput!): Article
 
   "undo lock to a doc"
-  undoLockDocComment(id: ID!, community: String!, thread: DocThread): Article
+  undoLockDocComment(article: ArticleRefInput!): Article
 
   "write a comment"
   createComment(community: String!, thread: Thread, id: ID!, body: String!): Comment
@@ -1256,7 +1256,7 @@ type PagedDocs {
   pageNumber: Int
 }
 
-type GroupedPosts {
+type KanbanPosts {
   backlog: PagedPosts
   todo: PagedPosts
   wip: PagedPosts
@@ -1557,6 +1557,12 @@ input CommunityTagsFilter {
 input ReindexTagInput {
   id: ID
   index: Int
+}
+
+input ArticleRefInput {
+  innerId: ID!
+  community: String!
+  thread: Thread
 }
 
 input PagiFilter {

--- a/backend/main/test/groupher_server_web/mutation/accounts/collect_folder_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/accounts/collect_folder_test.exs
@@ -97,8 +97,8 @@ defmodule GroupherServer.Test.Mutation.Accounts.CollectFolder do
 
   describe "[Accounts CollectFolder add/remove]" do
     @query """
-    mutation($id: ID!, $folderId: ID!, $community: String!, $thread: Thread) {
-      addToCollect(id: $id, folderId: $folderId, community: $community, thread: $thread) {
+    mutation($article: ArticleRefInput!, $folderId: ID!) {
+      addToCollect(article: $article, folderId: $folderId) {
         id
         title
         totalCount
@@ -124,10 +124,8 @@ defmodule GroupherServer.Test.Mutation.Accounts.CollectFolder do
       {:ok, folder} = Accounts.CollectFolders.create(args, user)
 
       variables = %{
-        id: post.inner_id,
-        folderId: folder.id,
-        community: community.slug,
-        thread: "POST"
+        article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"},
+        folderId: folder.id
       }
 
       folder = user_conn |> gq_mutation(@query, variables)
@@ -151,10 +149,8 @@ defmodule GroupherServer.Test.Mutation.Accounts.CollectFolder do
       {:ok, folder} = Accounts.CollectFolders.create(args, user)
 
       variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        folderId: folder.id,
-        thread: "BLOG"
+        article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"},
+        folderId: folder.id
       }
 
       folder = user_conn |> gq_mutation(@query, variables)
@@ -174,8 +170,8 @@ defmodule GroupherServer.Test.Mutation.Accounts.CollectFolder do
     end
 
     @query """
-    mutation($id: ID!, $community: String!, $folderId: ID!, $thread: Thread) {
-      removeFromCollect(id: $id, community: $community, folderId: $folderId, thread: $thread) {
+    mutation($article: ArticleRefInput!, $folderId: ID!) {
+      removeFromCollect(article: $article, folderId: $folderId) {
         id
         title
         totalCount
@@ -196,10 +192,8 @@ defmodule GroupherServer.Test.Mutation.Accounts.CollectFolder do
       {:ok, _folder} = Accounts.CollectFolders.add(post, folder.id, user)
 
       variables = %{
-        id: post.inner_id,
-        folderId: folder.id,
-        community: community.slug,
-        thread: "POST"
+        article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"},
+        folderId: folder.id
       }
 
       result = user_conn |> gq_mutation(@query, variables)
@@ -214,10 +208,8 @@ defmodule GroupherServer.Test.Mutation.Accounts.CollectFolder do
       {:ok, _folder} = Accounts.CollectFolders.add(blog, folder.id, user)
 
       variables = %{
-        id: blog.inner_id,
-        folderId: folder.id,
-        community: community.slug,
-        thread: "BLOG"
+        article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"},
+        folderId: folder.id
       }
 
       result = user_conn |> gq_mutation(@query, variables)

--- a/backend/main/test/groupher_server_web/mutation/cms/abuse_reports/blog_report_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/abuse_reports/blog_report_test.exs
@@ -15,19 +15,19 @@ defmodule GroupherServer.Test.Mutation.AbuseReports.BlogReport do
 
   describe "[blog report/undo_report]" do
     test "login user can report a blog", ~m(community blog user_conn)a do
-      variables = %{id: blog.inner_id, community: community.slug, reason: "reason"}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, reason: "reason"}
 
       article = user_conn |> gq_mutation(Schema.m(:report_article, :blog), variables)
       assert article["innerId"] == to_string(blog.inner_id)
     end
 
     test "login user can undo report a blog", ~m(community blog user_conn)a do
-      variables = %{id: blog.inner_id, reason: "reason", community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, reason: "reason"}
 
       article = user_conn |> gq_mutation(Schema.m(:report_article, :blog), variables)
       assert article["innerId"] == to_string(blog.inner_id)
 
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       article = user_conn |> gq_mutation(Schema.m(:undo_report_article, :blog), variables)
       assert article["innerId"] == to_string(blog.inner_id)

--- a/backend/main/test/groupher_server_web/mutation/cms/abuse_reports/changelog_report_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/abuse_reports/changelog_report_test.exs
@@ -15,19 +15,19 @@ defmodule GroupherServer.Test.Mutation.AbuseReports.ChangelogReport do
 
   describe "[changelog report/undo_report]" do
     test "login user can report a changelog", ~m(community changelog user_conn)a do
-      variables = %{id: changelog.inner_id, community: community.slug, reason: "reason"}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, reason: "reason"}
 
       article = user_conn |> gq_mutation(Schema.m(:report_article, :changelog), variables)
       assert article["innerId"] == to_string(changelog.inner_id)
     end
 
     test "login user can undo report a changelog", ~m(community changelog user_conn)a do
-      variables = %{id: changelog.inner_id, reason: "reason", community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, reason: "reason"}
 
       article = user_conn |> gq_mutation(Schema.m(:report_article, :changelog), variables)
       assert article["innerId"] == to_string(changelog.inner_id)
 
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       article =
         user_conn |> gq_mutation(Schema.m(:undo_report_article, :changelog), variables)

--- a/backend/main/test/groupher_server_web/mutation/cms/abuse_reports/doc_report_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/abuse_reports/doc_report_test.exs
@@ -15,7 +15,7 @@ defmodule GroupherServer.Test.Mutation.AbuseReports.DocReport do
 
   describe "[doc report/undo_report]" do
     test "login user can report a doc", ~m(community doc user_conn)a do
-      variables = %{id: doc.inner_id, community: community.slug, reason: "reason"}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, reason: "reason"}
 
       article =
         user_conn
@@ -25,13 +25,13 @@ defmodule GroupherServer.Test.Mutation.AbuseReports.DocReport do
     end
 
     test "login user can undo report a doc", ~m(community doc user_conn)a do
-      variables = %{id: doc.inner_id, reason: "reason", community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, reason: "reason"}
 
       article = user_conn |> gq_mutation(Schema.m(:report_article, :doc), variables)
 
       assert article["innerId"] == to_string(doc.inner_id)
 
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       article = user_conn |> gq_mutation(Schema.m(:undo_report_article, :doc), variables)
       assert article["innerId"] == to_string(doc.inner_id)

--- a/backend/main/test/groupher_server_web/mutation/cms/abuse_reports/post_report_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/abuse_reports/post_report_test.exs
@@ -15,19 +15,19 @@ defmodule GroupherServer.Test.Mutation.AbuseReports.PostReport do
 
   describe "[post report/undo_report]" do
     test "login user can report a post", ~m(community post user_conn)a do
-      variables = %{id: post.inner_id, community: community.slug, reason: "reason"}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, reason: "reason"}
       article = user_conn |> gq_mutation(Schema.m(:report_article, :post), variables)
 
       assert article["innerId"] == to_string(post.inner_id)
     end
 
     test "login user can undo report a post", ~m(community post user_conn)a do
-      variables = %{id: post.inner_id, community: community.slug, reason: "reason"}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, reason: "reason"}
       article = user_conn |> gq_mutation(Schema.m(:report_article, :post), variables)
 
       assert article["innerId"] == to_string(post.inner_id)
 
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       article = user_conn |> gq_mutation(Schema.m(:undo_report_article, :post), variables)
       assert article["innerId"] == to_string(post.inner_id)

--- a/backend/main/test/groupher_server_web/mutation/cms/article_community/blog_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/article_community/blog_test.exs
@@ -25,12 +25,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Blog do
       passport_rules = %{"blog.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
       {:ok, found} = ORM.find(Blog, blog.id, preload: :communities)
@@ -41,12 +36,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Blog do
 
     test "unauth user cannot mirror a blog to a community",
          ~m(user_conn guest_conn community community2 blog)a do
-      variables = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, targetCommunity: community2.slug}
 
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
@@ -65,21 +55,11 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Blog do
       passport_rules = %{"blog.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
-      variables = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        community: community.slug,
-        targetCommunity: community3.slug
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, targetCommunity: community3.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
@@ -95,19 +75,12 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Blog do
       passport_rules = %{"blog.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
       variables2 = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        community: community.slug,
+        article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"},
         targetCommunity: community3.slug
       }
 
@@ -132,7 +105,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Blog do
     test "auth user can mirror blog home", ~m(user community blog)a do
       {:ok, home_community} = mock_community(user, %{slug: "home"})
 
-      variables = %{id: blog.inner_id, community: community.slug, thread: "BLOG"}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}}
 
       passport_rules = %{"homemirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -145,7 +118,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Blog do
     end
 
     test "auth user can move blog to blackhole", ~m(community blackhole blog)a do
-      variables = %{id: blog.inner_id, thread: "BLOG", community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}}
 
       passport_rules = %{"blackeye" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -161,12 +134,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Blog do
       passport_rules = %{"blog.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
@@ -185,13 +153,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Blog do
       {:ok, user} = db_insert(:user)
       {:ok, article_tag} = CMS.Communities.create_tag(community2, :blog, article_tag_attrs, user)
 
-      variables = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        community: community.slug,
-        targetCommunity: community2.slug,
-        communityTags: [article_tag.id]
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, targetCommunity: community2.slug, communityTags: [article_tag.id]}
 
       rule_conn |> gq_mutation(Schema.m(:move_article), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/article_community/changelog_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/article_community/changelog_test.exs
@@ -25,12 +25,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Changelog do
       passport_rules = %{"changelog.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
       {:ok, found} = ORM.find(Changelog, changelog.id, preload: :communities)
@@ -41,12 +36,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Changelog do
 
     test "unauth user cannot mirror a changelog to a community",
          ~m(user_conn guest_conn community community2 changelog)a do
-      variables = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, targetCommunity: community2.slug}
 
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
@@ -65,21 +55,11 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Changelog do
       passport_rules = %{"changelog.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
-      variables = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        community: community.slug,
-        targetCommunity: community3.slug
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, targetCommunity: community3.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
@@ -95,19 +75,12 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Changelog do
       passport_rules = %{"changelog.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
       variables2 = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        community: community.slug,
+        article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"},
         targetCommunity: community3.slug
       }
 
@@ -132,7 +105,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Changelog do
     test "auth user can mirror changelog home", ~m(user community changelog)a do
       {:ok, home_community} = mock_community(user, %{slug: "home"})
 
-      variables = %{id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}}
 
       passport_rules = %{"homemirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -146,7 +119,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Changelog do
     end
 
     test "auth user can move changelog to blackhole", ~m(community blackhole changelog)a do
-      variables = %{id: changelog.inner_id, thread: "CHANGELOG", community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}}
 
       passport_rules = %{"blackeye" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -164,12 +137,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Changelog do
       passport_rules = %{"changelog.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
@@ -190,13 +158,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Changelog do
       {:ok, article_tag} =
         CMS.Communities.create_tag(community2, :changelog, article_tag_attrs, user)
 
-      variables = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        community: community.slug,
-        targetCommunity: community2.slug,
-        communityTags: [article_tag.id]
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, targetCommunity: community2.slug, communityTags: [article_tag.id]}
 
       rule_conn |> gq_mutation(Schema.m(:move_article), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/article_community/doc_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/article_community/doc_test.exs
@@ -24,12 +24,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Doc do
       passport_rules = %{"doc.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
       {:ok, found} = ORM.find(Doc, doc.id, preload: :communities)
@@ -40,12 +35,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Doc do
 
     test "unauth user cannot mirror a doc to a community",
          ~m(user_conn guest_conn community community2 doc)a do
-      variables = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, targetCommunity: community2.slug}
 
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
@@ -64,21 +54,11 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Doc do
       passport_rules = %{"doc.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
-      variables = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        community: community.slug,
-        targetCommunity: community3.slug
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, targetCommunity: community3.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
@@ -94,19 +74,12 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Doc do
       passport_rules = %{"doc.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
       variables2 = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        community: community.slug,
+        article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"},
         targetCommunity: community3.slug
       }
 
@@ -131,7 +104,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Doc do
     test "auth user can mirror doc home", ~m(user community doc)a do
       {:ok, home_community} = mock_community(user, %{slug: "home"})
 
-      variables = %{id: doc.inner_id, community: community.slug, thread: "DOC"}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}}
 
       passport_rules = %{"homemirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -144,7 +117,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Doc do
     end
 
     test "auth user can move doc to blackhole", ~m(community blackhole doc)a do
-      variables = %{id: doc.inner_id, thread: "DOC", community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}}
 
       passport_rules = %{"blackeye" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -160,12 +133,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Doc do
       passport_rules = %{"doc.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
@@ -184,13 +152,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Doc do
       {:ok, user} = db_insert(:user)
       {:ok, article_tag} = CMS.Communities.create_tag(community2, :doc, article_tag_attrs, user)
 
-      variables = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        community: community.slug,
-        targetCommunity: community2.slug,
-        communityTags: [article_tag.id]
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, targetCommunity: community2.slug, communityTags: [article_tag.id]}
 
       rule_conn |> gq_mutation(Schema.m(:move_article), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/article_community/post_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/article_community/post_test.exs
@@ -78,7 +78,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
       {:ok, community2} = db_insert(:community)
       {:ok, community3} = db_insert(:community)
 
-      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, targetCommunity: community2.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/article_community/post_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/article_community/post_test.exs
@@ -26,12 +26,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
 
       {:ok, community2} = mock_community()
 
-      variables = %{
-        id: post.inner_id,
-        thread: "POST",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
       {:ok, found} = ORM.find(Post, post.id, preload: :communities)
@@ -42,12 +37,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
 
     test "unauth user cannot mirror a post to a community",
          ~m(user_conn guest_conn community community2 post)a do
-      variables = %{
-        id: post.inner_id,
-        thread: "POST",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, targetCommunity: community2.slug}
 
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
@@ -66,21 +56,11 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
       passport_rules = %{"post.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: post.inner_id,
-        thread: "POST",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
-      variables = %{
-        id: post.inner_id,
-        thread: "POST",
-        community: community.slug,
-        targetCommunity: community3.slug
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, targetCommunity: community3.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
@@ -98,17 +78,12 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
       {:ok, community2} = db_insert(:community)
       {:ok, community3} = db_insert(:community)
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
 
       variables2 = %{
-        id: post.inner_id,
-        community: community.slug,
+        article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"},
         targetCommunity: community3.slug
       }
 
@@ -133,7 +108,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
     test "auth user can mirror post home", ~m(community post user)a do
       {:ok, home_community} = mock_community(user, %{slug: "home"})
 
-      variables = %{id: post.inner_id, community: community.slug, thread: "POST"}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}}
 
       passport_rules = %{"homemirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -146,7 +121,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
     end
 
     test "auth user can move post to blackhole", ~m(community blackhole post)a do
-      variables = %{id: post.inner_id, thread: "POST", community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}}
 
       passport_rules = %{"blackeye" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -160,12 +135,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
       passport_rules = %{"post.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: post.inner_id,
-        thread: "POST",
-        community: community.slug,
-        targetCommunity: community2.slug
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, targetCommunity: community2.slug}
 
       rule_conn |> gq_mutation(Schema.m(:mirror_article), variables)
       {:ok, found} = ORM.find(Post, post.id, preload: [:community, :communities])
@@ -181,13 +151,7 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
       {:ok, user} = db_insert(:user)
       {:ok, article_tag} = CMS.Communities.create_tag(community2, :post, article_tag_attrs, user)
 
-      variables = %{
-        id: post.inner_id,
-        thread: "POST",
-        community: community.slug,
-        targetCommunity: community2.slug,
-        communityTags: [article_tag.id]
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, targetCommunity: community2.slug, communityTags: [article_tag.id]}
 
       rule_conn |> gq_mutation(Schema.m(:move_article), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/blog_emotion_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/blog_emotion_test.exs
@@ -15,7 +15,7 @@ defmodule GroupherServer.Test.Mutation.Articles.BlogEmotion do
 
   describe "[blog emotion]" do
     test "login user can emotion to a blog", ~m(community blog user_conn)a do
-      variables = %{id: blog.inner_id, community: community.slug, emotion: "BEER"}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, emotion: "BEER"}
 
       article = user_conn |> gq_mutation(Schema.m(:emotion_article, :blog), variables)
 
@@ -26,7 +26,7 @@ defmodule GroupherServer.Test.Mutation.Articles.BlogEmotion do
     test "login user can undo emotion to a blog", ~m(community blog user owner_conn)a do
       {:ok, _} = CMS.Articles.emotion(blog, :beer, user)
 
-      variables = %{id: blog.inner_id, community: community.slug, emotion: "BEER"}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, emotion: "BEER"}
 
       article = owner_conn |> gq_mutation(Schema.m(:undo_emotion_article, :blog), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/blog_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/blog_test.exs
@@ -92,7 +92,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
     end
 
     test "delete a blog by blog's owner", ~m(owner_conn community blog)a do
-      variables = %{community: community.slug, id: blog.inner_id}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       result = owner_conn |> gq_mutation(Schema.m(:delete_article, :blog), variables)
 
       assert result["innerId"] == to_string(blog.inner_id)
@@ -106,7 +106,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
       rule_conn =
         simu_conn(:user, cms: %{belongs_community_title => %{"blog.delete" => true}})
 
-      variables = %{community: community.slug, id: blog.inner_id}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       result = rule_conn |> gq_mutation(Schema.m(:delete_article, :blog), variables)
 
       assert result["innerId"] == to_string(blog.inner_id)
@@ -114,7 +114,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
     end
 
     test "delete a blog without login user fails", ~m(guest_conn community blog)a do
-      variables = %{community: community.slug, id: blog.inner_id}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -130,14 +130,14 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
       passport_rules = %{blog_communities_0 => %{"blog.delete" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{community: community.slug, id: blog.inner_id}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       result = rule_conn |> gq_mutation(Schema.m(:delete_article, :blog), variables)
 
       assert result["innerId"] == to_string(blog.inner_id)
     end
 
     test "unauth user delete blog fails", ~m(user_conn guest_conn community blog)a do
-      variables = %{community: community.slug, id: blog.inner_id}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
       schema = Schema.m(:delete_article, :blog)
 
@@ -149,12 +149,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
     test "update a blog without login user fails", ~m(guest_conn community blog)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       assert guest_conn
              |> mutation_error?(
@@ -172,14 +167,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
       {:ok, community_tag} =
         CMS.Communities.create_tag(community, :blog, community_tag_attrs, user)
 
-      variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        # body: mock_rich_text("updated body #{unique_num}"),,
-        body: mock_rich_text("updated body #{unique_num}"),
-        communityTags: [community_tag.id]
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}"), communityTags: [community_tag.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :blog), variables)
       assert result["title"] == variables.title
@@ -207,11 +195,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
       {:ok, community_tag3} =
         CMS.Communities.create_tag(community, :blog, community_tag_attrs3, user)
 
-      variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        communityTags: [community_tag.id, community_tag2.id]
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, communityTags: [community_tag.id, community_tag2.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :blog), variables)
 
@@ -223,11 +207,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
       assert result["communityTags"] |> List.last() |> get_in(["id"]) ==
                to_string(community_tag2.id)
 
-      variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        communityTags: [community_tag2.id, community_tag3.id]
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, communityTags: [community_tag2.id, community_tag3.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :blog), variables)
 
@@ -244,12 +224,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
          ~m(owner_conn community blog)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       updated_blog =
         owner_conn |> gq_mutation(Schema.m(:update_article, :blog), variables)
@@ -266,12 +241,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
 
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       updated_blog =
         rule_conn |> gq_mutation(Schema.m(:update_article, :blog), variables)
@@ -282,12 +252,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Blog do
     test "unauth user update blog fails", ~m(user_conn guest_conn community blog)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/changelog_emotion_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/changelog_emotion_test.exs
@@ -15,7 +15,7 @@ defmodule GroupherServer.Test.Mutation.Articles.ChangelogEmotion do
 
   describe "[changelog emotion]" do
     test "login user can emotion to a changelog", ~m(community changelog user_conn)a do
-      variables = %{id: changelog.inner_id, community: community.slug, emotion: "BEER"}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, emotion: "BEER"}
 
       article = user_conn |> gq_mutation(Schema.m(:emotion_article, :changelog), variables)
 
@@ -26,7 +26,7 @@ defmodule GroupherServer.Test.Mutation.Articles.ChangelogEmotion do
     test "login user can undo emotion to a changelog", ~m(community changelog user owner_conn)a do
       {:ok, _} = CMS.Articles.emotion(changelog, :beer, user)
 
-      variables = %{id: changelog.inner_id, community: community.slug, emotion: "BEER"}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, emotion: "BEER"}
 
       article =
         owner_conn |> gq_mutation(Schema.m(:undo_emotion_article, :changelog), variables)

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/changelog_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/changelog_test.exs
@@ -98,7 +98,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
     end
 
     test "delete a changelog by changelog's owner", ~m(owner_conn community changelog)a do
-      variables = %{community: community.slug, id: changelog.inner_id}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       result = owner_conn |> gq_mutation(Schema.m(:delete_article, :changelog), variables)
 
       assert result["innerId"] == to_string(changelog.inner_id)
@@ -112,7 +112,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
       rule_conn =
         simu_conn(:user, cms: %{belongs_community_title => %{"changelog.delete" => true}})
 
-      variables = %{community: community.slug, id: changelog.inner_id}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       result = rule_conn |> gq_mutation(Schema.m(:delete_article, :changelog), variables)
 
       assert result["innerId"] == to_string(changelog.inner_id)
@@ -120,7 +120,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
     end
 
     test "delete a changelog without login user fails", ~m(guest_conn community changelog)a do
-      variables = %{community: community.slug, id: changelog.inner_id}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -136,14 +136,14 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
       passport_rules = %{changelog_communities_0 => %{"changelog.delete" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{community: community.slug, id: changelog.inner_id}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       result = rule_conn |> gq_mutation(Schema.m(:delete_article, :changelog), variables)
 
       assert result["innerId"] == to_string(changelog.inner_id)
     end
 
     test "unauth user delete changelog fails", ~m(user_conn guest_conn community changelog)a do
-      variables = %{community: community.slug, id: changelog.inner_id}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
       schema = Schema.m(:delete_article, :changelog)
 
@@ -155,12 +155,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
     test "update a changelog without login user fails", ~m(guest_conn community changelog)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: changelog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       assert guest_conn
              |> mutation_error?(
@@ -183,14 +178,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
           user
         )
 
-      variables = %{
-        id: changelog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        # body: mock_rich_text("updated body #{unique_num}"),,
-        body: mock_rich_text("updated body #{unique_num}"),
-        communityTags: [community_tag.id]
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}"), communityTags: [community_tag.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :changelog), variables)
       assert result["title"] == variables.title
@@ -233,11 +221,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
           user
         )
 
-      variables = %{
-        id: changelog.inner_id,
-        community: community.slug,
-        communityTags: [community_tag.id, community_tag2.id]
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, communityTags: [community_tag.id, community_tag2.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :changelog), variables)
 
@@ -249,11 +233,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
       assert result["communityTags"] |> List.last() |> get_in(["id"]) ==
                to_string(community_tag2.id)
 
-      variables = %{
-        id: changelog.inner_id,
-        community: community.slug,
-        communityTags: [community_tag2.id, community_tag3.id]
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, communityTags: [community_tag2.id, community_tag3.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :changelog), variables)
 
@@ -270,12 +250,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
          ~m(owner_conn community changelog)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: changelog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       updated_changelog =
         owner_conn |> gq_mutation(Schema.m(:update_article, :changelog), variables)
@@ -292,12 +267,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
 
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: changelog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       updated_changelog =
         rule_conn |> gq_mutation(Schema.m(:update_article, :changelog), variables)
@@ -308,12 +278,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Changelog do
     test "unauth user update changelog fails", ~m(user_conn guest_conn community changelog)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: changelog.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/doc_emotion_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/doc_emotion_test.exs
@@ -15,7 +15,7 @@ defmodule GroupherServer.Test.Mutation.Articles.DocEmotion do
 
   describe "[doc emotion]" do
     test "login user can emotion to a doc", ~m(community doc user_conn)a do
-      variables = %{id: doc.inner_id, community: community.slug, emotion: "BEER"}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, emotion: "BEER"}
 
       article = user_conn |> gq_mutation(Schema.m(:emotion_article, :doc), variables)
 
@@ -26,7 +26,7 @@ defmodule GroupherServer.Test.Mutation.Articles.DocEmotion do
     test "login user can undo emotion to a doc", ~m(community doc user owner_conn)a do
       {:ok, _} = CMS.Articles.emotion(doc, :beer, user)
 
-      variables = %{id: doc.inner_id, community: community.slug, emotion: "BEER"}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, emotion: "BEER"}
 
       article = owner_conn |> gq_mutation(Schema.m(:undo_emotion_article, :doc), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/doc_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/doc_test.exs
@@ -92,7 +92,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
     end
 
     test "delete a doc by doc's owner", ~m(owner_conn community doc)a do
-      variables = %{community: community.slug, id: doc.inner_id}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       result = owner_conn |> gq_mutation(Schema.m(:delete_article, :doc), variables)
 
       assert result["innerId"] == to_string(doc.inner_id)
@@ -106,7 +106,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
       rule_conn =
         simu_conn(:user, cms: %{belongs_community_title => %{"doc.delete" => true}})
 
-      variables = %{community: community.slug, id: doc.inner_id}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       result = rule_conn |> gq_mutation(Schema.m(:delete_article, :doc), variables)
 
       assert result["innerId"] == to_string(doc.inner_id)
@@ -114,7 +114,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
     end
 
     test "delete a doc without login user fails", ~m(guest_conn community doc)a do
-      variables = %{community: community.slug, id: doc.inner_id}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -130,14 +130,14 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
       passport_rules = %{doc_communities_0 => %{"doc.delete" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{community: community.slug, id: doc.inner_id}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       result = rule_conn |> gq_mutation(Schema.m(:delete_article, :doc), variables)
 
       assert result["innerId"] == to_string(doc.inner_id)
     end
 
     test "unauth user delete doc fails", ~m(user_conn guest_conn community doc)a do
-      variables = %{community: community.slug, id: doc.inner_id}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
       schema = Schema.m(:delete_article, :doc)
 
@@ -149,12 +149,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
     test "update a doc without login user fails", ~m(guest_conn community doc)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: doc.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       assert guest_conn
              |> mutation_error?(
@@ -172,14 +167,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
       {:ok, community_tag} =
         CMS.Communities.create_tag(community, :doc, community_tag_attrs, user)
 
-      variables = %{
-        id: doc.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        # body: mock_rich_text("updated body #{unique_num}"),,
-        body: mock_rich_text("updated body #{unique_num}"),
-        communityTags: [community_tag.id]
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}"), communityTags: [community_tag.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :doc), variables)
       assert result["title"] == variables.title
@@ -207,11 +195,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
       {:ok, community_tag3} =
         CMS.Communities.create_tag(community, :doc, community_tag_attrs3, user)
 
-      variables = %{
-        id: doc.inner_id,
-        community: community.slug,
-        communityTags: [community_tag.id, community_tag2.id]
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, communityTags: [community_tag.id, community_tag2.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :doc), variables)
 
@@ -222,11 +206,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
              |> Enum.sort() ==
                Enum.sort([to_string(community_tag.id), to_string(community_tag2.id)])
 
-      variables = %{
-        id: doc.inner_id,
-        community: community.slug,
-        communityTags: [community_tag2.id, community_tag3.id]
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, communityTags: [community_tag2.id, community_tag3.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :doc), variables)
 
@@ -242,12 +222,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
          ~m(owner_conn community doc)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: doc.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       updated_doc =
         owner_conn |> gq_mutation(Schema.m(:update_article, :doc), variables)
@@ -264,12 +239,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
 
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: doc.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       updated_doc =
         rule_conn |> gq_mutation(Schema.m(:update_article, :doc), variables)
@@ -280,12 +250,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Doc do
     test "unauth user update doc fails", ~m(user_conn guest_conn community doc)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: doc.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/post_cat_state_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/post_cat_state_test.exs
@@ -16,13 +16,11 @@ defmodule GroupherServer.Test.Mutation.Articles.PostCatState do
   describe "[post cat & state]" do
     @set_cat_query """
     mutation(
-      $id: ID!
-      $community: String!
+      $article: ArticleRefInput!
       $cat: ArticleCatEnum!
     ) {
       setPostCat(
-        id: $id
-        community: $community
+        article: $article
         cat: $cat
       ) {
         innerId
@@ -31,7 +29,11 @@ defmodule GroupherServer.Test.Mutation.Articles.PostCatState do
     }
     """
     test "can set cat for a existing post", ~m(user_conn community post)a do
-      variables = %{id: post.inner_id, cat: "FEATURE", community: community.slug}
+      variables = %{
+        article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"},
+        cat: "FEATURE"
+      }
+
       created = user_conn |> gq_mutation(@set_cat_query, variables)
 
       assert "FEATURE" == created["cat"]
@@ -39,13 +41,11 @@ defmodule GroupherServer.Test.Mutation.Articles.PostCatState do
 
     @set_state_query """
     mutation(
-      $id: ID!
-      $community: String!
+      $article: ArticleRefInput!
       $state: ArticleStateEnum!
     ) {
       setPostState(
-        id: $id
-                community: $community
+        article: $article
         state: $state
       ) {
         innerId
@@ -54,7 +54,11 @@ defmodule GroupherServer.Test.Mutation.Articles.PostCatState do
     }
     """
     test "can set state for a existing post", ~m(user_conn community post)a do
-      variables = %{id: post.inner_id, state: "DONE", community: community.slug}
+      variables = %{
+        article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"},
+        state: "DONE"
+      }
+
       created = user_conn |> gq_mutation(@set_state_query, variables)
 
       assert "DONE" == created["state"]

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/post_emotion_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/post_emotion_test.exs
@@ -15,7 +15,7 @@ defmodule GroupherServer.Test.Mutation.Articles.PostEmotion do
 
   describe "[post emotion]" do
     test "login user can emotion to a post", ~m(community post user_conn)a do
-      variables = %{id: post.inner_id, community: community.slug, emotion: "BEER"}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, emotion: "BEER"}
 
       article = user_conn |> gq_mutation(Schema.m(:emotion_article, :post), variables)
 
@@ -26,7 +26,7 @@ defmodule GroupherServer.Test.Mutation.Articles.PostEmotion do
     test "login user can undo emotion to a post", ~m(community post user owner_conn)a do
       {:ok, _} = CMS.Articles.emotion(post, :beer, user)
 
-      variables = %{id: post.inner_id, community: community.slug, emotion: "BEER"}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, emotion: "BEER"}
 
       article = owner_conn |> gq_mutation(Schema.m(:undo_emotion_article, :post), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/articles/post_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/articles/post_test.exs
@@ -88,7 +88,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
     end
 
     test "delete a post by post's owner", ~m(owner_conn community post)a do
-      variables = %{community: community.slug, id: post.inner_id}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       result = owner_conn |> gq_mutation(Schema.m(:delete_article, :post), variables)
 
       assert result["innerId"] == to_string(post.inner_id)
@@ -100,7 +100,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
       belongs_community_title = post.communities |> List.first() |> Map.get(:title)
       rule_conn = simu_conn(:user, cms: %{belongs_community_title => %{"post.delete" => true}})
 
-      variables = %{community: community.slug, id: post.inner_id}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       result = rule_conn |> gq_mutation(Schema.m(:delete_article, :post), variables)
 
       assert result["innerId"] == to_string(post.inner_id)
@@ -108,7 +108,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
     end
 
     test "delete a post without login user fails", ~m(guest_conn community post)a do
-      variables = %{community: community.slug, id: post.inner_id}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -124,14 +124,14 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
       passport_rules = %{post_communities_0 => %{"post.delete" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{community: community.slug, id: post.inner_id}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       result = rule_conn |> gq_mutation(Schema.m(:delete_article, :post), variables)
 
       assert result["innerId"] == to_string(post.inner_id)
     end
 
     test "unauth user delete post fails", ~m(user_conn guest_conn community post)a do
-      variables = %{community: community.slug, id: post.inner_id}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
       schema = Schema.m(:delete_article, :post)
 
@@ -143,12 +143,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
     test "update a post without login user fails", ~m(guest_conn community post)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       assert guest_conn
              |> mutation_error?(
@@ -166,14 +161,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
       {:ok, community_tag} =
         CMS.Communities.create_tag(community, :post, community_tag_attrs, user)
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}"),
-        copyRight: "translate",
-        communityTags: [community_tag.id]
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}"), copyRight: "translate", communityTags: [community_tag.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :post), variables)
       assert result["title"] == variables.title
@@ -203,11 +191,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
       {:ok, community_tag3} =
         CMS.Communities.create_tag(community, :post, community_tag_attrs3, user)
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        communityTags: [community_tag.id, community_tag2.id]
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, communityTags: [community_tag.id, community_tag2.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :post), variables)
 
@@ -219,11 +203,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
       assert result["communityTags"] |> List.last() |> get_in(["id"]) ==
                to_string(community_tag2.id)
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        communityTags: [community_tag2.id, community_tag3.id]
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, communityTags: [community_tag2.id, community_tag3.id]}
 
       result = owner_conn |> gq_mutation(Schema.m(:update_article, :post), variables)
 
@@ -240,12 +220,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
          ~m(owner_conn community post)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       updated_post = owner_conn |> gq_mutation(Schema.m(:update_article, :post), variables)
 
@@ -261,12 +236,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
 
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       updated_post = rule_conn |> gq_mutation(Schema.m(:update_article, :post), variables)
 
@@ -276,12 +246,7 @@ defmodule GroupherServer.Test.Mutation.Articles.Post do
     test "unauth user update post fails", ~m(user_conn guest_conn community post)a do
       unique_num = System.unique_integer([:positive, :monotonic])
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        title: "updated title #{unique_num}",
-        body: mock_rich_text("updated body #{unique_num}")
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}, title: "updated title #{unique_num}", body: mock_rich_text("updated body #{unique_num}")}
 
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 

--- a/backend/main/test/groupher_server_web/mutation/cms/comments/blog_comment_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/comments/blog_comment_test.exs
@@ -141,7 +141,7 @@ defmodule GroupherServer.Test.Mutation.Comments.BlogComment do
 
   describe "[article comment lock/unlock]" do
     test "can lock a blog's comment", ~m(community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"blog.lock_comment" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -154,7 +154,7 @@ defmodule GroupherServer.Test.Mutation.Comments.BlogComment do
     end
 
     test "unauth user fails", ~m(guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -169,7 +169,7 @@ defmodule GroupherServer.Test.Mutation.Comments.BlogComment do
       {:ok, blog} = ORM.find(Blog, blog.id)
       assert blog.meta.is_comment_locked
 
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"blog.undo_lock_comment" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -182,7 +182,7 @@ defmodule GroupherServer.Test.Mutation.Comments.BlogComment do
     end
 
     test "unauth user undo fails", ~m(guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/comments/changelog_comment_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/comments/changelog_comment_test.exs
@@ -141,7 +141,7 @@ defmodule GroupherServer.Test.Mutation.Comments.ChangelogComment do
 
   describe "[article comment lock/unlock]" do
     test "can lock a changelog's comment", ~m(community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"changelog.lock_comment" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -154,7 +154,7 @@ defmodule GroupherServer.Test.Mutation.Comments.ChangelogComment do
     end
 
     test "unauth user fails", ~m(guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -169,7 +169,7 @@ defmodule GroupherServer.Test.Mutation.Comments.ChangelogComment do
       {:ok, changelog} = ORM.find(Changelog, changelog.id)
       assert changelog.meta.is_comment_locked
 
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"changelog.undo_lock_comment" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -182,7 +182,7 @@ defmodule GroupherServer.Test.Mutation.Comments.ChangelogComment do
     end
 
     test "unauth user undo fails", ~m(guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/comments/doc_comment_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/comments/doc_comment_test.exs
@@ -141,7 +141,7 @@ defmodule GroupherServer.Test.Mutation.Comments.DocComment do
 
   describe "[article comment lock/unlock]" do
     test "can lock a doc's comment", ~m(community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"doc.lock_comment" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -154,7 +154,7 @@ defmodule GroupherServer.Test.Mutation.Comments.DocComment do
     end
 
     test "unauth user fails", ~m(guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -169,7 +169,7 @@ defmodule GroupherServer.Test.Mutation.Comments.DocComment do
       {:ok, doc} = ORM.find(Doc, doc.id)
       assert doc.meta.is_comment_locked
 
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"doc.undo_lock_comment" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -182,7 +182,7 @@ defmodule GroupherServer.Test.Mutation.Comments.DocComment do
     end
 
     test "unauth user undo fails", ~m(guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/comments/post_comment_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/comments/post_comment_test.exs
@@ -141,7 +141,7 @@ defmodule GroupherServer.Test.Mutation.Comments.PostComment do
 
   describe "[article comment lock/unlock]" do
     test "can lock a post's comment", ~m(community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"post.lock_comment" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -154,7 +154,7 @@ defmodule GroupherServer.Test.Mutation.Comments.PostComment do
     end
 
     test "unauth user fails", ~m(guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -169,7 +169,7 @@ defmodule GroupherServer.Test.Mutation.Comments.PostComment do
       {:ok, post} = ORM.find(Post, post.id)
       assert post.meta.is_comment_locked
 
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"post.undo_lock_comment" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -182,7 +182,7 @@ defmodule GroupherServer.Test.Mutation.Comments.PostComment do
     end
 
     test "unauth user undo fails", ~m(guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/community_tags/blog_set_tag_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/community_tags/blog_set_tag_test.exs
@@ -25,12 +25,7 @@ defmodule GroupherServer.Test.Mutation.CommunityTags.BlogSetTag do
       passport_rules = %{community.title => %{"blog.community_tag.set" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        communityTagId: community_tag.id,
-        community: community.slug
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, communityTagId: community_tag.id}
 
       rule_conn |> gq_mutation(Schema.m(:set_community_tag), variables)
       {:ok, found} = ORM.find(Blog, blog.id, preload: :community_tags)
@@ -53,12 +48,7 @@ defmodule GroupherServer.Test.Mutation.CommunityTags.BlogSetTag do
       passport_rules = %{community.title => %{"blog.community_tag.unset" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: blog.inner_id,
-        thread: "BLOG",
-        communityTagId: community_tag.id,
-        community: community.slug
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, communityTagId: community_tag.id}
 
       rule_conn |> gq_mutation(Schema.m(:unset_community_tag), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/community_tags/changelog_set_tag_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/community_tags/changelog_set_tag_test.exs
@@ -26,12 +26,7 @@ defmodule GroupherServer.Test.Mutation.CommunityTags.ChangelogSetTag do
       passport_rules = %{community.title => %{"changelog.community_tag.set" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        communityTagId: community_tag.id,
-        community: community.slug
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, communityTagId: community_tag.id}
 
       rule_conn |> gq_mutation(Schema.m(:set_community_tag), variables)
       {:ok, found} = ORM.find(Changelog, changelog.id, preload: :community_tags)
@@ -54,12 +49,7 @@ defmodule GroupherServer.Test.Mutation.CommunityTags.ChangelogSetTag do
       passport_rules = %{community.title => %{"changelog.community_tag.unset" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: changelog.inner_id,
-        thread: "CHANGELOG",
-        communityTagId: community_tag.id,
-        community: community.slug
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, communityTagId: community_tag.id}
 
       rule_conn |> gq_mutation(Schema.m(:unset_community_tag), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/community_tags/doc_set_tag_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/community_tags/doc_set_tag_test.exs
@@ -26,12 +26,7 @@ defmodule GroupherServer.Test.Mutation.CommunityTags.DocSetTag do
       passport_rules = %{community.title => %{"doc.community_tag.set" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        communityTagId: community_tag.id,
-        community: community.slug
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, communityTagId: community_tag.id}
 
       rule_conn |> gq_mutation(Schema.m(:set_community_tag), variables)
       {:ok, found} = ORM.find(Doc, doc.id, preload: :community_tags)
@@ -54,12 +49,7 @@ defmodule GroupherServer.Test.Mutation.CommunityTags.DocSetTag do
       passport_rules = %{community.title => %{"doc.community_tag.unset" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: doc.inner_id,
-        thread: "DOC",
-        communityTagId: community_tag.id,
-        community: community.slug
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, communityTagId: community_tag.id}
 
       rule_conn |> gq_mutation(Schema.m(:unset_community_tag), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/community_tags/post_set_tag_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/community_tags/post_set_tag_test.exs
@@ -25,12 +25,7 @@ defmodule GroupherServer.Test.Mutation.CommunityTags.PostSetTag do
       passport_rules = %{community.title => %{"post.community_tag.set" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: post.inner_id,
-        thread: "POST",
-        communityTagId: community_tag.id,
-        community: community.slug
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, communityTagId: community_tag.id}
 
       rule_conn |> gq_mutation(Schema.m(:set_community_tag), variables)
       {:ok, found} = ORM.find(Post, post.id, preload: :community_tags)
@@ -53,12 +48,7 @@ defmodule GroupherServer.Test.Mutation.CommunityTags.PostSetTag do
       passport_rules = %{community.title => %{"post.community_tag.unset" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{
-        id: post.inner_id,
-        thread: "POST",
-        communityTagId: community_tag.id,
-        community: community.slug
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, communityTagId: community_tag.id}
 
       rule_conn |> gq_mutation(Schema.m(:unset_community_tag), variables)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/flags/blog_flag_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/flags/blog_flag_test.exs
@@ -18,7 +18,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
 
   describe "[mutation blog flag curd]" do
     test "auth user can markDelete blog", ~m(community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       passport_rules = %{"blog.mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -38,7 +38,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
       {:ok, community} = ORM.find(Community, community.id)
       assert community.meta.blogs_count == 1
 
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       passport_rules = %{"blog.mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -50,7 +50,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
 
     test "unauth user markDelete blog fails",
          ~m(user_conn guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       schema = Schema.m(:mark_delete_article, :blog)
@@ -61,7 +61,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
     end
 
     test "auth user can undo markDelete blog", ~m(community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       {:ok, _} = CMS.Articles.mark_delete(blog)
 
@@ -85,7 +85,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
       {:ok, community} = ORM.find(Community, community.id)
       assert community.meta.blogs_count == 0
 
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       passport_rules = %{"blog.undo_mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
       rule_conn |> gq_mutation(Schema.m(:undo_mark_delete_article, :blog), variables)
@@ -96,7 +96,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
 
     test "unauth user undo markDelete blog fails",
          ~m(user_conn guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       schema = Schema.m(:undo_mark_delete_article, :blog)
@@ -158,7 +158,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
     end
 
     test "auth user can pin blog", ~m(community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"blog.pin" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -169,7 +169,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
     end
 
     test "unauth user pin blog fails", ~m(user_conn guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       assert user_conn
@@ -187,7 +187,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
     end
 
     test "auth user can undo pin blog", ~m(community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"blog.undo_pin" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -199,7 +199,7 @@ defmodule GroupherServer.Test.Mutation.Flags.BlogFlag do
     end
 
     test "unauth user undo pin blog fails", ~m(user_conn guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       assert user_conn

--- a/backend/main/test/groupher_server_web/mutation/cms/flags/changelog_flag_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/flags/changelog_flag_test.exs
@@ -18,7 +18,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
 
   describe "[mutation changelog flag curd]" do
     test "auth user can markDelete changelog", ~m(community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       passport_rules = %{"changelog.mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -38,7 +38,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
       {:ok, community} = ORM.find(Community, community.id)
       assert community.meta.changelogs_count == 1
 
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       passport_rules = %{"changelog.mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -50,7 +50,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
 
     test "unauth user markDelete changelog fails",
          ~m(user_conn guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       schema = Schema.m(:mark_delete_article, :changelog)
@@ -61,7 +61,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
     end
 
     test "auth user can undo markDelete changelog", ~m(community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       {:ok, _} = CMS.Articles.mark_delete(changelog)
 
@@ -86,7 +86,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
       {:ok, community} = ORM.find(Community, community.id)
       assert community.meta.changelogs_count == 0
 
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       passport_rules = %{"changelog.undo_mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
       rule_conn |> gq_mutation(Schema.m(:undo_mark_delete_article, :changelog), variables)
@@ -97,7 +97,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
 
     test "unauth user undo markDelete changelog fails",
          ~m(user_conn guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       schema = Schema.m(:undo_mark_delete_article, :changelog)
@@ -161,7 +161,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
     end
 
     test "auth user can pin changelog", ~m(community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"changelog.pin" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -172,7 +172,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
     end
 
     test "unauth user pin changelog fails", ~m(user_conn guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       assert user_conn
@@ -190,7 +190,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
     end
 
     test "auth user can undo pin changelog", ~m(community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"changelog.undo_pin" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -202,7 +202,7 @@ defmodule GroupherServer.Test.Mutation.Flags.ChangelogFlag do
     end
 
     test "unauth user undo pin changelog fails", ~m(user_conn guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       assert user_conn

--- a/backend/main/test/groupher_server_web/mutation/cms/flags/doc_flag_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/flags/doc_flag_test.exs
@@ -18,7 +18,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
 
   describe "[mutation doc flag curd]" do
     test "auth user can markDelete doc", ~m(community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       passport_rules = %{"doc.mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -38,7 +38,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
       {:ok, community} = ORM.find(Community, community.id)
       assert community.meta.docs_count == 1
 
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       passport_rules = %{"doc.mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -50,7 +50,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
 
     test "unauth user markDelete doc fails",
          ~m(user_conn guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       schema = Schema.m(:mark_delete_article, :doc)
@@ -61,7 +61,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
     end
 
     test "auth user can undo markDelete doc", ~m(community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       {:ok, _} = CMS.Articles.mark_delete(doc)
 
@@ -85,7 +85,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
       {:ok, community} = ORM.find(Community, community.id)
       assert community.meta.docs_count == 0
 
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       passport_rules = %{"doc.undo_mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
       rule_conn |> gq_mutation(Schema.m(:undo_mark_delete_article, :doc), variables)
@@ -96,7 +96,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
 
     test "unauth user undo markDelete doc fails",
          ~m(user_conn guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       schema = Schema.m(:undo_mark_delete_article, :doc)
@@ -158,7 +158,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
     end
 
     test "auth user can pin doc", ~m(community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"doc.pin" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -169,7 +169,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
     end
 
     test "unauth user pin doc fails", ~m(user_conn guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       assert user_conn
@@ -187,7 +187,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
     end
 
     test "auth user can undo pin doc", ~m(community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"doc.undo_pin" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -199,7 +199,7 @@ defmodule GroupherServer.Test.Mutation.Flags.DocFlag do
     end
 
     test "unauth user undo pin doc fails", ~m(user_conn guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       assert user_conn

--- a/backend/main/test/groupher_server_web/mutation/cms/flags/post_flag_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/flags/post_flag_test.exs
@@ -18,7 +18,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
 
   describe "[mutation post flag curd]" do
     test "auth user can markDelete post", ~m(community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       passport_rules = %{"post.mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -38,7 +38,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
       {:ok, community} = ORM.find(Community, community.id)
       assert community.meta.posts_count == 1
 
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       passport_rules = %{"post.mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -50,7 +50,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
 
     test "unauth user markDelete post fails",
          ~m(user_conn guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       schema = Schema.m(:mark_delete_article, :post)
@@ -61,7 +61,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
     end
 
     test "auth user can undo markDelete post", ~m(community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       {:ok, _} = CMS.Articles.mark_delete(post)
 
@@ -85,7 +85,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
       {:ok, community} = ORM.find(Community, community.id)
       assert community.meta.posts_count == 0
 
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       passport_rules = %{"post.undo_mark_delete" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
       rule_conn |> gq_mutation(Schema.m(:undo_mark_delete_article, :post), variables)
@@ -96,7 +96,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
 
     test "unauth user undo markDelete post fails",
          ~m(user_conn guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       schema = Schema.m(:undo_mark_delete_article, :post)
@@ -158,7 +158,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
     end
 
     test "auth user can pin post", ~m(community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"post.pin" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -169,7 +169,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
     end
 
     test "unauth user pin post fails", ~m(user_conn guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       assert user_conn
@@ -187,7 +187,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
     end
 
     test "auth user can undo pin post", ~m(community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"post.undo_pin" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -199,7 +199,7 @@ defmodule GroupherServer.Test.Mutation.Flags.PostFlag do
     end
 
     test "unauth user undo pin post fails", ~m(user_conn guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})
 
       assert user_conn

--- a/backend/main/test/groupher_server_web/mutation/cms/manager_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/manager_test.exs
@@ -17,7 +17,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Manager do
 
   describe "root mutation" do
     test "root can markDelete a post", ~m(community post)a do
-      variables = %{community: community.slug, id: post.inner_id}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       passport_rules = %{"root" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -32,7 +32,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Manager do
       passport_rules = %{"root" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      variables = %{community: community.slug, id: post.inner_id}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       deleted = rule_conn |> gq_mutation(Schema.m(:delete_article, :post), variables)
 
       assert deleted["innerId"] == to_string(post.inner_id)

--- a/backend/main/test/groupher_server_web/mutation/cms/sink/blog_sink_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/sink/blog_sink_test.exs
@@ -13,7 +13,7 @@ defmodule GroupherServer.Test.Mutation.Sink.BlogSink do
 
   describe "[blog sink]" do
     test "login user can sink a blog", ~m(community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"blog.sink" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -26,7 +26,7 @@ defmodule GroupherServer.Test.Mutation.Sink.BlogSink do
     end
 
     test "unauth user sink a blog fails", ~m(guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -37,7 +37,7 @@ defmodule GroupherServer.Test.Mutation.Sink.BlogSink do
     end
 
     test "login user can undo sink to a blog", ~m(community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"blog.undo_sink" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -53,7 +53,7 @@ defmodule GroupherServer.Test.Mutation.Sink.BlogSink do
     end
 
     test "unauth user undo sink a blog fails", ~m(guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/sink/changelog_sink_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/sink/changelog_sink_test.exs
@@ -13,7 +13,7 @@ defmodule GroupherServer.Test.Mutation.Sink.ChangelogSink do
 
   describe "[changelog sink]" do
     test "login user can sink a changelog", ~m(community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"changelog.sink" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -27,7 +27,7 @@ defmodule GroupherServer.Test.Mutation.Sink.ChangelogSink do
     end
 
     test "unauth user sink a changelog fails", ~m(guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -38,7 +38,7 @@ defmodule GroupherServer.Test.Mutation.Sink.ChangelogSink do
     end
 
     test "login user can undo sink to a changelog", ~m(community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"changelog.undo_sink" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -54,7 +54,7 @@ defmodule GroupherServer.Test.Mutation.Sink.ChangelogSink do
     end
 
     test "unauth user undo sink a changelog fails", ~m(guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/sink/doc_sink_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/sink/doc_sink_test.exs
@@ -13,7 +13,7 @@ defmodule GroupherServer.Test.Mutation.Sink.DocSink do
 
   describe "[doc sink]" do
     test "login user can sink a doc", ~m(community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"doc.sink" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -26,7 +26,7 @@ defmodule GroupherServer.Test.Mutation.Sink.DocSink do
     end
 
     test "unauth user sink a doc fails", ~m(guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -37,7 +37,7 @@ defmodule GroupherServer.Test.Mutation.Sink.DocSink do
     end
 
     test "login user can undo sink to a doc", ~m(community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"doc.undo_sink" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -53,7 +53,7 @@ defmodule GroupherServer.Test.Mutation.Sink.DocSink do
     end
 
     test "unauth user undo sink a doc fails", ~m(guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/sink/post_sink_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/sink/post_sink_test.exs
@@ -13,7 +13,7 @@ defmodule GroupherServer.Test.Mutation.Sink.PostSink do
 
   describe "[post sink]" do
     test "login user can sink a post", ~m(community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
       passport_rules = %{community.slug => %{"post.sink" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
@@ -26,7 +26,7 @@ defmodule GroupherServer.Test.Mutation.Sink.PostSink do
     end
 
     test "unauth user sink a post fails", ~m(guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -37,7 +37,7 @@ defmodule GroupherServer.Test.Mutation.Sink.PostSink do
     end
 
     test "login user can undo sink to a post", ~m(community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       passport_rules = %{community.slug => %{"post.undo_sink" => true}}
       rule_conn = simu_conn(:user, cms: passport_rules)
@@ -52,7 +52,7 @@ defmodule GroupherServer.Test.Mutation.Sink.PostSink do
     end
 
     test "unauth user undo sink a post fails", ~m(guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/upvotes/blog_upvote_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/upvotes/blog_upvote_test.exs
@@ -13,7 +13,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.BlogUpvote do
 
   describe "[blog upvote]" do
     test "login user can upvote a blog", ~m(user_conn community blog user)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       created = user_conn |> gq_mutation(Schema.m(:upvote_article, :blog), variables)
 
@@ -22,7 +22,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.BlogUpvote do
     end
 
     test "unauth user upvote a blog fails", ~m(guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -35,7 +35,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.BlogUpvote do
     test "login user can undo upvote to a blog", ~m(user_conn community blog user)a do
       {:ok, _} = CMS.Articles.upvote(blog, user)
 
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       updated = user_conn |> gq_mutation(Schema.m(:undo_upvote_article, :blog), variables)
 
@@ -44,7 +44,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.BlogUpvote do
     end
 
     test "unauth user undo upvote a blog fails", ~m(guest_conn community blog)a do
-      variables = %{id: blog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/upvotes/changelog_upvote_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/upvotes/changelog_upvote_test.exs
@@ -13,7 +13,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.ChangelogUpvote do
 
   describe "[changelog upvote]" do
     test "login user can upvote a changelog", ~m(user_conn community changelog user)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       created = user_conn |> gq_mutation(Schema.m(:upvote_article, :changelog), variables)
 
@@ -22,7 +22,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.ChangelogUpvote do
     end
 
     test "unauth user upvote a changelog fails", ~m(guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -35,7 +35,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.ChangelogUpvote do
     test "login user can undo upvote to a changelog", ~m(user_conn community changelog user)a do
       {:ok, _} = CMS.Articles.upvote(changelog, user)
 
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       updated =
         user_conn |> gq_mutation(Schema.m(:undo_upvote_article, :changelog), variables)
@@ -45,7 +45,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.ChangelogUpvote do
     end
 
     test "unauth user undo upvote a changelog fails", ~m(guest_conn community changelog)a do
-      variables = %{id: changelog.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/upvotes/doc_upvote_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/upvotes/doc_upvote_test.exs
@@ -13,7 +13,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.DocUpvote do
 
   describe "[doc upvote]" do
     test "login user can upvote a doc", ~m(user_conn community doc user)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       created = user_conn |> gq_mutation(Schema.m(:upvote_article, :doc), variables)
 
@@ -22,7 +22,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.DocUpvote do
     end
 
     test "unauth user upvote a doc fails", ~m(guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -35,7 +35,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.DocUpvote do
     test "login user can undo upvote to a doc", ~m(user_conn community doc user)a do
       {:ok, _} = CMS.Articles.upvote(doc, user)
 
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       updated = user_conn |> gq_mutation(Schema.m(:undo_upvote_article, :doc), variables)
 
@@ -44,7 +44,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.DocUpvote do
     end
 
     test "unauth user undo upvote a doc fails", ~m(guest_conn community doc)a do
-      variables = %{id: doc.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/mutation/cms/upvotes/post_upvote_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/upvotes/post_upvote_test.exs
@@ -14,7 +14,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.PostUpvote do
 
   describe "[post upvote]" do
     test "tmp login user can upvote a post", ~m(user_conn user2_conn community post user)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       _created = user_conn |> gq_mutation(Schema.m(:upvote_article, :post), variables)
       created = user2_conn |> gq_mutation(Schema.m(:upvote_article, :post), variables)
@@ -25,7 +25,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.PostUpvote do
     end
 
     test "login user can upvote a post", ~m(user_conn user2_conn community post user)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       _created = user_conn |> gq_mutation(Schema.m(:upvote_article, :post), variables)
       created = user2_conn |> gq_mutation(Schema.m(:upvote_article, :post), variables)
@@ -37,7 +37,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.PostUpvote do
     end
 
     test "unauth user upvote a post fails", ~m(guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(
@@ -50,7 +50,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.PostUpvote do
     test "login user can undo upvote to a post", ~m(user_conn community post user)a do
       {:ok, _} = CMS.Articles.upvote(post, user)
 
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       updated = user_conn |> gq_mutation(Schema.m(:undo_upvote_article, :post), variables)
 
@@ -59,7 +59,7 @@ defmodule GroupherServer.Test.Mutation.Upvotes.PostUpvote do
     end
 
     test "unauth user undo upvote a post fails", ~m(guest_conn community post)a do
-      variables = %{id: post.inner_id, community: community.slug}
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug}}
 
       assert guest_conn
              |> mutation_error?(

--- a/backend/main/test/groupher_server_web/query/cms/articles/collects/blog_collect_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/collects/blog_collect_test.exs
@@ -20,12 +20,7 @@ defmodule GroupherServer.Test.Query.Collects.BlogCollect do
       {:ok, _} = CMS.Articles.collect(blog, user)
       {:ok, _} = CMS.Articles.collect(blog, user2)
 
-      variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        thread: "BLOG",
-        filter: %{page: 1, size: 20}
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, filter: %{page: 1, size: 20}}
 
       results =
         guest_conn |> gq_query(Schema.q(:collected_users), variables)

--- a/backend/main/test/groupher_server_web/query/cms/articles/collects/changelog_collect_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/collects/changelog_collect_test.exs
@@ -20,12 +20,7 @@ defmodule GroupherServer.Test.Query.Collects.ChangelogCollect do
       {:ok, _} = CMS.Articles.collect(changelog, user)
       {:ok, _} = CMS.Articles.collect(changelog, user2)
 
-      variables = %{
-        id: changelog.inner_id,
-        community: community.slug,
-        thread: "CHANGELOG",
-        filter: %{page: 1, size: 20}
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, filter: %{page: 1, size: 20}}
 
       results =
         guest_conn |> gq_query(Schema.q(:collected_users), variables)

--- a/backend/main/test/groupher_server_web/query/cms/articles/collects/doc_collect_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/collects/doc_collect_test.exs
@@ -19,12 +19,7 @@ defmodule GroupherServer.Test.Query.Collects.DocCollect do
       {:ok, _} = CMS.Articles.collect(doc, user)
       {:ok, _} = CMS.Articles.collect(doc, user2)
 
-      variables = %{
-        id: doc.inner_id,
-        community: community.slug,
-        thread: "DOC",
-        filter: %{page: 1, size: 20}
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, filter: %{page: 1, size: 20}}
 
       results =
         guest_conn |> gq_query(Schema.q(:collected_users), variables)

--- a/backend/main/test/groupher_server_web/query/cms/articles/collects/post_collect_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/collects/post_collect_test.exs
@@ -20,12 +20,7 @@ defmodule GroupherServer.Test.Query.Collects.PostCollect do
       {:ok, _} = CMS.Articles.collect(post, user)
       {:ok, _} = CMS.Articles.collect(post, user2)
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        thread: "POST",
-        filter: %{page: 1, size: 20}
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, filter: %{page: 1, size: 20}}
 
       results =
         guest_conn |> gq_query(Schema.q(:collected_users), variables)

--- a/backend/main/test/groupher_server_web/query/cms/articles/list/kanban_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/list/kanban_test.exs
@@ -22,7 +22,7 @@ defmodule GroupherServer.Test.Query.Articles.Kanban do
 
     {:ok, post} = CMS.Articles.create(community, :post, kanban_attrs, user)
 
-    variables = %{community: post.community_slug, id: post.inner_id}
+    variables = %{article: %{inner_id: post.inner_id, community: post.community_slug}}
     result = user_conn |> gq_query(Schema.q(:article, :post, "cat state"), variables)
 
     assert result["innerId"] == to_string(post.inner_id)

--- a/backend/main/test/groupher_server_web/query/cms/articles/read/blog_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/read/blog_test.exs
@@ -16,7 +16,7 @@ defmodule GroupherServer.Test.Query.Articles.Blog do
        ~m(user_conn community user blog_attrs)a do
     {:ok, blog} = CMS.Articles.create(community, :blog, blog_attrs, user)
 
-    variables = %{community: blog.community_slug, id: blog.inner_id}
+    variables = %{article: %{inner_id: blog.inner_id, community: blog.community_slug}}
     results = user_conn |> gq_query(Schema.q(:article, :blog), variables)
 
     assert results["innerId"] == to_string(blog.inner_id)
@@ -36,7 +36,7 @@ defmodule GroupherServer.Test.Query.Articles.Blog do
        ~m(guest_conn community blog_attrs user)a do
     {:ok, blog} = CMS.Articles.create(community, :blog, blog_attrs, user)
 
-    variables = %{community: blog.community_slug, id: blog.inner_id}
+    variables = %{article: %{inner_id: blog.inner_id, community: blog.community_slug}}
     results = guest_conn |> gq_query(Schema.q(:article, :blog), variables)
 
     assert results["innerId"] == to_string(blog.inner_id)
@@ -45,7 +45,7 @@ defmodule GroupherServer.Test.Query.Articles.Blog do
 
   test "pending state should in meta", ~m(guest_conn user_conn community user blog_attrs)a do
     {:ok, blog} = CMS.Articles.create(community, :blog, blog_attrs, user)
-    variables = %{community: blog.community_slug, id: blog.inner_id}
+    variables = %{article: %{inner_id: blog.inner_id, community: blog.community_slug}}
     results = user_conn |> gq_query(Schema.q(:article, :blog), variables)
 
     assert results |> get_in(["meta", "isLegal"])

--- a/backend/main/test/groupher_server_web/query/cms/articles/read/changelog_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/read/changelog_test.exs
@@ -16,7 +16,7 @@ defmodule GroupherServer.Test.Query.Articles.Changelog do
        ~m(user_conn community user changelog_attrs)a do
     {:ok, changelog} = CMS.Articles.create(community, :changelog, changelog_attrs, user)
 
-    variables = %{community: changelog.community_slug, id: changelog.inner_id}
+    variables = %{article: %{inner_id: changelog.inner_id, community: changelog.community_slug}}
     results = user_conn |> gq_query(Schema.q(:article, :changelog), variables)
 
     assert results["innerId"] == to_string(changelog.inner_id)
@@ -36,7 +36,7 @@ defmodule GroupherServer.Test.Query.Articles.Changelog do
        ~m(guest_conn community changelog_attrs user)a do
     {:ok, changelog} = CMS.Articles.create(community, :changelog, changelog_attrs, user)
 
-    variables = %{community: changelog.community_slug, id: changelog.inner_id}
+    variables = %{article: %{inner_id: changelog.inner_id, community: changelog.community_slug}}
     results = guest_conn |> gq_query(Schema.q(:article, :changelog), variables)
 
     assert results["innerId"] == to_string(changelog.inner_id)
@@ -45,7 +45,7 @@ defmodule GroupherServer.Test.Query.Articles.Changelog do
 
   test "pending state should in meta", ~m(guest_conn user_conn community user changelog_attrs)a do
     {:ok, changelog} = CMS.Articles.create(community, :changelog, changelog_attrs, user)
-    variables = %{community: changelog.community_slug, id: changelog.inner_id}
+    variables = %{article: %{inner_id: changelog.inner_id, community: changelog.community_slug}}
     results = user_conn |> gq_query(Schema.q(:article, :changelog), variables)
 
     assert results |> get_in(["meta", "isLegal"])

--- a/backend/main/test/groupher_server_web/query/cms/articles/read/doc_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/read/doc_test.exs
@@ -16,7 +16,7 @@ defmodule GroupherServer.Test.Query.Articles.Doc do
        ~m(user_conn community user doc_attrs)a do
     {:ok, doc} = CMS.Articles.create(community, :doc, doc_attrs, user)
 
-    variables = %{community: doc.community_slug, id: doc.inner_id}
+    variables = %{article: %{inner_id: doc.inner_id, community: doc.community_slug}}
     results = user_conn |> gq_query(Schema.q(:article, :doc), variables)
 
     assert results["innerId"] == to_string(doc.inner_id)
@@ -36,7 +36,7 @@ defmodule GroupherServer.Test.Query.Articles.Doc do
        ~m(guest_conn community doc_attrs user)a do
     {:ok, doc} = CMS.Articles.create(community, :doc, doc_attrs, user)
 
-    variables = %{community: doc.community_slug, id: doc.inner_id}
+    variables = %{article: %{inner_id: doc.inner_id, community: doc.community_slug}}
     results = guest_conn |> gq_query(Schema.q(:article, :doc), variables)
 
     assert results["innerId"] == to_string(doc.inner_id)
@@ -45,7 +45,7 @@ defmodule GroupherServer.Test.Query.Articles.Doc do
 
   test "pending state should in meta", ~m(guest_conn user_conn community user doc_attrs)a do
     {:ok, doc} = CMS.Articles.create(community, :doc, doc_attrs, user)
-    variables = %{community: doc.community_slug, id: doc.inner_id}
+    variables = %{article: %{inner_id: doc.inner_id, community: doc.community_slug}}
     results = user_conn |> gq_query(Schema.q(:article, :doc), variables)
 
     assert results |> get_in(["meta", "isLegal"])

--- a/backend/main/test/groupher_server_web/query/cms/articles/read/post_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/read/post_test.exs
@@ -16,7 +16,7 @@ defmodule GroupherServer.Test.Query.Articles.Post do
        ~m(user_conn community user post_attrs)a do
     {:ok, post} = CMS.Articles.create(community, :post, post_attrs, user)
 
-    variables = %{community: post.community_slug, id: post.inner_id}
+    variables = %{article: %{inner_id: post.inner_id, community: post.community_slug}}
     results = user_conn |> gq_query(Schema.q(:article, :post), variables)
 
     assert results["innerId"] == to_string(post.inner_id)
@@ -36,7 +36,7 @@ defmodule GroupherServer.Test.Query.Articles.Post do
        ~m(guest_conn community post_attrs user)a do
     {:ok, post} = CMS.Articles.create(community, :post, post_attrs, user)
 
-    variables = %{community: post.community_slug, id: post.inner_id}
+    variables = %{article: %{inner_id: post.inner_id, community: post.community_slug}}
     results = guest_conn |> gq_query(Schema.q(:article, :post), variables)
 
     assert results["innerId"] == to_string(post.inner_id)
@@ -45,7 +45,7 @@ defmodule GroupherServer.Test.Query.Articles.Post do
 
   test "pending state should in meta", ~m(guest_conn user_conn community user post_attrs)a do
     {:ok, post} = CMS.Articles.create(community, :post, post_attrs, user)
-    variables = %{community: post.community_slug, id: post.inner_id}
+    variables = %{article: %{inner_id: post.inner_id, community: post.community_slug}}
     results = user_conn |> gq_query(Schema.q(:article, :post), variables)
 
     assert results |> get_in(["meta", "isLegal"])

--- a/backend/main/test/groupher_server_web/query/cms/articles/upvotes/blog_upvote_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/upvotes/blog_upvote_test.exs
@@ -18,12 +18,7 @@ defmodule GroupherServer.Test.Query.Upvotes.BlogUpvote do
       {:ok, _} = CMS.Articles.upvote(blog, user)
       {:ok, _} = CMS.Articles.upvote(blog, user2)
 
-      variables = %{
-        id: blog.inner_id,
-        community: community.slug,
-        thread: "BLOG",
-        filter: %{page: 1, size: 20}
-      }
+      variables = %{article: %{inner_id: blog.inner_id, community: community.slug, thread: "BLOG"}, filter: %{page: 1, size: 20}}
 
       results = guest_conn |> gq_query(Schema.q(:upvoted_users), variables)
 

--- a/backend/main/test/groupher_server_web/query/cms/articles/upvotes/changelog_upvote_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/upvotes/changelog_upvote_test.exs
@@ -18,12 +18,7 @@ defmodule GroupherServer.Test.Query.Upvotes.ChangelogUpvote do
       {:ok, _} = CMS.Articles.upvote(changelog, user)
       {:ok, _} = CMS.Articles.upvote(changelog, user2)
 
-      variables = %{
-        id: changelog.inner_id,
-        community: community.slug,
-        thread: "CHANGELOG",
-        filter: %{page: 1, size: 20}
-      }
+      variables = %{article: %{inner_id: changelog.inner_id, community: community.slug, thread: "CHANGELOG"}, filter: %{page: 1, size: 20}}
 
       results = guest_conn |> gq_query(Schema.q(:upvoted_users), variables)
 

--- a/backend/main/test/groupher_server_web/query/cms/articles/upvotes/doc_upvote_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/upvotes/doc_upvote_test.exs
@@ -18,12 +18,7 @@ defmodule GroupherServer.Test.Query.Upvotes.DocUpvote do
       {:ok, _} = CMS.Articles.upvote(doc, user)
       {:ok, _} = CMS.Articles.upvote(doc, user2)
 
-      variables = %{
-        id: doc.inner_id,
-        community: community.slug,
-        thread: "DOC",
-        filter: %{page: 1, size: 20}
-      }
+      variables = %{article: %{inner_id: doc.inner_id, community: community.slug, thread: "DOC"}, filter: %{page: 1, size: 20}}
 
       results = guest_conn |> gq_query(Schema.q(:upvoted_users), variables)
 

--- a/backend/main/test/groupher_server_web/query/cms/articles/upvotes/post_upvote_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/upvotes/post_upvote_test.exs
@@ -18,12 +18,7 @@ defmodule GroupherServer.Test.Query.Upvotes.PostUpvote do
       {:ok, _} = CMS.Articles.upvote(post, user)
       {:ok, _} = CMS.Articles.upvote(post, user2)
 
-      variables = %{
-        id: post.inner_id,
-        community: community.slug,
-        thread: "POST",
-        filter: %{page: 1, size: 20}
-      }
+      variables = %{article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"}, filter: %{page: 1, size: 20}}
 
       results = guest_conn |> gq_query(Schema.q(:upvoted_users), variables)
 

--- a/backend/main/test/groupher_server_web/query/cms/comments/blog_comment_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/comments/blog_comment_test.exs
@@ -97,7 +97,7 @@ defmodule GroupherServer.Test.Query.Comments.BlogComment do
       {:ok, _} =
         CMS.Comments.create_comment(community, thread, blog.inner_id, mock_comment(), user)
 
-      variables = %{community: blog.community_slug, id: blog.inner_id}
+      variables = %{article: %{inner_id: blog.inner_id, community: blog.community_slug}}
       results = guest_conn |> gq_query(Schema.q(:article, :blog), variables)
 
       assert not results["isArchived"]
@@ -118,7 +118,7 @@ defmodule GroupherServer.Test.Query.Comments.BlogComment do
       {:ok, _} =
         CMS.Comments.create_comment(community, thread, blog.inner_id, mock_comment(), user2)
 
-      variables = %{community: blog.community_slug, id: blog.inner_id}
+      variables = %{article: %{inner_id: blog.inner_id, community: blog.community_slug}}
       results = guest_conn |> gq_query(Schema.q(:article, :blog), variables)
 
       comments_participants = results["commentsParticipants"]

--- a/backend/main/test/groupher_server_web/query/cms/comments/changelog_comment_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/comments/changelog_comment_test.exs
@@ -97,7 +97,7 @@ defmodule GroupherServer.Test.Query.Comments.ChangelogComment do
       {:ok, _} =
         CMS.Comments.create_comment(community, thread, changelog.inner_id, mock_comment(), user)
 
-      variables = %{community: changelog.community_slug, id: changelog.inner_id}
+      variables = %{article: %{inner_id: changelog.inner_id, community: changelog.community_slug}}
       results = guest_conn |> gq_query(Schema.q(:article, :changelog), variables)
 
       assert not results["isArchived"]
@@ -118,7 +118,7 @@ defmodule GroupherServer.Test.Query.Comments.ChangelogComment do
       {:ok, _} =
         CMS.Comments.create_comment(community, thread, changelog.inner_id, mock_comment(), user2)
 
-      variables = %{community: changelog.community_slug, id: changelog.inner_id}
+      variables = %{article: %{inner_id: changelog.inner_id, community: changelog.community_slug}}
       results = guest_conn |> gq_query(Schema.q(:article, :changelog), variables)
 
       comments_participants = results["commentsParticipants"]

--- a/backend/main/test/groupher_server_web/query/cms/comments/doc_comment_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/comments/doc_comment_test.exs
@@ -98,7 +98,7 @@ defmodule GroupherServer.Test.Query.Comments.DocComment do
       {:ok, _} =
         CMS.Comments.create_comment(community, thread, doc.inner_id, mock_comment(), user)
 
-      variables = %{community: doc.community_slug, id: doc.inner_id}
+      variables = %{article: %{inner_id: doc.inner_id, community: doc.community_slug}}
       results = guest_conn |> gq_query(Schema.q(:article, :doc), variables)
 
       assert not results["isArchived"]
@@ -119,7 +119,7 @@ defmodule GroupherServer.Test.Query.Comments.DocComment do
       {:ok, _} =
         CMS.Comments.create_comment(community, thread, doc.inner_id, mock_comment(), user2)
 
-      variables = %{community: doc.community_slug, id: doc.inner_id}
+      variables = %{article: %{inner_id: doc.inner_id, community: doc.community_slug}}
       results = guest_conn |> gq_query(Schema.q(:article, :doc), variables)
 
       comments_participants = results["commentsParticipants"]

--- a/backend/main/test/groupher_server_web/query/cms/comments/post_comment_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/comments/post_comment_test.exs
@@ -96,7 +96,7 @@ defmodule GroupherServer.Test.Query.Comments.PostComment do
       thread = :post
       {:ok, _} = CMS.Comments.create_comment(community, thread, post.inner_id, mock_comment(), user)
 
-      variables = %{community: post.community_slug, id: post.inner_id}
+      variables = %{article: %{inner_id: post.inner_id, community: post.community_slug}}
       results = guest_conn |> gq_query(Schema.q(:article, :post), variables)
 
       assert not results["isArchived"]
@@ -116,7 +116,7 @@ defmodule GroupherServer.Test.Query.Comments.PostComment do
 
       {:ok, _} = CMS.Comments.create_comment(community, thread, post.inner_id, mock_comment(), user2)
 
-      variables = %{community: post.community_slug, id: post.inner_id}
+      variables = %{article: %{inner_id: post.inner_id, community: post.community_slug}}
       results = guest_conn |> gq_query(Schema.q(:article, :post), variables)
 
       comments_participants = results["commentsParticipants"]

--- a/backend/main/test/helper/schema.ex
+++ b/backend/main/test/helper/schema.ex
@@ -5,8 +5,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def q(:article, thread, extra) do
     """
-    query($community: String!, $id: ID!) {
-      #{thread}(community: $community, id: $id) {
+    query($article: ArticleRefInput!) {
+      #{thread}(article: $article) {
         title
         innerId
         communitySlug
@@ -182,13 +182,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def q(:upvoted_users) do
     """
-    query(
-      $id: ID!
-      $community: String!
-      $thread: Thread
-      $filter: PagiFilter!
-    ) {
-      upvotedUsers(id: $id, community: $community, thread: $thread, filter: $filter) {
+    query($article: ArticleRefInput!, $filter: PagiFilter!) {
+      upvotedUsers(article: $article, filter: $filter) {
         entries {
           login
           avatar
@@ -205,13 +200,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def q(:collected_users) do
     """
-    query(
-      $id: ID!
-      $community: String!
-      $thread: Thread
-      $filter: PagiFilter!
-    ) {
-      collectedUsers(id: $id, community: $community, thread: $thread, filter: $filter) {
+    query($article: ArticleRefInput!, $filter: PagiFilter!) {
+      collectedUsers(article: $article, filter: $filter) {
         entries {
           login
           avatar
@@ -228,8 +218,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:pin_article, thread) do
     """
-    mutation($id: ID!, $community: String!){
-      pin#{t(thread)}(id: $id, community: $community) {
+    mutation($article: ArticleRefInput!){
+      pin#{t(thread)}(article: $article) {
         innerId
         isPinned
       }
@@ -239,8 +229,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:undo_pin_article, thread) do
     """
-    mutation($id: ID!, $community: String!){
-      undoPin#{t(thread)}(id: $id, community: $community) {
+    mutation($article: ArticleRefInput!){
+      undoPin#{t(thread)}(article: $article) {
         innerId
         isPinned
       }
@@ -250,8 +240,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:emotion_article, thread) do
     """
-    mutation($id: ID!, $community: String!, $emotion: ArticleEmotion!) {
-      emotionTo#{t(thread)}(id: $id, community: $community, emotion: $emotion) {
+    mutation($article: ArticleRefInput!, $emotion: ArticleEmotion!) {
+      emotionTo#{t(thread)}(article: $article, emotion: $emotion) {
         innerId
         emotions {
           beerCount
@@ -268,8 +258,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:undo_emotion_article, thread) do
     """
-    mutation($id: ID!, $community: String!, $emotion: ArticleEmotion!) {
-      undoEmotionTo#{t(thread)}(id: $id, community: $community, emotion: $emotion) {
+    mutation($article: ArticleRefInput!, $emotion: ArticleEmotion!) {
+      undoEmotionTo#{t(thread)}(article: $article, emotion: $emotion) {
         innerId
         emotions {
           beerCount
@@ -316,8 +306,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:mark_delete_article, thread) do
     """
-    mutation($community: String!, $id: ID!){
-      markDelete#{t(thread)}(community: $community, id: $id) {
+    mutation($article: ArticleRefInput!){
+      markDelete#{t(thread)}(article: $article) {
         innerId
         markDelete
       }
@@ -327,8 +317,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:undo_mark_delete_article, thread) do
     """
-    mutation($community: String!, $id: ID!){
-      undoMarkDelete#{t(thread)}(community: $community, id: $id) {
+    mutation($article: ArticleRefInput!){
+      undoMarkDelete#{t(thread)}(article: $article) {
         innerId
         markDelete
       }
@@ -358,8 +348,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:delete_article, thread) do
     """
-    mutation($community: String!, $id: ID!){
-      delete#{t(thread)}(community: $community, id: $id) {
+    mutation($article: ArticleRefInput!){
+      delete#{t(thread)}(article: $article) {
         innerId
       }
     }
@@ -368,8 +358,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:update_article, thread) do
     """
-    mutation($id: ID!, $community: String!, $title: String, $body: String, $copyRight: String, $communityTags: [ID]){
-      update#{t(thread)}(id: $id, community: $community, title: $title, body: $body, copyRight: $copyRight, communityTags: $communityTags) {
+    mutation($article: ArticleRefInput!, $title: String, $body: String, $copyRight: String, $communityTags: [ID]){
+      update#{t(thread)}(article: $article, title: $title, body: $body, copyRight: $copyRight, communityTags: $communityTags) {
         innerId
         title
         document {
@@ -393,8 +383,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:upvote_article, thread) do
     """
-    mutation($id: ID!, $community: String!) {
-      upvote#{t(thread)}(id: $id, community: $community) {
+    mutation($article: ArticleRefInput!) {
+      upvote#{t(thread)}(article: $article) {
         innerId
         meta {
           latestUpvotedUsers {
@@ -409,8 +399,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:undo_upvote_article, thread) do
     """
-    mutation($id: ID!, $community: String!) {
-      undoUpvote#{t(thread)}(id: $id, community: $community) {
+    mutation($article: ArticleRefInput!) {
+      undoUpvote#{t(thread)}(article: $article) {
         innerId
         meta {
           latestUpvotedUsers {
@@ -424,8 +414,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:sink_article, thread) do
     """
-    mutation($id: ID!, $community: String!){
-      sink#{t(thread)}(id: $id, community: $community) {
+    mutation($article: ArticleRefInput!){
+      sink#{t(thread)}(article: $article) {
         innerId
       }
     }
@@ -434,8 +424,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:undo_sink_article, thread) do
     """
-    mutation($id: ID!, $community: String!){
-      undoSink#{t(thread)}(id: $id, community: $community) {
+    mutation($article: ArticleRefInput!){
+      undoSink#{t(thread)}(article: $article) {
         innerId
       }
     }
@@ -444,8 +434,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:lock_comment, thread) do
     """
-    mutation($id: ID!, $community: String!) {
-      lock#{t(thread)}Comment(id: $id, community: $community) {
+    mutation($article: ArticleRefInput!) {
+      lock#{t(thread)}Comment(article: $article) {
         innerId
         title
       }
@@ -455,8 +445,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:unlock_comment, thread) do
     """
-    mutation($id: ID!, $community: String!){
-      undoLock#{t(thread)}Comment(id: $id, community: $community) {
+    mutation($article: ArticleRefInput!){
+      undoLock#{t(thread)}Comment(article: $article) {
         innerId
       }
     }
@@ -465,8 +455,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:report_article, thread) do
     """
-    mutation($id: ID!, $community: String!, $reason: String!, $attr: String) {
-      report#{t(thread)}(id: $id, community: $community, reason: $reason, attr: $attr) {
+    mutation($article: ArticleRefInput!, $reason: String!, $attr: String) {
+      report#{t(thread)}(article: $article, reason: $reason, attr: $attr) {
         innerId
         title
       }
@@ -476,8 +466,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:undo_report_article, thread) do
     """
-    mutation($id: ID!, $community: String!) {
-      undoReport#{t(thread)}(id: $id, community: $community) {
+    mutation($article: ArticleRefInput!) {
+      undoReport#{t(thread)}(article: $article) {
         innerId
         title
       }
@@ -487,8 +477,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:set_community_tag) do
     """
-    mutation($id: ID!, $thread: Thread, $communityTagId: ID!, $community: String!) {
-      setCommunityTag(id: $id, thread: $thread, communityTagId: $communityTagId, community: $community) {
+    mutation($article: ArticleRefInput!, $communityTagId: ID!) {
+      setCommunityTag(article: $article, communityTagId: $communityTagId) {
         innerId
       }
     }
@@ -497,8 +487,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:unset_community_tag) do
     """
-    mutation($id: ID!, $thread: Thread, $communityTagId: ID!, $community: String!) {
-      unsetCommunityTag(id: $id, thread: $thread, communityTagId: $communityTagId, community: $community) {
+    mutation($article: ArticleRefInput!, $communityTagId: ID!) {
+      unsetCommunityTag(article: $article, communityTagId: $communityTagId) {
         innerId
         title
       }
@@ -508,8 +498,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:mirror_article) do
     """
-    mutation($id: ID!, $thread: Thread, $community: String!, $targetCommunity: String!, $communityTags: [ID]) {
-        mirrorArticle(id: $id, thread: $thread, community: $community, targetCommunity: $targetCommunity, communityTags: $communityTags) {
+    mutation($article: ArticleRefInput!, $targetCommunity: String!, $communityTags: [ID]) {
+        mirrorArticle(article: $article, targetCommunity: $targetCommunity, communityTags: $communityTags) {
           innerId
         }
       }
@@ -518,8 +508,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:unmirror_article) do
     """
-    mutation($id: ID!, $thread: Thread, $community: String!, $targetCommunity: String!) {
-      unmirrorArticle(id: $id, thread: $thread, community: $community, targetCommunity: $targetCommunity) {
+    mutation($article: ArticleRefInput!, $targetCommunity: String!) {
+      unmirrorArticle(article: $article, targetCommunity: $targetCommunity) {
         innerId
       }
     }
@@ -528,8 +518,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:mirror_to_home) do
     """
-    mutation($id: ID!, $community: String!, $thread: Thread, $communityTags: [ID]) {
-      mirrorToHome(id: $id, community: $community, thread: $thread, communityTags: $communityTags) {
+    mutation($article: ArticleRefInput!, $communityTags: [ID]) {
+      mirrorToHome(article: $article, communityTags: $communityTags) {
         innerId
       }
     }
@@ -538,8 +528,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:move_article) do
     """
-    mutation($community: String!, $thread: Thread, $targetCommunity: String!, $id: ID!, $communityTags: [ID]) {
-      moveArticle(id: $id, thread: $thread, community: $community, targetCommunity: $targetCommunity, communityTags: $communityTags) {
+    mutation($article: ArticleRefInput!, $targetCommunity: String!, $communityTags: [ID]) {
+      moveArticle(article: $article, targetCommunity: $targetCommunity, communityTags: $communityTags) {
         innerId
       }
     }
@@ -548,8 +538,8 @@ defmodule GroupherServer.Test.Helper.Schema do
 
   def m(:move_to_blackhole) do
     """
-    mutation($community: String!, $thread: Thread, $id: ID!, $communityTags: [ID]) {
-      moveToBlackhole(community: $community, thread: $thread, id: $id, communityTags: $communityTags) {
+    mutation($article: ArticleRefInput!, $communityTags: [ID]) {
+      moveToBlackhole(article: $article, communityTags: $communityTags) {
         innerId
       }
     }

--- a/frontend/core/containers/editor/ArticleEditor/schema.ts
+++ b/frontend/core/containers/editor/ArticleEditor/schema.ts
@@ -7,7 +7,7 @@ const createPost = gql`
     $title: String!
     $body: String!
     $communityId: ID!
-    $communityTags: [Id]
+    $communityTags: [ID]
     $linkAddr: String
     $copyRight: String
   ) {
@@ -34,7 +34,7 @@ const updatePost = gql`
     $body: String
     $linkAddr: String
     $copyRight: String
-    $communityTags: [Id]
+    $communityTags: [ID]
   ) {
     updatePost(
       article: $article
@@ -66,7 +66,7 @@ const createJob = gql`
     $communityId: ID!
     $company: String!
     $companyLink: String
-    $communityTags: [Id]
+    $communityTags: [ID]
   ) {
     createJob(
       title: $title
@@ -92,7 +92,7 @@ const updateJob = gql`
     $company: String!
     $companyLink: String
     $body: String
-    $communityTags: [Ids]
+    $communityTags: [ID]
   ) {
     updateJob(
       id: $id
@@ -124,7 +124,7 @@ const createRadar = gql`
     $body: String
     $linkAddr: String!
     $communityId: ID!
-    $communityTags: [Id]
+    $communityTags: [ID]
   ) {
     createRadar(
       title: $title
@@ -147,7 +147,7 @@ const updateRadar = gql`
     $title: String
     $body: String
     $linkAddr: String
-    $communityTags: [Id]
+    $communityTags: [ID]
   ) {
     updateRadar(
       id: $id

--- a/frontend/core/containers/editor/ArticleEditor/schema.ts
+++ b/frontend/core/containers/editor/ArticleEditor/schema.ts
@@ -29,7 +29,7 @@ const createPost = gql`
 `
 const updatePost = gql`
   mutation (
-    $id: ID!
+    $article: ArticleRefInput!
     $title: String
     $body: String
     $linkAddr: String
@@ -37,7 +37,7 @@ const updatePost = gql`
     $communityTags: [Id]
   ) {
     updatePost(
-      id: $id
+      article: $article
       title: $title
       body: $body
       linkAddr: $linkAddr
@@ -186,8 +186,8 @@ const community = gql`
 `
 
 const post = gql`
-  query post($id: ID!) {
-    post(id: $id) {
+  query post($article: ArticleRefInput!) {
+    post(article: $article) {
       id
       title
       linkAddr

--- a/frontend/core/containers/thread/PostThread/schema.ts
+++ b/frontend/core/containers/thread/PostThread/schema.ts
@@ -12,8 +12,8 @@ const getPagedArticlesSchema = (thread) => {
 const getArticleFreshSchema = () => {
   // TODO: commentParticipants
   return gql`
-    query post($id: ID!, $userHasLogin: Boolean!) {
-      post(id: $id) {
+    query post($article: ArticleRefInput!, $userHasLogin: Boolean!) {
+      post(article: $article) {
         id
         views
         upvotesCount

--- a/frontend/core/containers/viewer/ArticleViewer/useLogic.ts
+++ b/frontend/core/containers/viewer/ArticleViewer/useLogic.ts
@@ -49,7 +49,14 @@ export default (): TRet => {
     // console.log("## load article: ", article)
     // const { communitySlug, innerId, meta } = article
     // const { communitySlug, meta } = article
-    const params = { community, id: innerId, userHasLogin }
+    const params = {
+      article: {
+        innerId,
+        community,
+        thread: thread.toUpperCase(),
+      },
+      userHasLogin,
+    }
 
     setLoading(true)
     // query(S.getArticle(meta.thread), params).then((res) => {

--- a/frontend/core/providers/ssr.ts
+++ b/frontend/core/providers/ssr.ts
@@ -102,8 +102,11 @@ export const getPost = async (community: string, id: string): Promise<TPost | nu
   // cacheLife('minutes')
   // cacheTag(CACHE_TAG.articlesCache(community, THREAD.POST))
   const response = await gqFetch(P.post, {
-    community,
-    id,
+    article: {
+      innerId: id,
+      community,
+      thread: THREAD.POST,
+    },
     userHasLogin: false,
   })
 

--- a/frontend/core/schemas/fragments/base.ts
+++ b/frontend/core/schemas/fragments/base.ts
@@ -286,8 +286,8 @@ export const pagi = `
 export const getUpvote = (thread, withLatestUser = false) => {
   if (withLatestUser) {
     return gql`
-    mutation ($id: ID!, $community: String!) {
-      upvote${titleCase(thread)}(id: $id, $community: $community) {
+    mutation ($article: ArticleRefInput!) {
+      upvote${titleCase(thread)}(article: $article) {
         innerId
         upvotesCount
         meta {
@@ -300,8 +300,8 @@ export const getUpvote = (thread, withLatestUser = false) => {
   `
   }
   return gql`
-    mutation ($id: ID!, $community: String!) {
-      upvote${titleCase(thread)}(id: $id, $community: $community) {
+    mutation ($article: ArticleRefInput!) {
+      upvote${titleCase(thread)}(article: $article) {
         innerId
         upvotesCount
       }
@@ -312,8 +312,8 @@ export const getUpvote = (thread, withLatestUser = false) => {
 export const getUndoUpvote = (thread, withLatestUser = false) => {
   if (withLatestUser) {
     return gql`
-    mutation ($id: ID!, $community: String!) {
-      undoUpvote${titleCase(thread)}(id: $id, $community: $community) {
+    mutation ($article: ArticleRefInput!) {
+      undoUpvote${titleCase(thread)}(article: $article) {
         innerId
         upvotesCount
         meta {
@@ -326,8 +326,8 @@ export const getUndoUpvote = (thread, withLatestUser = false) => {
   `
   }
   return gql`
-    mutation ($id: ID!, $community: String!) {
-      undoUpvote${titleCase(thread)}(id: $id, $community: $community) {
+    mutation ($article: ArticleRefInput!) {
+      undoUpvote${titleCase(thread)}(article: $article) {
         innerId
         upvotesCount
       }

--- a/frontend/core/schemas/pages/changelog.ts
+++ b/frontend/core/schemas/pages/changelog.ts
@@ -1,8 +1,8 @@
 import F from '../fragments'
 
 export const changelog = `
-  query changelog($community: String!, $id: ID!, $userHasLogin: Boolean!) {
-    changelog(community: $community, id: $id) {
+  query changelog($article: ArticleRefInput!, $userHasLogin: Boolean!) {
+    changelog(article: $article) {
       ${F.article}
       ${F.articleDetail}
     }

--- a/frontend/core/schemas/pages/doc.ts
+++ b/frontend/core/schemas/pages/doc.ts
@@ -1,8 +1,8 @@
 import F from '../fragments'
 
 export const doc = `
-  query doc($community: String!, $id: ID!, $userHasLogin: Boolean!) {
-    doc(community: $community, id: $id) {
+  query doc($article: ArticleRefInput!, $userHasLogin: Boolean!) {
+    doc(article: $article) {
       ${F.article}
       ${F.articleDetail}
     }

--- a/frontend/core/schemas/pages/post.ts
+++ b/frontend/core/schemas/pages/post.ts
@@ -1,8 +1,8 @@
 import F from '../fragments'
 
 export const post = `
-  query post($community: String!, $id: ID!, $userHasLogin: Boolean!) {
-    post(community: $community, id: $id) {
+  query post($article: ArticleRefInput!, $userHasLogin: Boolean!) {
+    post(article: $article) {
       ${F.article}
       ${F.articleDetail}
     }

--- a/frontend/core/widgets/ArticleSettingMenu/Menu/PinItem.tsx
+++ b/frontend/core/widgets/ArticleSettingMenu/Menu/PinItem.tsx
@@ -22,9 +22,15 @@ export default () => {
   }, [article.isPinned])
 
   const handlePin = useCallback(() => {
+    const articleRef = {
+      innerId: article.innerId,
+      community: article.communitySlug,
+      thread: article.meta.thread,
+    }
+
     const action = !pin
-      ? pinPost({ id: article.id, communityId: article.community.id })
-      : undoPinPost({ id: article.id, communityId: article.community.id })
+      ? pinPost({ article: articleRef })
+      : undoPinPost({ article: articleRef })
 
     action.then((result) => {
       if (result.error) {

--- a/frontend/core/widgets/ArticleSettingMenu/SubMenu/CatSetting.tsx
+++ b/frontend/core/widgets/ArticleSettingMenu/SubMenu/CatSetting.tsx
@@ -31,7 +31,15 @@ const CatSetting: FC<TProps> = ({ onBack }) => {
   }, [])
 
   const handleCat = () => {
-    const params = { id: article.id, cat }
+    const params = {
+      article: {
+        innerId: article.innerId,
+        community: article.communitySlug,
+        thread: article.meta.thread,
+      },
+      cat,
+    }
+
     setPostCat(params).then((result) => {
       if (result.error) {
         toast('修改失败', 'error')

--- a/frontend/core/widgets/ArticleSettingMenu/SubMenu/Mirror2Home.tsx
+++ b/frontend/core/widgets/ArticleSettingMenu/SubMenu/Mirror2Home.tsx
@@ -22,7 +22,14 @@ const Mirrow2Home: FC<TProps> = ({ onBack }) => {
   const [result, updatePost] = useMutation(S.updatePost)
 
   const handleUpdate = () => {
-    const params = { id: article.id }
+    const params = {
+      article: {
+        innerId: article.innerId,
+        community: article.communitySlug,
+        thread: article.meta.thread,
+      },
+    }
+
     console.log('## ## handle action')
     updatePost(params).then((result) => {
       if (result.error) {

--- a/frontend/core/widgets/ArticleSettingMenu/SubMenu/StateSetting.tsx
+++ b/frontend/core/widgets/ArticleSettingMenu/SubMenu/StateSetting.tsx
@@ -38,7 +38,15 @@ const StateSetting: FC<TProps> = ({ onBack }) => {
   }, [article.state])
 
   const handleState = () => {
-    const params = { id: article.id, state }
+    const params = {
+      article: {
+        innerId: article.innerId,
+        community: article.communitySlug,
+        thread: article.meta.thread,
+      },
+      state,
+    }
+
     setPostState(params).then((result) => {
       if (result.error) {
         toast('修改失败', 'error')

--- a/frontend/core/widgets/ArticleSettingMenu/SubMenu/TagsSetting.tsx
+++ b/frontend/core/widgets/ArticleSettingMenu/SubMenu/TagsSetting.tsx
@@ -57,7 +57,15 @@ const TagSetting: FC<TProps> = ({ onBack }) => {
   }
 
   const handleUpdate = () => {
-    const params = { id: article.id, communityTags: checked }
+    const params = {
+      article: {
+        innerId: article.innerId,
+        community: article.communitySlug,
+        thread: article.meta.thread,
+      },
+      communityTags: checked,
+    }
+
     updatePost(params).then((res) => {
       if (res.error) {
         toast('修改失败', 'error')

--- a/frontend/core/widgets/ArticleSettingMenu/SubMenu/TitleSetting.tsx
+++ b/frontend/core/widgets/ArticleSettingMenu/SubMenu/TitleSetting.tsx
@@ -29,7 +29,15 @@ const TitleSetting: FC<TProps> = ({ onBack }) => {
   }, [])
 
   const handleUpdate = () => {
-    const params = { id: article.id, title }
+    const params = {
+      article: {
+        innerId: article.innerId,
+        community: article.communitySlug,
+        thread: article.meta.thread,
+      },
+      title,
+    }
+
     updatePost(params).then((result) => {
       if (result.error) {
         toast('修改失败', 'error')

--- a/frontend/core/widgets/ArticleSettingMenu/schema.ts
+++ b/frontend/core/widgets/ArticleSettingMenu/schema.ts
@@ -3,8 +3,8 @@ import { gql } from 'urql'
 import { F } from '~/schemas'
 
 const updatePost = gql`
-  mutation ($id: ID!, $title: String, $body: String, $communityTags: [ID]) {
-    updatePost(id: $id, title: $title, body: $body, communityTags: $communityTags) {
+  mutation ($article: ArticleRefInput!, $title: String, $body: String, $communityTags: [ID]) {
+    updatePost(article: $article, title: $title, body: $body, communityTags: $communityTags) {
       id
       title
       communityTags {
@@ -14,16 +14,16 @@ const updatePost = gql`
   }
 `
 const setPostCat = gql`
-  mutation ($id: ID!, $cat: ArticleCatEnum!) {
-    setPostCat(id: $id, cat: $cat) {
+  mutation ($article: ArticleRefInput!, $cat: ArticleCatEnum!) {
+    setPostCat(article: $article, cat: $cat) {
       id
       cat
     }
   }
 `
 const setPostState = gql`
-  mutation ($id: ID!, $state: ArticleStateEnum!) {
-    setPostState(id: $id, state: $state) {
+  mutation ($article: ArticleRefInput!, $state: ArticleStateEnum!) {
+    setPostState(article: $article, state: $state) {
       id
       state
     }
@@ -31,16 +31,16 @@ const setPostState = gql`
 `
 
 const pinPost = gql`
-  mutation ($id: ID!, $communityId: ID!) {
-    pinPost(id: $id, communityId: $communityId) {
+  mutation ($article: ArticleRefInput!) {
+    pinPost(article: $article) {
       id
     }
   }
 `
 
 const undoPinPost = gql`
-  mutation ($id: ID!, $communityId: ID!) {
-    undoPinPost(id: $id, communityId: $communityId) {
+  mutation ($article: ArticleRefInput!) {
+    undoPinPost(article: $article) {
       id
       isPinned
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the GraphQL workflow to use a single ArticleRefInput with middlewares to normalize and load articles. This simplifies all article operations, strengthens permission checks, and updates schema, frontend, and tests.

- **Refactors**
  - Added ArticleArgs and ArticleLoader middlewares for argument normalization and article loading.
  - Replaced id/community/thread args with article: ArticleRefInput across reads and mutations (upvotes, collects, emotions, tags, sink, pin, delete, update).
  - Passport now falls back to owner checks when stamp validation fails.
  - Simplified resolvers to use article.community where needed (e.g., pin/undoPin).
  - Introduced ArticleRefInput (innerId, community, optional thread) and consolidated helper queries/mutations.
  - Minor schema tweak: groupedKanbanPosts now returns KanbanPosts.
  - Fixed remaining arg/type mismatches in frontend schemas and queries (Id/Ids -> ID) and moved them to ArticleRefInput.

- **Migration**
  - Clients must pass article: { innerId, community, thread? } instead of separate id/community/thread.
  - Thread is fixed by field for thread-specific endpoints (e.g., updatePost); for generic endpoints, include thread or rely on default POST.
  - Queries upvotedUsers/collectedUsers now take article: ArticleRefInput.

<sup>Written for commit d49a73906f64c5170da2bed2adb68754e5466405. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Unified article input: all article-related queries and mutations now accept a single ArticleRefInput instead of separate id/community/thread parameters.
  * GraphQL schema updated across posts, blogs, changelogs, docs and related operations (pin, upvote, report, sink, tags, mirror/move, collect, etc.).

* **Other**
  * Frontend and tests updated to use the new article-shaped inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->