### PR TITLE
refactor(be): recived_xx_id mis-spell

### DIFF
--- a/backend/main/lib/groupher_server/cms/articles/reactions.ex
+++ b/backend/main/lib/groupher_server/cms/articles/reactions.ex
@@ -21,11 +21,12 @@ defmodule GroupherServer.CMS.Articles.Reactions do
   @spec emotion(term(), atom(), User.t()) :: T.domain_res(term())
   def emotion(article, emotion, %User{} = user) do
     {:ok, info} = match(article)
+
     with {:ok, thread} <- FrontDesk.thread_of(article),
          :ok <- CanCan.ensure_emotion_allowed(article.community_slug, :article, thread, emotion) do
       Transaction.lock_row(article, fn article ->
         target =
-          %{recived_user_id: article.author.user_id, user_id: user.id}
+          %{received_user_id: article.author.user_id, user_id: user.id}
           |> Map.put(info.foreign_key, article.id)
 
         Multi.new()
@@ -44,11 +45,12 @@ defmodule GroupherServer.CMS.Articles.Reactions do
   @spec undo_emotion(term(), atom(), User.t()) :: T.domain_res(term())
   def undo_emotion(article, emotion, %User{} = user) do
     {:ok, info} = match(article)
+
     with {:ok, thread} <- FrontDesk.thread_of(article),
          :ok <- CanCan.ensure_emotion_allowed(article.community_slug, :article, thread, emotion) do
       Transaction.lock_row(article, fn article ->
         target =
-          %{recived_user_id: article.author.user_id, user_id: user.id}
+          %{received_user_id: article.author.user_id, user_id: user.id}
           |> Map.put(info.foreign_key, article.id)
 
         Multi.new()
@@ -83,6 +85,7 @@ defmodule GroupherServer.CMS.Articles.Reactions do
             avatar: user.avatar
           }
         )
+
       {:ok, Repo.all(query)}
     end
   end

--- a/backend/main/lib/groupher_server/cms/comments/emotion.ex
+++ b/backend/main/lib/groupher_server/cms/comments/emotion.ex
@@ -33,11 +33,17 @@ defmodule GroupherServer.CMS.Comments.Emotion do
   def set(comment_id, emotion, %User{} = user) do
     with {:ok, comment} <- FrontDesk.comment(comment_id) do
       with {:ok, article} <- FrontDesk.article_of(comment),
-           :ok <- CanCan.ensure_emotion_allowed(article.community_slug, :comment, comment.thread, emotion) do
+           :ok <-
+             CanCan.ensure_emotion_allowed(
+               article.community_slug,
+               :comment,
+               comment.thread,
+               emotion
+             ) do
         Transaction.lock_row(comment, fn locked_comment ->
           target = %{
             comment_id: locked_comment.id,
-            recived_user_id: locked_comment.author_id,
+            received_user_id: locked_comment.author_id,
             user_id: user.id
           }
 
@@ -49,7 +55,9 @@ defmodule GroupherServer.CMS.Comments.Emotion do
             update_emotion_embed(locked_comment, emotion, user, changed?, :add)
           end)
           |> Multi.run(:after_events, fn _, _ ->
-            Later.run({Events, :emit, [:subscribe_community, %{target: locked_comment, user: user}]})
+            Later.run(
+              {Events, :emit, [:subscribe_community, %{target: locked_comment, user: user}]}
+            )
           end)
           |> Repo.transaction()
           |> result
@@ -62,11 +70,17 @@ defmodule GroupherServer.CMS.Comments.Emotion do
   def undo(comment_id, emotion, %User{} = user) do
     with {:ok, comment} <- FrontDesk.comment(comment_id) do
       with {:ok, article} <- FrontDesk.article_of(comment),
