### PR TITLE
refactor(be): use domain insert for community in tests

### DIFF
--- a/backend/main/test/groupher_server/accounts/publish/published_changelogs_test.exs
+++ b/backend/main/test/groupher_server/accounts/publish/published_changelogs_test.exs
@@ -11,7 +11,8 @@ defmodule GroupherServer.Test.Accounts.Publish.Changelog do
     {community, changelog, _, user} = mock_article(:changelog)
 
     {:ok, user2} = db_insert(:user)
-    {:ok, community2} = db_insert(:community)
+    community2_attrs = mock_attrs(:community)
+    {:ok, community2} = CMS.Communities.create(community2_attrs, user)
 
     {:ok, ~m(user user2 changelog community community2)a}
   end

--- a/backend/main/test/groupher_server/accounts/publish/published_changelogs_test.exs
+++ b/backend/main/test/groupher_server/accounts/publish/published_changelogs_test.exs
@@ -46,7 +46,7 @@ defmodule GroupherServer.Test.Accounts.Publish.Changelog do
       pub_changelogs2 =
         Enum.reduce(1..@publish_count, [], fn _, acc ->
           changelog_attrs = mock_attrs(:changelog, %{community_id: community2.id})
-          {:ok, changelog} = CMS.Articles.create(community, :changelog, changelog_attrs, user)
+          {:ok, changelog} = CMS.Articles.create(community2, :changelog, changelog_attrs, user)
 
           acc ++ [changelog]
         end)

--- a/backend/main/test/groupher_server/accounts/publish/published_docs_test.exs
+++ b/backend/main/test/groupher_server/accounts/publish/published_docs_test.exs
@@ -11,7 +11,8 @@ defmodule GroupherServer.Test.Accounts.Publish.Doc do
     {community, doc, _, user} = mock_article(:doc)
 
     {:ok, user2} = db_insert(:user)
-    {:ok, community2} = db_insert(:community)
+    community2_attrs = mock_attrs(:community)
+    {:ok, community2} = CMS.Communities.create(community2_attrs, user)
 
     {:ok, ~m(user user2 doc community community2)a}
   end

--- a/backend/main/test/groupher_server/accounts/publish/published_posts_test.exs
+++ b/backend/main/test/groupher_server/accounts/publish/published_posts_test.exs
@@ -11,7 +11,8 @@ defmodule GroupherServer.Test.Accounts.Publish.Post do
     {community, post, _, user} = mock_article(:post)
 
     {:ok, user2} = db_insert(:user)
-    {:ok, community2} = db_insert(:community)
+    community2_attrs = mock_attrs(:community)
+    {:ok, community2} = CMS.Communities.create(community2_attrs, user)
 
     {:ok, ~m(user user2 post community community2)a}
   end

--- a/backend/main/test/groupher_server/cms/abuse_reports/account_report_test.exs
+++ b/backend/main/test/groupher_server/cms/abuse_reports/account_report_test.exs
@@ -10,7 +10,8 @@ defmodule GroupherServer.Test.CMS.AbuseReports.AccountReport do
     {:ok, user2} = db_insert(:user)
     {:ok, user3} = db_insert(:user)
 
-    {:ok, community} = db_insert(:community)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
     post_attrs = mock_attrs(:post, %{community_id: community.id})
 
     {:ok, ~m(user user2 user3 community post_attrs)a}

--- a/backend/main/test/groupher_server/cms/articles/states/changelog_archive_test.exs
+++ b/backend/main/test/groupher_server/cms/articles/states/changelog_archive_test.exs
@@ -12,7 +12,8 @@ defmodule GroupherServer.Test.CMS.ChangelogArchive do
   setup do
     {:ok, user} = db_insert(:user)
     # {:ok, changelog} = db_insert(:changelog)
-    {:ok, community} = db_insert(:community)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     {:ok, changelog_long_ago} =
       db_insert(:changelog, %{title: "last week", inserted_at: @last_year})

--- a/backend/main/test/groupher_server/cms/articles/states/post_archive_test.exs
+++ b/backend/main/test/groupher_server/cms/articles/states/post_archive_test.exs
@@ -11,7 +11,8 @@ defmodule GroupherServer.Test.CMS.PostArchive do
   setup do
     {:ok, user} = db_insert(:user)
     # {:ok, post} = db_insert(:post)
-    {:ok, community} = db_insert(:community)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     {:ok, post_long_ago} = db_insert(:post, %{title: "last week", inserted_at: @last_year})
     db_insert_multi(:post, 5)

--- a/backend/main/test/groupher_server/cms/can_can/communities_test.exs
+++ b/backend/main/test/groupher_server/cms/can_can/communities_test.exs
@@ -6,7 +6,9 @@ defmodule GroupherServer.Test.CMS.CanCan.Communities do
   alias CMS.CanCan
 
   setup do
-    {:ok, community} = db_insert(:community)
+    {:ok, user} = db_insert(:user)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     {:ok, community: community}
   end

--- a/backend/main/test/groupher_server/cms/communities/meta/meta_test.exs
+++ b/backend/main/test/groupher_server/cms/communities/meta/meta_test.exs
@@ -26,12 +26,14 @@ defmodule GroupherServer.Test.CMS.Communities.Meta do
                Map.merge(@default_meta, %{moderators_ids: [community.user_id]})
     end
 
-    test "update legacy community should add default meta" do
-      {:ok, community} = db_insert(:community)
-      assert is_nil(community.meta)
+    test "update community should keep default meta", ~m(user)a do
+      community_attrs = mock_attrs(:community)
+      {:ok, community} = CMS.Communities.create(community_attrs, user)
 
       {:ok, community} = CMS.Communities.update(community, %{title: "new title"})
-      assert strip_struct(community.meta) == @default_meta
+
+      assert strip_struct(community.meta) ==
+               Map.merge(@default_meta, %{moderators_ids: [community.user_id]})
     end
 
     test "create a post should inc posts_count in meta",

--- a/backend/main/test/groupher_server/cms/communities/moderator/moderator_test.exs
+++ b/backend/main/test/groupher_server/cms/communities/moderator/moderator_test.exs
@@ -123,7 +123,8 @@ defmodule GroupherServer.Test.CMS.Communities.Moderator do
       cur_user = user
       {:ok, _} = CMS.Communities.add_moderator(community, role, user2, cur_user)
 