-           :ok <- CanCan.ensure_emotion_allowed(article.community_slug, :comment, comment.thread, emotion) do
+           :ok <-
+             CanCan.ensure_emotion_allowed(
+               article.community_slug,
+               :comment,
+               comment.thread,
+               emotion
+             ) do
         Transaction.lock_row(comment, fn locked_comment ->
           target = %{
             comment_id: locked_comment.id,
-            recived_user_id: locked_comment.author_id,
+            received_user_id: locked_comment.author_id,
             user_id: user.id
           }
 

--- a/backend/main/lib/groupher_server/cms/helper/emotion_toggle.ex
+++ b/backend/main/lib/groupher_server/cms/helper/emotion_toggle.ex
@@ -10,10 +10,10 @@ defmodule GroupherServer.CMS.Helper.EmotionToggle do
 
   Example:
 
-      iex> EmotionToggle.persist(CommentUserEmotion, %{comment_id: 1, user_id: 2, recived_user_id: 3}, :beer, true)
+      iex> EmotionToggle.persist(CommentUserEmotion, %{comment_id: 1, user_id: 2, received_user_id: 3}, :beer, true)
       {:ok, true}
 
-      iex> EmotionToggle.persist(CommentUserEmotion, %{comment_id: 1, user_id: 2, recived_user_id: 3}, :beer, true)
+      iex> EmotionToggle.persist(CommentUserEmotion, %{comment_id: 1, user_id: 2, received_user_id: 3}, :beer, true)
       {:ok, false}
 
   The second call is idempotent because the same `(target, user, emotion)` row
@@ -45,7 +45,7 @@ defmodule GroupherServer.CMS.Helper.EmotionToggle do
     end
   end
 
-  @spec update_embed(map(), atom(), User.t(), :add | :remove, (() -> [map()])) ::
+  @spec update_embed(map(), atom(), User.t(), :add | :remove, (-> [map()])) ::
           {:ok, map()} | {:error, map()}
   def update_embed(artiment, emotion, %User{} = user, opt, latest_users_loader \\ fn -> [] end)
       when opt in [:add, :remove] and is_function(latest_users_loader, 0) do

--- a/backend/main/lib/groupher_server/cms/model/article_user_emotion.ex
+++ b/backend/main/lib/groupher_server/cms/model/article_user_emotion.ex
@@ -21,12 +21,12 @@ defmodule GroupherServer.CMS.Model.ArticleUserEmotion do
   @supported_emotions get_config(:article, :emotions)
   @article_threads get_config(:article, :threads)
 
-  @required_fields ~w(user_id recived_user_id emotion)a
+  @required_fields ~w(user_id received_user_id emotion)a
   @optional_fields Enum.map(@article_threads, &:"#{&1}_id")
 
   @type t :: %__MODULE__{}
   schema "articles_users_emotions" do
-    belongs_to(:recived_user, User, foreign_key: :recived_user_id)
+    belongs_to(:received_user, User, foreign_key: :received_user_id)
     belongs_to(:user, User, foreign_key: :user_id)
 
     field(:emotion, :string)
@@ -43,7 +43,7 @@ defmodule GroupherServer.CMS.Model.ArticleUserEmotion do
     |> validate_required(@required_fields)
     |> validate_inclusion(:emotion, Enum.map(@supported_emotions, &to_string/1))
     |> foreign_key_constraint(:user_id)
-    |> foreign_key_constraint(:recived_user_id)
+    |> foreign_key_constraint(:received_user_id)
     |> articles_emotion_unique_key_constraint()
     |> articles_foreign_key_constraint()
     |> articles_exactly_one_ref_constraint(:articles_users_emotions)

--- a/backend/main/lib/groupher_server/cms/model/comment_user_emotion.ex
+++ b/backend/main/lib/groupher_server/cms/model/comment_user_emotion.ex
@@ -14,12 +14,12 @@ defmodule GroupherServer.CMS.Model.CommentUserEmotion do
   @schema_prefix DBPrefix.cms()
   @supported_emotions get_config(:article, :comment_emotions)
 
-  @required_fields ~w(comment_id user_id recived_user_id emotion)a
+  @required_fields ~w(comment_id user_id received_user_id emotion)a
 
   @type t :: %__MODULE__{}
   schema "comments_users_emotions" do
     belongs_to(:comment, Comment, foreign_key: :comment_id)
-    belongs_to(:recived_user, User, foreign_key: :recived_user_id)
+    belongs_to(:received_user, User, foreign_key: :received_user_id)
     belongs_to(:user, User, foreign_key: :user_id)
 
     field(:emotion, :string)
@@ -36,7 +36,7 @@ defmodule GroupherServer.CMS.Model.CommentUserEmotion do
     |> validate_inclusion(:emotion, Enum.map(@supported_emotions, &to_string/1))
     |> foreign_key_constraint(:comment_id)
     |> foreign_key_constraint(:user_id)
-    |> foreign_key_constraint(:recived_user_id)
+    |> foreign_key_constraint(:received_user_id)
     |> comment_emotion_unique_key_constraint()
   end
 

--- a/backend/main/priv/repo/migrations/20260329000000_narrow_user_emotions_tables.exs
+++ b/backend/main/priv/repo/migrations/20260329000000_narrow_user_emotions_tables.exs
@@ -11,33 +11,39 @@ defmodule GroupherServer.Repo.Migrations.NarrowUserEmotionsTables do
       add(:comment_id, references(:comments, prefix: "cms", on_delete: :delete_all), null: false)
       add(:user_id, references(:users, prefix: "account", on_delete: :delete_all), null: false)
 
-      add(:recived_user_id, references(:users, prefix: "account", on_delete: :delete_all),
+      add(:received_user_id, references(:users, prefix: "account", on_delete: :delete_all),
         null: false
       )
+
       add(:emotion, :string, null: false)
 
       timestamps()
     end
 
-    create(unique_index(:comments_users_emotions, [:comment_id, :user_id, :emotion],
-             prefix: "cms",
-             name: :comments_users_emotions_comment_id_user_id_emotion_index
-           ))
+    create(
+      unique_index(:comments_users_emotions, [:comment_id, :user_id, :emotion],
+        prefix: "cms",
+        name: :comments_users_emotions_comment_id_user_id_emotion_index
+      )
+    )
 
-    create(index(:comments_users_emotions, [:comment_id, :emotion, :updated_at],
-             prefix: "cms",
-             name: :comments_users_emotions_comment_id_emotion_updated_at_index
-           ))
+    create(
+      index(:comments_users_emotions, [:comment_id, :emotion, :updated_at],
+        prefix: "cms",
+        name: :comments_users_emotions_comment_id_emotion_updated_at_index
+      )
+    )
 
     create(index(:comments_users_emotions, [:user_id], prefix: "cms"))
-    create(index(:comments_users_emotions, [:recived_user_id], prefix: "cms"))
+    create(index(:comments_users_emotions, [:received_user_id], prefix: "cms"))
 
     create table(:articles_users_emotions, prefix: "cms") do
       add(:user_id, references(:users, prefix: "account", on_delete: :delete_all), null: false)
 
-      add(:recived_user_id, references(:users, prefix: "account", on_delete: :delete_all),
+      add(:received_user_id, references(:users, prefix: "account", on_delete: :delete_all),
         null: false
       )
+
       add(:emotion, :string, null: false)
 
       add(:post_id, references(:posts, prefix: "cms", on_delete: :delete_all))
@@ -74,7 +80,7 @@ defmodule GroupherServer.Repo.Migrations.NarrowUserEmotionsTables do
     end)
 
     create(index(:articles_users_emotions, [:user_id], prefix: "cms"))
-    create(index(:articles_users_emotions, [:recived_user_id], prefix: "cms"))
+    create(index(:articles_users_emotions, [:received_user_id], prefix: "cms"))
   end
 
   def down do

--- a/backend/main/priv/repo/migrations/20260329000000_narrow_user_emotions_tables.exs
+++ b/backend/main/priv/repo/migrations/20260329000000_narrow_user_emotions_tables.exs
@@ -11,7 +11,7 @@ defmodule GroupherServer.Repo.Migrations.NarrowUserEmotionsTables do
       add(:comment_id, references(:comments, prefix: "cms", on_delete: :delete_all), null: false)
       add(:user_id, references(:users, prefix: "account", on_delete: :delete_all), null: false)
 
-      add(:received_user_id, references(:users, prefix: "account", on_delete: :delete_all),
+      add(:recived_user_id, references(:users, prefix: "account", on_delete: :delete_all),
         null: false
       )
 
@@ -35,12 +35,12 @@ defmodule GroupherServer.Repo.Migrations.NarrowUserEmotionsTables do
     )
 
     create(index(:comments_users_emotions, [:user_id], prefix: "cms"))
-    create(index(:comments_users_emotions, [:received_user_id], prefix: "cms"))
+    create(index(:comments_users_emotions, [:recived_user_id], prefix: "cms"))
 
     create table(:articles_users_emotions, prefix: "cms") do
       add(:user_id, references(:users, prefix: "account", on_delete: :delete_all), null: false)
 
-      add(:received_user_id, references(:users, prefix: "account", on_delete: :delete_all),
+      add(:recived_user_id, references(:users, prefix: "account", on_delete: :delete_all),
         null: false
       )
 
@@ -80,7 +80,7 @@ defmodule GroupherServer.Repo.Migrations.NarrowUserEmotionsTables do
     end)
 
     create(index(:articles_users_emotions, [:user_id], prefix: "cms"))
-    create(index(:articles_users_emotions, [:received_user_id], prefix: "cms"))
+    create(index(:articles_users_emotions, [:recived_user_id], prefix: "cms"))
   end
 
   def down do

--- a/backend/main/priv/repo/migrations/20260329120000_rename_received_user_id_in_user_emotions.exs
+++ b/backend/main/priv/repo/migrations/20260329120000_rename_received_user_id_in_user_emotions.exs
@@ -1,0 +1,159 @@
+defmodule GroupherServer.Repo.Migrations.RenameReceivedUserIdInUserEmotions do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'cms'
+          AND table_name = 'comments_users_emotions'
+          AND column_name = 'recived_user_id'
+      ) THEN
+        ALTER TABLE cms.comments_users_emotions
+        RENAME COLUMN recived_user_id TO received_user_id;
+      END IF;
+    END
+    $$;
+    """)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'cms'
+          AND table_name = 'articles_users_emotions'
+          AND column_name = 'recived_user_id'
+      ) THEN
+        ALTER TABLE cms.articles_users_emotions
+        RENAME COLUMN recived_user_id TO received_user_id;
+      END IF;
+    END
+    $$;
+    """)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'comments_users_emotions_recived_user_id_fkey'
+      ) THEN
+        ALTER TABLE cms.comments_users_emotions
+        RENAME CONSTRAINT comments_users_emotions_recived_user_id_fkey
+        TO comments_users_emotions_received_user_id_fkey;
+      END IF;
+    END
+    $$;
+    """)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'articles_users_emotions_recived_user_id_fkey'
+      ) THEN
+        ALTER TABLE cms.articles_users_emotions
+        RENAME CONSTRAINT articles_users_emotions_recived_user_id_fkey
+        TO articles_users_emotions_received_user_id_fkey;
+      END IF;
+    END
+    $$;
+    """)
+
+    execute("""
+    ALTER INDEX IF EXISTS cms.comments_users_emotions_recived_user_id_index
+    RENAME TO comments_users_emotions_received_user_id_index
+    """)
+
+    execute("""
+    ALTER INDEX IF EXISTS cms.articles_users_emotions_recived_user_id_index
+    RENAME TO articles_users_emotions_received_user_id_index
+    """)
+  end
+
+  def down do
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'cms'
+          AND table_name = 'comments_users_emotions'
+          AND column_name = 'received_user_id'
+      ) THEN
+        ALTER TABLE cms.comments_users_emotions
+        RENAME COLUMN received_user_id TO recived_user_id;
+      END IF;
+    END
+    $$;
+    """)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'cms'
+          AND table_name = 'articles_users_emotions'
+          AND column_name = 'received_user_id'
+      ) THEN
+        ALTER TABLE cms.articles_users_emotions
+        RENAME COLUMN received_user_id TO recived_user_id;
+      END IF;
+    END
+    $$;
+    """)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'comments_users_emotions_received_user_id_fkey'
+      ) THEN
+        ALTER TABLE cms.comments_users_emotions
+        RENAME CONSTRAINT comments_users_emotions_received_user_id_fkey
+        TO comments_users_emotions_recived_user_id_fkey;
+      END IF;
+    END
+    $$;
+    """)
+
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'articles_users_emotions_received_user_id_fkey'
+      ) THEN
+        ALTER TABLE cms.articles_users_emotions
+        RENAME CONSTRAINT articles_users_emotions_received_user_id_fkey
+        TO articles_users_emotions_recived_user_id_fkey;
+      END IF;
+    END
+    $$;
+    """)
+
+    execute("""
+    ALTER INDEX IF EXISTS cms.comments_users_emotions_received_user_id_index
+    RENAME TO comments_users_emotions_recived_user_id_index
+    """)
+
+    execute("""
+    ALTER INDEX IF EXISTS cms.articles_users_emotions_received_user_id_index
+    RENAME TO articles_users_emotions_recived_user_id_index
+    """)
+  end
+end