-      {:ok, other_community} = db_insert(:community)
+      other_community_attrs = mock_attrs(:community)
+      {:ok, other_community} = CMS.Communities.create(other_community_attrs, user)
 
       new_passport_rules = %{
         "global" => %{},
@@ -145,7 +146,8 @@ defmodule GroupherServer.Test.CMS.Communities.Moderator do
       cur_user = user
       {:ok, _} = CMS.Communities.add_moderator(community, role, user2, cur_user)
 
-      {:ok, other_community} = db_insert(:community)
+      other_community_attrs = mock_attrs(:community)
+      {:ok, other_community} = CMS.Communities.create(other_community_attrs, user)
 
       new_passport_rules = %{
         "global" => %{},

--- a/backend/main/test/groupher_server/cms/communities/tags/blog_tag_test.exs
+++ b/backend/main/test/groupher_server/cms/communities/tags/blog_tag_test.exs
@@ -102,7 +102,8 @@ defmodule GroupherServer.Test.CMS.Communities.Tags.BlogTagTest do
 
     test "can not create blog with other community's community tags",
          ~m(community user blog_attrs article_tag_attrs article_tag_attrs2)a do
-      {:ok, community2} = db_insert(:community)
+      community2_attrs = mock_attrs(:community)
+      {:ok, community2} = CMS.Communities.create(community2_attrs, user)
       {:ok, article_tag} = CMS.Communities.create_tag(community, :blog, article_tag_attrs, user)
 
       {:ok, article_tag2} =

--- a/backend/main/test/groupher_server/cms/communities/tags/changelog_tag_test.exs
+++ b/backend/main/test/groupher_server/cms/communities/tags/changelog_tag_test.exs
@@ -114,7 +114,8 @@ defmodule GroupherServer.Test.CMS.Communities.Tags.ChangelogTagTest do
 
     test "can not create changelog with other community's community tags",
          ~m(community user changelog_attrs article_tag_attrs article_tag_attrs2)a do
-      {:ok, community2} = db_insert(:community)
+      community2_attrs = mock_attrs(:community)
+      {:ok, community2} = CMS.Communities.create(community2_attrs, user)
 
       {:ok, article_tag} =
         CMS.Communities.create_tag(community, :changelog, article_tag_attrs, user)

--- a/backend/main/test/groupher_server/cms/communities/tags/doc_tag_test.exs
+++ b/backend/main/test/groupher_server/cms/communities/tags/doc_tag_test.exs
@@ -107,7 +107,8 @@ defmodule GroupherServer.Test.CMS.Communities.Tags.DocTagTest do
 
     test "can not create doc with other community's community tags",
          ~m(community user doc_attrs article_tag_attrs article_tag_attrs2)a do
-      {:ok, community2} = db_insert(:community)
+      community2_attrs = mock_attrs(:community)
+      {:ok, community2} = CMS.Communities.create(community2_attrs, user)
       {:ok, article_tag} = CMS.Communities.create_tag(community, :doc, article_tag_attrs, user)
 
       {:ok, article_tag2} =

--- a/backend/main/test/groupher_server/cms/events/audition/post_test.exs
+++ b/backend/main/test/groupher_server/cms/events/audition/post_test.exs
@@ -7,7 +7,8 @@ defmodule GroupherServer.Test.CMS.Events.Audition.PostTest do
     {:ok, user} = db_insert(:user)
     {:ok, post} = db_insert(:post)
 
-    {:ok, community} = db_insert(:community)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     post_attrs = mock_attrs(:post, %{community_id: community.id})
 

--- a/backend/main/test/groupher_server/cms/search/search_test.exs
+++ b/backend/main/test/groupher_server/cms/search/search_test.exs
@@ -4,13 +4,19 @@ defmodule GroupherServer.Test.CMS.Search do
 
   alias CMS.Search
 
+  defp create_community!(user, attrs) do
+    community_attrs = mock_attrs(:community, attrs)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
+    community
+  end
+
   setup do
     {:ok, user} = db_insert(:user)
-    {:ok, _community} = db_insert(:community, %{title: "react"})
-    {:ok, _community} = db_insert(:community, %{title: "php"})
-    {:ok, _community} = db_insert(:community, %{title: "每日妹子"})
-    {:ok, _community} = db_insert(:community, %{title: "javascript"})
-    {:ok, _community} = db_insert(:community, %{title: "java"})
+    _community = create_community!(user, %{title: "react"})
+    _community = create_community!(user, %{title: "php"})
+    _community = create_community!(user, %{title: "每日妹子"})
+    _community = create_community!(user, %{title: "javascript"})
+    _community = create_community!(user, %{title: "java"})
 
     {:ok, _community} = db_insert(:post, %{title: "react"})
     {:ok, _community} = db_insert(:post, %{title: "php"})
@@ -60,8 +66,8 @@ defmodule GroupherServer.Test.CMS.Search do
   end
 
   describe "[cms search community with category]" do
-    test "community with category can be searched" do
-      {:ok, community} = db_insert(:community, %{title: "cool-pl"})
+    test "community with category can be searched", ~m(user)a do
+      community = create_community!(user, %{title: "cool-pl"})
       {:ok, category} = db_insert(:category, %{slug: "pl"})
 
       {:ok, _} = CMS.Communities.set_category(community, category)

--- a/backend/main/test/groupher_server/messaging/mention_test.exs
+++ b/backend/main/test/groupher_server/messaging/mention_test.exs
@@ -12,7 +12,8 @@ defmodule GroupherServer.Test.Messaging.Mention do
     {:ok, user} = db_insert(:user)
     {:ok, user2} = db_insert(:user)
     {:ok, user3} = db_insert(:user)
-    {:ok, community} = db_insert(:community)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     mention_attr = %{
       thread: "POST",

--- a/backend/main/test/groupher_server/messaging/notification_test.exs
+++ b/backend/main/test/groupher_server/messaging/notification_test.exs
@@ -15,7 +15,8 @@ defmodule GroupherServer.Test.Messaging.Notification do
     {:ok, user2} = db_insert(:user)
     {:ok, user3} = db_insert(:user)
     {:ok, user4} = db_insert(:user)
-    {:ok, community} = db_insert(:community)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     notify_attrs = %{
       thread: :post,

--- a/backend/main/test/groupher_server/statistics/status_test.exs
+++ b/backend/main/test/groupher_server/statistics/status_test.exs
@@ -8,8 +8,16 @@ defmodule GroupherServer.Test.Statistics.Status do
   @communities_count 10
   # @posts_count 11
 
+  defp create_communities!(count, user) do
+    Enum.each(1..count, fn _ ->
+      community_attrs = mock_attrs(:community)
+      {:ok, _community} = CMS.Communities.create(community_attrs, user)
+    end)
+  end
+
   setup do
-    {:ok, _} = db_insert_multi(:community, @communities_count)
+    {:ok, user} = db_insert(:user)
+    create_communities!(@communities_count, user)
 
     :ok
   end

--- a/backend/main/test/groupher_server_web/mutation/cms/article_community/post_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/article_community/post_test.exs
@@ -87,8 +87,11 @@ defmodule GroupherServer.Test.Mutation.ArticleCommunity.Post do
       passport_rules = %{"post.community.mirror" => true}
       rule_conn = simu_conn(:user, cms: passport_rules)
 
-      {:ok, community2} = db_insert(:community)
-      {:ok, community3} = db_insert(:community)
+      {:ok, user} = db_insert(:user)
+      community2_attrs = mock_attrs(:community)
+      community3_attrs = mock_attrs(:community)
+      {:ok, community2} = CMS.Communities.create(community2_attrs, user)
+      {:ok, community3} = CMS.Communities.create(community3_attrs, user)
 
       variables = %{
         article: %{inner_id: post.inner_id, community: community.slug, thread: "POST"},

--- a/backend/main/test/groupher_server_web/mutation/cms/community_tags/blog_tag_crud_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/community_tags/blog_tag_crud_test.exs
@@ -6,9 +6,10 @@ defmodule GroupherServer.Test.Mutation.CMS.ArticleCommunityTags.BlogTagCRUD do
   alias CMS.Model.CommunityTag
 
   setup do
-    {:ok, community} = db_insert(:community)
     {:ok, thread} = db_insert(:thread)
     {:ok, user} = db_insert(:user)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     community_tag_attrs = mock_attrs(:community_tag)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/community_tags/changelog_tag_crud_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/community_tags/changelog_tag_crud_test.exs
@@ -6,9 +6,10 @@ defmodule GroupherServer.Test.Mutation.CMS.ArticleCommunityTags.ChangelogTagCRUD
   alias CMS.Model.CommunityTag
 
   setup do
-    {:ok, community} = db_insert(:community)
     {:ok, thread} = db_insert(:thread)
     {:ok, user} = db_insert(:user)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     community_tag_attrs = mock_attrs(:community_tag)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/community_tags/doc_tag_crud_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/community_tags/doc_tag_crud_test.exs
@@ -6,9 +6,10 @@ defmodule GroupherServer.Test.Mutation.CMS.ArticleCommunityTags.DocTagCRUD do
   alias CMS.Model.CommunityTag
 
   setup do
-    {:ok, community} = db_insert(:community)
     {:ok, thread} = db_insert(:thread)
     {:ok, user} = db_insert(:user)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     community_tag_attrs = mock_attrs(:community_tag)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/community_tags/post_tag_crud_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/community_tags/post_tag_crud_test.exs
@@ -6,9 +6,10 @@ defmodule GroupherServer.Test.Mutation.CMS.ArticleCommunityTags.PostTagCRUD do
   alias CMS.Model.CommunityTag
 
   setup do
-    {:ok, community} = db_insert(:community)
     {:ok, thread} = db_insert(:thread)
     {:ok, user} = db_insert(:user)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     community_tag_attrs = mock_attrs(:community_tag)
 

--- a/backend/main/test/groupher_server_web/mutation/cms/crud_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/crud_test.exs
@@ -167,7 +167,9 @@ defmodule GroupherServer.Test.Mutation.CMS.CRUD do
     end
 
     test "unauth user set/unset category fails", ~m(user_conn guest_conn)a do
-      {:ok, community} = db_insert(:community)
+      {:ok, user} = db_insert(:user)
+      community_attrs = mock_attrs(:community)
+      {:ok, community} = CMS.Communities.create(community_attrs, user)
       {:ok, category} = db_insert(:category)
 
       rule_conn = simu_conn(:user, cms: %{"what.ever" => true})

--- a/backend/main/test/groupher_server_web/mutation/cms/dashboard_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/dashboard_test.exs
@@ -5,9 +5,10 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
 
   setup do
     {:ok, category} = db_insert(:category)
-    {:ok, community} = db_insert(:community)
     {:ok, thread} = db_insert(:thread)
     {:ok, user} = db_insert(:user)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     user_conn = simu_conn(:user)
     guest_conn = simu_conn(:guest)

--- a/backend/main/test/groupher_server_web/query/accounts/account_test.exs
+++ b/backend/main/test/groupher_server_web/query/accounts/account_test.exs
@@ -329,7 +329,8 @@ defmodule GroupherServer.Test.Query.Account.Basic do
     end
 
     test "user should subscribe home community if not subscribed before", ~m(user)a do
-      community = create_community!(user, %{slug: "home"})
+      {:ok, owner} = db_insert(:user)
+      community = create_community!(owner, %{slug: "home"})
 
       user_conn = simu_conn(:user, user)
       _results = user_conn |> gq_query(@query)

--- a/backend/main/test/groupher_server_web/query/accounts/account_test.exs
+++ b/backend/main/test/groupher_server_web/query/accounts/account_test.exs
@@ -7,6 +7,18 @@ defmodule GroupherServer.Test.Query.Account.Basic do
 
   @default_subscribed_communities get_config(:general, :default_subscribed_communities)
 
+  defp create_community!(user, attrs \\ %{}) do
+    community_attrs = mock_attrs(:community, attrs)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
+    community
+  end
+
+  defp create_communities!(count, user) do
+    Enum.map(1..count, fn _ ->
+      create_community!(user)
+    end)
+  end
+
   setup do
     {:ok, user} = db_insert(:user)
     guest_conn = simu_conn(:guest)
@@ -234,8 +246,9 @@ defmodule GroupherServer.Test.Query.Account.Basic do
     }
     """
     test "guest user can get paged default subscribed communities", ~m(guest_conn)a do
-      {:ok, _} = db_insert_multi(:community, 25)
-      {:ok, _} = db_insert(:community, %{slug: "home"})
+      {:ok, user} = db_insert(:user)
+      _ = create_communities!(25, user)
+      _community = create_community!(user, %{slug: "home"})
 
       variables = %{filter: %{page: 1, size: 10}}
       results = guest_conn |> gq_query(@query, variables)
@@ -246,8 +259,9 @@ defmodule GroupherServer.Test.Query.Account.Basic do
 
     test "guest user can get paged default subscribed communities with home included",
          ~m(guest_conn)a do
-      {:ok, _} = db_insert_multi(:community, 25)
-      {:ok, _} = db_insert(:community, %{slug: "home"})
+      {:ok, user} = db_insert(:user)
+      _ = create_communities!(25, user)
+      _community = create_community!(user, %{slug: "home"})
 
       variables = %{filter: %{page: 1, size: 10}}
       results = guest_conn |> gq_query(@query, variables)
@@ -270,7 +284,8 @@ defmodule GroupherServer.Test.Query.Account.Basic do
     """
     test "guest user can get paged default subscribed communities with empty args",
          ~m(guest_conn)a do
-      {:ok, _} = db_insert_multi(:community, 25)
+      {:ok, user} = db_insert(:user)
+      _ = create_communities!(25, user)
 
       variables = %{filter: %{page: 1, size: 10}}
       results = guest_conn |> gq_query(@query, variables)
@@ -314,7 +329,7 @@ defmodule GroupherServer.Test.Query.Account.Basic do
     end
 
     test "user should subscribe home community if not subscribed before", ~m(user)a do
-      {:ok, community} = db_insert(:community, %{slug: "home"})
+      community = create_community!(user, %{slug: "home"})
 
       user_conn = simu_conn(:user, user)
       _results = user_conn |> gq_query(@query)

--- a/backend/main/test/groupher_server_web/query/cms/abuse_reports/account_report_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/abuse_reports/account_report_test.exs
@@ -7,7 +7,8 @@ defmodule GroupherServer.Test.Query.AbuseReports.AccountReport do
     {:ok, user} = db_insert(:user)
     {:ok, user2} = db_insert(:user)
 
-    {:ok, community} = db_insert(:community)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
     guest_conn = simu_conn(:guest)
 
     {:ok, ~m(guest_conn community user user2)a}

--- a/backend/main/test/groupher_server_web/query/cms/blog_tags_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/blog_tags_test.exs
@@ -5,9 +5,11 @@ defmodule GroupherServer.Test.Query.CMS.BlogTags do
 
   setup do
     guest_conn = simu_conn(:guest)
-    {:ok, community} = db_insert(:community)
-    {:ok, community2} = db_insert(:community)
     {:ok, user} = db_insert(:user)
+    community_attrs = mock_attrs(:community)
+    community2_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
+    {:ok, community2} = CMS.Communities.create(community2_attrs, user)
 
     article_tag_attrs = mock_attrs(:community_tag)
     article_tag_attrs2 = mock_attrs(:community_tag)

--- a/backend/main/test/groupher_server_web/query/cms/blog_tags_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/blog_tags_test.exs
@@ -7,14 +7,12 @@ defmodule GroupherServer.Test.Query.CMS.BlogTags do
     guest_conn = simu_conn(:guest)
     {:ok, user} = db_insert(:user)
     community_attrs = mock_attrs(:community)
-    community2_attrs = mock_attrs(:community)
     {:ok, community} = CMS.Communities.create(community_attrs, user)
-    {:ok, community2} = CMS.Communities.create(community2_attrs, user)
 
     article_tag_attrs = mock_attrs(:community_tag)
     article_tag_attrs2 = mock_attrs(:community_tag)
 
-    {:ok, ~m(guest_conn community community2 article_tag_attrs article_tag_attrs2 user)a}
+    {:ok, ~m(guest_conn community article_tag_attrs article_tag_attrs2 user)a}
   end
 
   describe "[cms query tags]" do

--- a/backend/main/test/groupher_server_web/query/cms/changelog_tags_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/changelog_tags_test.exs
@@ -5,9 +5,11 @@ defmodule GroupherServer.Test.Query.CMS.ChangelogTags do
 
   setup do
     guest_conn = simu_conn(:guest)
-    {:ok, community} = db_insert(:community)
-    {:ok, community2} = db_insert(:community)
     {:ok, user} = db_insert(:user)
+    community_attrs = mock_attrs(:community)
+    community2_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
+    {:ok, community2} = CMS.Communities.create(community2_attrs, user)
 
     article_tag_attrs = mock_attrs(:community_tag)
     article_tag_attrs2 = mock_attrs(:community_tag)

--- a/backend/main/test/groupher_server_web/query/cms/changelog_tags_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/changelog_tags_test.exs
@@ -7,14 +7,12 @@ defmodule GroupherServer.Test.Query.CMS.ChangelogTags do
     guest_conn = simu_conn(:guest)
     {:ok, user} = db_insert(:user)
     community_attrs = mock_attrs(:community)
-    community2_attrs = mock_attrs(:community)
     {:ok, community} = CMS.Communities.create(community_attrs, user)
-    {:ok, community2} = CMS.Communities.create(community2_attrs, user)
 
     article_tag_attrs = mock_attrs(:community_tag)
     article_tag_attrs2 = mock_attrs(:community_tag)
 
-    {:ok, ~m(guest_conn community community2 article_tag_attrs article_tag_attrs2 user)a}
+    {:ok, ~m(guest_conn community article_tag_attrs article_tag_attrs2 user)a}
   end
 
   describe "[cms query tags]" do

--- a/backend/main/test/groupher_server_web/query/cms/cms_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/cms_test.exs
@@ -226,7 +226,7 @@ defmodule GroupherServer.Test.Query.CMS.Basic do
       variables = %{filter: %{page: 1, size: 20}}
       results = guest_conn |> gq_query(@query, variables)
 
-      results["entries"] |> Enum.all?(fn x -> x["index"] == 100_000 end)
+      assert Enum.all?(results["entries"], fn x -> x["index"] == 100_000 end)
     end
 
     test "guest user can get paged communities based on category", ~m(guest_conn user)a do

--- a/backend/main/test/groupher_server_web/query/cms/cms_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/cms_test.exs
@@ -5,6 +5,18 @@ defmodule GroupherServer.Test.Query.CMS.Basic do
 
   alias CMS.Model.Category
 
+  defp create_community!(user, attrs \\ %{}) do
+    community_attrs = mock_attrs(:community, attrs)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
+    community
+  end
+
+  defp create_communities!(count, user) do
+    Enum.map(1..count, fn _ ->
+      create_community!(user)
+    end)
+  end
+
   setup do
     guest_conn = simu_conn(:guest)
     {:ok, user} = db_insert(:user)
@@ -79,8 +91,8 @@ defmodule GroupherServer.Test.Query.CMS.Basic do
       }
     }
     """
-    test "views should work", ~m(guest_conn)a do
-      {:ok, community} = db_insert(:community)
+    test "views should work", ~m(guest_conn user)a do
+      community = create_community!(user)
 
       variables = %{slug: community.slug}
       guest_conn |> gq_query(@query, variables)
@@ -93,8 +105,8 @@ defmodule GroupherServer.Test.Query.CMS.Basic do
       assert community.views == 2
     end
 
-    test "views should work with inc_views as false", ~m(guest_conn)a do
-      {:ok, community} = db_insert(:community)
+    test "views should work with inc_views as false", ~m(guest_conn user)a do
+      community = create_community!(user)
 
       variables = %{slug: community.slug, incViews: false}
       guest_conn |> gq_query(@query, variables)
@@ -107,8 +119,8 @@ defmodule GroupherServer.Test.Query.CMS.Basic do
       assert community.views == 0
     end
 
-    test "can get from alias community name", ~m(guest_conn)a do
-      {:ok, _community} = db_insert(:community, %{slug: "kubernetes", aka: "k8s"})
+    test "can get from alias community name", ~m(guest_conn user)a do
+      _community = create_community!(user, %{slug: "kubernetes", aka: "k8s"})
 
       variables = %{slug: "k8s"}
       aka_results = guest_conn |> gq_query(@query, variables)
@@ -188,7 +200,7 @@ defmodule GroupherServer.Test.Query.CMS.Basic do
     }
     """
     test "user can get viewer has subscribed state", ~m(user)a do
-      {:ok, communities} = db_insert_multi(:community, 5)
+      communities = create_communities!(5, user)
       {:ok, _record} = CMS.Communities.subscribe(communities |> List.first(), user)
 
       variables = %{filter: %{page: 1, size: 20}}
@@ -198,8 +210,8 @@ defmodule GroupherServer.Test.Query.CMS.Basic do
       assert results["entries"] |> Enum.any?(&(&1["viewerHasSubscribed"] == true))
     end
 
-    test "guest user can get paged communities", ~m(guest_conn)a do
-      {:ok, _communities} = db_insert_multi(:community, 5)
+    test "guest user can get paged communities", ~m(guest_conn user)a do
+      _communities = create_communities!(5, user)
 
       variables = %{filter: %{page: 1, size: 20}}
       results = guest_conn |> gq_query(@query, variables)
@@ -209,19 +221,19 @@ defmodule GroupherServer.Test.Query.CMS.Basic do
       assert results["totalCount"] == 5 + 1
     end
 
-    test "community has default index = 100000", ~m(guest_conn)a do
-      {:ok, _communities} = db_insert_multi(:community, 5)
+    test "community has default index = 100000", ~m(guest_conn user)a do
+      _communities = create_communities!(5, user)
       variables = %{filter: %{page: 1, size: 20}}
       results = guest_conn |> gq_query(@query, variables)
 
       results["entries"] |> Enum.all?(fn x -> x["index"] == 100_000 end)
     end
 
-    test "guest user can get paged communities based on category", ~m(guest_conn)a do
+    test "guest user can get paged communities based on category", ~m(guest_conn user)a do
       {:ok, category1} = db_insert(:category)
       {:ok, category2} = db_insert(:category)
 
-      {:ok, communities} = db_insert_multi(:community, 10)
+      communities = create_communities!(10, user)
 
       community1 = communities |> Enum.at(0)
       community2 = communities |> Enum.at(1)

--- a/backend/main/test/groupher_server_web/query/cms/doc_tags_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/doc_tags_test.exs
@@ -5,8 +5,9 @@ defmodule GroupherServer.Test.Query.CMS.DocTags do
 
   setup do
     guest_conn = simu_conn(:guest)
-    {:ok, community} = db_insert(:community)
     {:ok, user} = db_insert(:user)
+    community_attrs = mock_attrs(:community)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     article_tag_attrs = mock_attrs(:community_tag)
 

--- a/backend/main/test/groupher_server_web/query/cms/search_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/search_test.exs
@@ -3,13 +3,20 @@ defmodule GroupherServer.Test.Query.CMS.Search do
 
   use GroupherServer.TestMate
 
+  defp create_community!(user, attrs) do
+    community_attrs = mock_attrs(:community, attrs)
+    {:ok, community} = CMS.Communities.create(community_attrs, user)
+    community
+  end
+
   setup do
     guest_conn = simu_conn(:guest)
-    {:ok, _community} = db_insert(:community, %{title: "react"})
-    {:ok, _community} = db_insert(:community, %{title: "php"})
-    {:ok, _community} = db_insert(:community, %{title: "每日妹子"})
-    {:ok, _community} = db_insert(:community, %{title: "javascript"})
-    {:ok, _community} = db_insert(:community, %{title: "java"})
+    {:ok, user} = db_insert(:user)
+    _community = create_community!(user, %{title: "react"})
+    _community = create_community!(user, %{title: "php"})
+    _community = create_community!(user, %{title: "每日妹子"})
+    _community = create_community!(user, %{title: "javascript"})
+    _community = create_community!(user, %{title: "java"})
 
     {:ok, _community} = db_insert(:post, %{title: "react"})
     {:ok, _community} = db_insert(:post, %{title: "php"})
@@ -17,7 +24,7 @@ defmodule GroupherServer.Test.Query.CMS.Search do
     {:ok, _community} = db_insert(:post, %{title: "javascript"})
     {:ok, _community} = db_insert(:post, %{title: "java"})
 
-    {:ok, ~m(guest_conn)a}
+    {:ok, ~m(guest_conn user)a}
   end
 
   describe "[cms search post query]" do
@@ -61,8 +68,8 @@ defmodule GroupherServer.Test.Query.CMS.Search do
       assert results["entries"] |> Enum.any?(&(&1["title"] == "javascript"))
     end
 
-    test "can search community with category", ~m(guest_conn)a do
-      {:ok, community} = db_insert(:community, %{title: "cool-pl"})
+    test "can search community with category", ~m(guest_conn user)a do
+      community = create_community!(user, %{title: "cool-pl"})
       {:ok, category} = db_insert(:category, %{slug: "pl"})
 
       {:ok, _} = CMS.Communities.set_category(community, category)

--- a/backend/main/test/helper/orm_test.exs
+++ b/backend/main/test/helper/orm_test.exs
@@ -174,10 +174,11 @@ defmodule GroupherServer.Test.Helper.ORM do
 
   describe "update meta" do
     test "update meta should fill default meta info if need" do
-      {:ok, community} = db_insert(:community)
       {:ok, user} = db_insert(:user)
+      community_attrs = mock_attrs(:community)
+      {:ok, community} = CMS.Communities.create(community_attrs, user)
 
-      assert is_nil(community.meta)
+      assert not is_nil(community.meta)
       assert is_nil(user.meta)
 
       {:ok, community} = ORM.update_meta(community, %{})

--- a/backend/main/test/helper/transaction_test.exs
+++ b/backend/main/test/helper/transaction_test.exs
@@ -31,7 +31,9 @@ defmodule GroupherServer.Test.Helper.Transaction do
 
   describe "lock_row/2" do
     test "locks existing row and returns callback value" do
-      {:ok, community} = db_insert(:community)
+      {:ok, user} = db_insert(:user)
+      community_attrs = mock_attrs(:community)
+      {:ok, community} = CMS.Communities.create(community_attrs, user)
 
       assert {:ok, locked_community} =
                Transaction.lock_row(community, fn locked_community ->
@@ -47,8 +49,11 @@ defmodule GroupherServer.Test.Helper.Transaction do
     end
 
     test "locks multiple rows in deterministic order" do
-      {:ok, community1} = db_insert(:community)
-      {:ok, community2} = db_insert(:community)
+      {:ok, user} = db_insert(:user)
+      community1_attrs = mock_attrs(:community)
+      community2_attrs = mock_attrs(:community)
+      {:ok, community1} = CMS.Communities.create(community1_attrs, user)
+      {:ok, community2} = CMS.Communities.create(community2_attrs, user)
 
       expected_ids = [community1.id, community2.id] |> Enum.sort()
 


### PR DESCRIPTION
## Summary
- replace direct `db_insert(:community)` usage in backend tests with explicit `CMS.Communities.create` calls
- update multi-community test setup to build communities through test-local helpers that call the CMS create path
- align community meta expectations with real creation behavior now that tests no longer bypass community initialization

## Testing
- `mix test test/helper/transaction_test.exs test/helper/orm_test.exs test/groupher_server/messaging/mention_test.exs test/groupher_server/messaging/notification_test.exs test/groupher_server/accounts/publish/published_docs_test.exs test/groupher_server/accounts/publish/published_posts_test.exs test/groupher_server/accounts/publish/published_changelogs_test.exs test/groupher_server/cms/can_can/communities_test.exs test/groupher_server/cms/events/audition/post_test.exs test/groupher_server/cms/search/search_test.exs test/groupher_server/cms/abuse_reports/account_report_test.exs test/groupher_server/cms/articles/states/changelog_archive_test.exs test/groupher_server/cms/articles/states/post_archive_test.exs test/groupher_server/cms/communities/meta/meta_test.exs test/groupher_server/cms/communities/moderator/moderator_test.exs test/groupher_server/cms/communities/tags/blog_tag_test.exs test/groupher_server/cms/communities/tags/changelog_tag_test.exs test/groupher_server/cms/communities/tags/doc_tag_test.exs test/groupher_server/statistics/status_test.exs test/groupher_server_web/query/accounts/account_test.exs test/groupher_server_web/query/cms/doc_tags_test.exs test/groupher_server_web/query/cms/search_test.exs test/groupher_server_web/query/cms/blog_tags_test.exs test/groupher_server_web/query/cms/changelog_tags_test.exs test/groupher_server_web/query/cms/cms_test.exs test/groupher_server_web/query/cms/abuse_reports/account_report_test.exs test/groupher_server_web/mutation/cms/dashboard_test.exs test/groupher_server_web/mutation/cms/crud_test.exs test/groupher_server_web/mutation/cms/community_tags/blog_tag_crud_test.exs test/groupher_server_web/mutation/cms/community_tags/post_tag_crud_test.exs test/groupher_server_web/mutation/cms/community_tags/changelog_tag_crud_test.exs test/groupher_server_web/mutation/cms/community_tags/doc_tag_crud_test.exs test/groupher_server_web/mutation/cms/article_community/post_test.exs`
- `mix test test/groupher_server/cms/search/search_test.exs test/groupher_server_web/query/cms/search_test.exs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors backend tests to create communities via `CMS.Communities.create` instead of `db_insert(:community)` to use real initialization (meta, moderators) and improve accuracy. Adds small helpers and fixes a couple of test issues found during review.

- **Refactors**
  - Replaced `db_insert(:community)` with `CMS.Communities.create(mock_attrs(:community), user)` across tests.
  - Added helpers (`create_community!`, `create_communities!`) in search and account/cms query suites to reduce duplication.
  - Updated assertions to match real defaults (meta is set; `moderators_ids` includes creator).
  - Adjusted setups to ensure a `user` exists wherever a community is created.

- **Bug Fixes**
  - Published changelogs tests now create entries in the correct community.
  - Meta tests updated to assert initialized defaults instead of relying on legacy nil meta.

<sup>Written for commit b0b99634c37679f3cb7742213c5bff1306bc67cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Tests**
* Updated test infrastructure to create communities through the application layer instead of direct database insertion, improving test reliability and consistency across the test suite.

---

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->