--- a/backend/main/priv/repo/migrations/20260329120000_rename_received_user_id_in_user_emotions.exs
+++ b/backend/main/priv/repo/migrations/20260329120000_rename_received_user_id_in_user_emotions.exs
@@ -41,8 +41,12 @@ defmodule GroupherServer.Repo.Migrations.RenameReceivedUserIdInUserEmotions do
     BEGIN
       IF EXISTS (
         SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'comments_users_emotions_recived_user_id_fkey'
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE c.conname = 'comments_users_emotions_recived_user_id_fkey'
+          AND n.nspname = 'cms'
+          AND t.relname = 'comments_users_emotions'
       ) THEN
         ALTER TABLE cms.comments_users_emotions
         RENAME CONSTRAINT comments_users_emotions_recived_user_id_fkey
@@ -57,8 +61,12 @@ defmodule GroupherServer.Repo.Migrations.RenameReceivedUserIdInUserEmotions do
     BEGIN
       IF EXISTS (
         SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'articles_users_emotions_recived_user_id_fkey'
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE c.conname = 'articles_users_emotions_recived_user_id_fkey'
+          AND n.nspname = 'cms'
+          AND t.relname = 'articles_users_emotions'
       ) THEN
         ALTER TABLE cms.articles_users_emotions
         RENAME CONSTRAINT articles_users_emotions_recived_user_id_fkey
@@ -70,12 +78,12 @@ defmodule GroupherServer.Repo.Migrations.RenameReceivedUserIdInUserEmotions do
 
     execute("""
     ALTER INDEX IF EXISTS cms.comments_users_emotions_recived_user_id_index
-    RENAME TO comments_users_emotions_received_user_id_index
+    RENAME TO comments_users_emotions_received_user_id_index;
     """)
 
     execute("""
     ALTER INDEX IF EXISTS cms.articles_users_emotions_recived_user_id_index
-    RENAME TO articles_users_emotions_received_user_id_index
+    RENAME TO articles_users_emotions_received_user_id_index;
     """)
   end
 
@@ -119,8 +127,12 @@ defmodule GroupherServer.Repo.Migrations.RenameReceivedUserIdInUserEmotions do
     BEGIN
       IF EXISTS (
         SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'comments_users_emotions_received_user_id_fkey'
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE c.conname = 'comments_users_emotions_received_user_id_fkey'
+          AND n.nspname = 'cms'
+          AND t.relname = 'comments_users_emotions'
       ) THEN
         ALTER TABLE cms.comments_users_emotions
         RENAME CONSTRAINT comments_users_emotions_received_user_id_fkey
@@ -135,8 +147,12 @@ defmodule GroupherServer.Repo.Migrations.RenameReceivedUserIdInUserEmotions do
     BEGIN
       IF EXISTS (
         SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'articles_users_emotions_received_user_id_fkey'
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE c.conname = 'articles_users_emotions_received_user_id_fkey'
+          AND n.nspname = 'cms'
+          AND t.relname = 'articles_users_emotions'
       ) THEN
         ALTER TABLE cms.articles_users_emotions
         RENAME CONSTRAINT articles_users_emotions_received_user_id_fkey
@@ -148,12 +164,12 @@ defmodule GroupherServer.Repo.Migrations.RenameReceivedUserIdInUserEmotions do
 
     execute("""
     ALTER INDEX IF EXISTS cms.comments_users_emotions_received_user_id_index
-    RENAME TO comments_users_emotions_recived_user_id_index
+    RENAME TO comments_users_emotions_recived_user_id_index;
     """)
 
     execute("""
     ALTER INDEX IF EXISTS cms.articles_users_emotions_received_user_id_index
-    RENAME TO articles_users_emotions_recived_user_id_index
+    RENAME TO articles_users_emotions_recived_user_id_index;
     """)
   end
 end

--- a/backend/main/test/groupher_server/cms/polymorphic_article_constraints_test.exs
+++ b/backend/main/test/groupher_server/cms/polymorphic_article_constraints_test.exs
@@ -87,7 +87,7 @@ defmodule GroupherServer.Test.CMS.PolymorphicArticleConstraintsTest do
     test "article user emotion rejects multiple article refs", ~m(post blog user other_user)a do
       attrs = %{
         user_id: user.id,
-        recived_user_id: other_user.id,
+        received_user_id: other_user.id,
         emotion: "beer",
         post_id: post.id,
         blog_id: blog.id


### PR DESCRIPTION
## Summary
- rename `recived_user_id` to `received_user_id` across article and comment emotion models, helpers, and tests
- update the narrowed user emotion table migration to create the corrected column and indexes
- add a follow-up migration to rename existing database columns, foreign key constraints, and indexes safely

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed recived_user_id to received_user_id across article/comment emotion code. Added an idempotent migration that safely renames DB columns, constraints, and indexes without data loss.

- **Refactors**
  - Updated reactions, comment emotion flows, `EmotionToggle`, models, and validations to use received_user_id.
  - Adjusted examples and tests to the new field name.

- **Migration**
  - 20260329000000 keeps recived_user_id in table creation for backward compatibility.
  - 20260329120000 renames existing columns, FK constraints, and indexes to received_user_id when present (idempotent; includes down).
  - Run migrations to apply.

<sup>Written for commit a3c958c5b96e45e786f87984549dc667fe42290d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data field inconsistencies in the emotion and reaction tracking system affecting articles and comments.

* **Chores**
  * Database migration updates to align with corrected field naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->