### PR TITLE
fix(be): can-can logic for dashboard enable workflow

### DIFF
--- a/backend/main/lib/groupher_server/cms/articles/list.ex
+++ b/backend/main/lib/groupher_server/cms/articles/list.ex
@@ -43,7 +43,7 @@ defmodule GroupherServer.CMS.Articles.List do
     %{page: page, size: size} = filter
     flags = %{mark_delete: false, pending: :legal}
 
-    with {:ok, _thread} <- CanCan.ensure_thread_visible(filter, thread),
+    with {:ok, _thread} <- CanCan.ensure_thread_visible(Map.get(filter, :community), thread),
          {:ok, info} <- match(thread) do
       info.model
       |> QueryBuilder.domain_query(filter)

--- a/backend/main/lib/groupher_server/cms/articles/list.ex
+++ b/backend/main/lib/groupher_server/cms/articles/list.ex
@@ -19,6 +19,7 @@ defmodule GroupherServer.CMS.Articles.List do
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias Accounts.Model.User
+  alias CMS.CanCan
   alias CMS.FrontDesk
   alias CMS.Helper.ArticleEnums
   alias CMS.Model.{CitedArtiment, Community, PinnedArticle, Post}
@@ -42,7 +43,8 @@ defmodule GroupherServer.CMS.Articles.List do
     %{page: page, size: size} = filter
     flags = %{mark_delete: false, pending: :legal}
 
-    with {:ok, info} <- match(thread) do
+    with {:ok, _thread} <- CanCan.ensure_thread_visible(filter, thread),
+         {:ok, info} <- match(thread) do
       info.model
       |> QueryBuilder.domain_query(filter)
       |> QueryBuilder.filter_pack(Map.merge(filter, flags))

--- a/backend/main/lib/groupher_server/cms/articles/list.ex
+++ b/backend/main/lib/groupher_server/cms/articles/list.ex
@@ -43,7 +43,7 @@ defmodule GroupherServer.CMS.Articles.List do
     %{page: page, size: size} = filter
     flags = %{mark_delete: false, pending: :legal}
 
-    with {:ok, _thread} <- CanCan.ensure_thread_visible(Map.get(filter, :community), thread),
+    with {:ok, _thread} <- CanCan.allow_thread(Map.get(filter, :community), thread),
          {:ok, info} <- match(thread) do
       info.model
       |> QueryBuilder.domain_query(filter)

--- a/backend/main/lib/groupher_server/cms/articles/reactions.ex
+++ b/backend/main/lib/groupher_server/cms/articles/reactions.ex
@@ -23,7 +23,8 @@ defmodule GroupherServer.CMS.Articles.Reactions do
     {:ok, info} = match(article)
 
     with {:ok, thread} <- FrontDesk.thread_of(article),
-         :ok <- CanCan.ensure_emotion_allowed(article.community_slug, :article, thread, emotion) do
+         {:ok, _thread_key} <-
+           CanCan.ensure_emotion_allowed(article.community_slug, :article, thread, emotion) do
       Transaction.lock_row(article, fn article ->
         target =
           %{received_user_id: article.author.user_id, user_id: user.id}
@@ -47,7 +48,8 @@ defmodule GroupherServer.CMS.Articles.Reactions do
     {:ok, info} = match(article)
 
     with {:ok, thread} <- FrontDesk.thread_of(article),
-         :ok <- CanCan.ensure_emotion_allowed(article.community_slug, :article, thread, emotion) do
+         {:ok, _thread_key} <-
+           CanCan.ensure_emotion_allowed(article.community_slug, :article, thread, emotion) do
       Transaction.lock_row(article, fn article ->
         target =
           %{received_user_id: article.author.user_id, user_id: user.id}

--- a/backend/main/lib/groupher_server/cms/articles/reactions.ex
+++ b/backend/main/lib/groupher_server/cms/articles/reactions.ex
@@ -24,7 +24,7 @@ defmodule GroupherServer.CMS.Articles.Reactions do
 
     with {:ok, thread} <- FrontDesk.thread_of(article),
          {:ok, _thread_key} <-
-           CanCan.ensure_emotion_allowed(article.community_slug, :article, thread, emotion) do
+           CanCan.allow_emotion(article.community_slug, :article, thread, emotion) do
       Transaction.lock_row(article, fn article ->
         target =
           %{received_user_id: article.author.user_id, user_id: user.id}
@@ -49,7 +49,7 @@ defmodule GroupherServer.CMS.Articles.Reactions do
 
     with {:ok, thread} <- FrontDesk.thread_of(article),
          {:ok, _thread_key} <-
-           CanCan.ensure_emotion_allowed(article.community_slug, :article, thread, emotion) do
+           CanCan.allow_emotion(article.community_slug, :article, thread, emotion) do
       Transaction.lock_row(article, fn article ->
         target =
           %{received_user_id: article.author.user_id, user_id: user.id}

--- a/backend/main/lib/groupher_server/cms/articles/read.ex
+++ b/backend/main/lib/groupher_server/cms/articles/read.ex
@@ -15,6 +15,7 @@ defmodule GroupherServer.CMS.Articles.Read do
   alias GroupherServer.{Accounts, CMS, Repo}
 
   alias Accounts.Model.User
+  alias CMS.CanCan
   alias CMS.Model.{Community, PinnedArticle}
   alias Helper.{Multi, Constant, ORM, T}
 
@@ -26,7 +27,8 @@ defmodule GroupherServer.CMS.Articles.Read do
 
   @spec read(String.t(), T.article_thread(), T.id()) :: T.domain_res(T.article())
   def read(community_slug, thread, inner_id) when thread in @article_threads do
-    with {:ok, article} <- if_article_legal(community_slug, thread, inner_id) do
+    with {:ok, _thread} <- CanCan.ensure_thread_visible(community_slug, thread),
+         {:ok, article} <- if_article_legal(community_slug, thread, inner_id) do
       do_read_article(article, community_slug, thread)
     end
   end
@@ -34,7 +36,8 @@ defmodule GroupherServer.CMS.Articles.Read do
   @spec read(String.t(), T.article_thread(), T.id(), User.t()) :: T.domain_res(T.article())
   def read(community_slug, thread, inner_id, %User{id: user_id} = user)
       when thread in @article_threads do
-    with {:ok, article} <- if_article_legal(community_slug, thread, inner_id, user) do
+    with {:ok, _thread} <- CanCan.ensure_thread_visible(community_slug, thread),
+         {:ok, article} <- if_article_legal(community_slug, thread, inner_id, user) do
       Multi.new()
       |> Multi.run(:normal_read, fn _, _ ->
         do_read_article(article, community_slug, thread)

--- a/backend/main/lib/groupher_server/cms/articles/read.ex
+++ b/backend/main/lib/groupher_server/cms/articles/read.ex
@@ -27,7 +27,7 @@ defmodule GroupherServer.CMS.Articles.Read do
 
   @spec read(String.t(), T.article_thread(), T.id()) :: T.domain_res(T.article())
   def read(community_slug, thread, inner_id) when thread in @article_threads do
-    with {:ok, _thread} <- CanCan.ensure_thread_visible(community_slug, thread),
+    with {:ok, _thread} <- CanCan.allow_thread(community_slug, thread),
          {:ok, article} <- if_article_legal(community_slug, thread, inner_id) do
       do_read_article(article, community_slug, thread)
     end
@@ -36,7 +36,7 @@ defmodule GroupherServer.CMS.Articles.Read do
   @spec read(String.t(), T.article_thread(), T.id(), User.t()) :: T.domain_res(T.article())
   def read(community_slug, thread, inner_id, %User{id: user_id} = user)
       when thread in @article_threads do
-    with {:ok, _thread} <- CanCan.ensure_thread_visible(community_slug, thread),
+    with {:ok, _thread} <- CanCan.allow_thread(community_slug, thread),
          {:ok, article} <- if_article_legal(community_slug, thread, inner_id, user) do
       Multi.new()
       |> Multi.run(:normal_read, fn _, _ ->

--- a/backend/main/lib/groupher_server/cms/can_can.ex
+++ b/backend/main/lib/groupher_server/cms/can_can.ex
@@ -35,6 +35,10 @@ defmodule GroupherServer.CMS.CanCan do
   @spec thread_visible?(map(), atom() | String.t()) :: boolean()
   def thread_visible?(community, thread), do: Communities.thread_visible?(community, thread)
 
+  @spec ensure_thread_visible(map() | String.t() | nil, atom() | String.t()) ::
+          {:ok, atom()} | {:error, atom()}
+  def ensure_thread_visible(community, thread), do: Communities.ensure_thread_visible(community, thread)
+
   @spec thread_mutable?(map(), atom() | String.t()) :: boolean()
   def thread_mutable?(community, thread), do: Communities.thread_mutable?(community, thread)
 
@@ -44,7 +48,7 @@ defmodule GroupherServer.CMS.CanCan do
   end
 
   @spec ensure_emotion_allowed(String.t() | nil, scope(), atom() | String.t(), atom()) ::
-          :ok | {:error, atom()}
+          {:ok, atom()} | {:error, atom()}
   def ensure_emotion_allowed(community, scope, thread, emotion) do
     Communities.ensure_emotion_allowed(community, scope, thread, emotion)
   end

--- a/backend/main/lib/groupher_server/cms/can_can.ex
+++ b/backend/main/lib/groupher_server/cms/can_can.ex
@@ -7,7 +7,7 @@ defmodule GroupherServer.CMS.CanCan do
 
   Design intent:
   - `FrontDesk` prepares runtime context such as community, dashboard, thread, article, comment.
-  - `CMS.CanCan` answers whether a capability is allowed in that context.
+  - `CMS.CanCan` validates whether a capability is allowed in that context.
   - CMS domains execute the actual read/write logic after the check passes.
 
   Current implementation delegates community-scoped decisions to
@@ -15,50 +15,27 @@ defmodule GroupherServer.CMS.CanCan do
 
   Example:
 
-      iex> CMS.CanCan.thread_visible?(community, :post)
-      true
+      iex> CMS.CanCan.allow_thread(community, :post)
+      {:ok, :post}
 
-      iex> CMS.CanCan.emotion_allowed?(community.slug, :comment, :post, :beer)
-      true
+      iex> CMS.CanCan.allow_emotion(community.slug, :comment, :post, :beer)
+      {:ok, :post_comment}
 
-      iex> CMS.CanCan.ensure_emotion_allowed(community.slug, :comment, :post, :upvote)
+      iex> CMS.CanCan.allow_emotion(community.slug, :comment, :post, :upvote)
       {:error, :emotion_not_allowed}
-
-  The `?` functions are boolean checks. `ensure_*` helpers are for write paths
-  that need a standard error atom when a policy rejects the action.
   """
 
   alias GroupherServer.CMS.CanCan.Communities
 
   @type scope :: :article | :comment
 
-  @spec thread_visible?(map(), atom() | String.t()) :: boolean()
-  def thread_visible?(community, thread), do: Communities.thread_visible?(community, thread)
-
-  @spec ensure_thread_visible(map() | String.t() | nil, atom() | String.t()) ::
+  @spec allow_thread(map() | String.t() | nil, atom() | String.t()) ::
           {:ok, atom()} | {:error, atom()}
-  def ensure_thread_visible(community, thread), do: Communities.ensure_thread_visible(community, thread)
+  def allow_thread(community, thread), do: Communities.allow_thread(community, thread)
 
-  @spec thread_mutable?(map(), atom() | String.t()) :: boolean()
-  def thread_mutable?(community, thread), do: Communities.thread_mutable?(community, thread)
-
-  @spec emotion_allowed?(String.t() | nil, scope(), atom() | String.t(), atom()) :: boolean()
-  def emotion_allowed?(community, scope, thread, emotion) do
-    Communities.emotion_allowed?(community, scope, thread, emotion)
-  end
-
-  @spec ensure_emotion_allowed(String.t() | nil, scope(), atom() | String.t(), atom()) ::
+  @spec allow_emotion(String.t() | nil, scope(), atom() | String.t(), atom()) ::
           {:ok, atom()} | {:error, atom()}
-  def ensure_emotion_allowed(community, scope, thread, emotion) do
-    Communities.ensure_emotion_allowed(community, scope, thread, emotion)
+  def allow_emotion(community, scope, thread, emotion) do
+    Communities.allow_emotion(community, scope, thread, emotion)
   end
-
-  @spec community_frozen?(map()) :: boolean()
-  def community_frozen?(community), do: Communities.community_frozen?(community)
-
-  @spec publishable?(map(), atom() | String.t(), map() | nil) :: boolean()
-  def publishable?(community, thread, user), do: Communities.publishable?(community, thread, user)
-
-  @spec dashboard_updatable?(map(), map() | nil) :: boolean()
-  def dashboard_updatable?(community, user), do: Communities.dashboard_updatable?(community, user)
 end

--- a/backend/main/lib/groupher_server/cms/can_can/communities.ex
+++ b/backend/main/lib/groupher_server/cms/can_can/communities.ex
@@ -27,10 +27,10 @@ defmodule GroupherServer.CMS.CanCan.Communities do
       iex> CMS.CanCan.Communities.allowed_emotions("groupher", :comment, :post)
       [:beer, :heart]
 
-      iex> CMS.CanCan.Communities.emotion_allowed?("groupher", :comment, :post, :beer)
-      true
+      iex> CMS.CanCan.Communities.allow_emotion("groupher", :comment, :post, :beer)
+      {:ok, :post_comment}
 
-      iex> CMS.CanCan.Communities.ensure_emotion_allowed("groupher", :comment, :post, :upvote)
+      iex> CMS.CanCan.Communities.allow_emotion("groupher", :comment, :post, :upvote)
       {:error, :emotion_not_allowed}
   """
 
@@ -44,24 +44,9 @@ defmodule GroupherServer.CMS.CanCan.Communities do
 
   @type scope :: :article | :comment
 
-  @spec emotion_allowed?(String.t() | nil, scope(), atom() | String.t(), atom()) :: boolean()
-  def emotion_allowed?(community_slug, scope, thread, emotion) do
-    emotion in allowed_emotions(community_slug, scope, thread)
-  end
-
-  @spec thread_visible?(map() | String.t() | nil, atom() | String.t()) :: boolean()
-  def thread_visible?(community, thread) do
-    thread_key = normalize_thread(thread)
-
-    case dashboard_enable(community) do
-      nil -> true
-      enable -> Map.get(enable, thread_key, true)
-    end
-  end
-
-  @spec ensure_thread_visible(map() | String.t() | nil, atom() | String.t()) ::
+  @spec allow_thread(map() | String.t() | nil, atom() | String.t()) ::
           {:ok, atom()} | {:error, atom()}
-  def ensure_thread_visible(community, thread) do
+  def allow_thread(community, thread) do
     thread_key = normalize_thread(thread)
 
     case thread_visible?(community, thread_key) do
@@ -70,27 +55,9 @@ defmodule GroupherServer.CMS.CanCan.Communities do
     end
   end
 
-  @spec thread_mutable?(map() | String.t() | nil, atom() | String.t()) :: boolean()
-  def thread_mutable?(community, thread) do
-    thread_visible?(community, thread) and not community_frozen?(community)
-  end
-
-  @spec community_frozen?(map() | String.t() | nil) :: boolean()
-  def community_frozen?(_community), do: false
-
-  @spec publishable?(map() | String.t() | nil, atom() | String.t(), map() | nil) :: boolean()
-  def publishable?(community, thread, _user) do
-    thread_mutable?(community, thread)
-  end
-
-  @spec dashboard_updatable?(map() | String.t() | nil, map() | nil) :: boolean()
-  def dashboard_updatable?(community, _user) do
-    not community_frozen?(community)
-  end
-
-  @spec ensure_emotion_allowed(String.t() | nil, scope(), atom() | String.t(), atom()) ::
+  @spec allow_emotion(String.t() | nil, scope(), atom() | String.t(), atom()) ::
           {:ok, atom()} | {:error, atom()}
-  def ensure_emotion_allowed(community_slug, scope, thread, emotion) do
+  def allow_emotion(community_slug, scope, thread, emotion) do
     thread_key = thread_key(scope, thread)
 
     case emotion_allowed?(community_slug, scope, thread, emotion) do
@@ -157,6 +124,19 @@ defmodule GroupherServer.CMS.CanCan.Communities do
   end
 
   defp community_override(_, _thread_key), do: nil
+
+  defp emotion_allowed?(community_slug, scope, thread, emotion) do
+    emotion in allowed_emotions(community_slug, scope, thread)
+  end
+
+  defp thread_visible?(community, thread) do
+    thread_key = normalize_thread(thread)
+
+    case dashboard_enable(community) do
+      nil -> true
+      enable -> Map.get(enable, thread_key, true)
+    end
+  end
 
   defp thread_key(:article, thread), do: normalize_thread(thread)
   defp thread_key(:comment, thread), do: :"#{normalize_thread(thread)}_comment"

--- a/backend/main/lib/groupher_server/cms/can_can/communities.ex
+++ b/backend/main/lib/groupher_server/cms/can_can/communities.ex
@@ -34,7 +34,7 @@ defmodule GroupherServer.CMS.CanCan.Communities do
       {:error, :emotion_not_allowed}
   """
 
-  import Helper.Utils, only: [get_config: 2]
+  import Helper.Utils, only: [get_config: 2, done: 1]
 
   alias GroupherServer.CMS.FrontDesk
 
@@ -59,6 +59,17 @@ defmodule GroupherServer.CMS.CanCan.Communities do
     end
   end
 
+  @spec ensure_thread_visible(map() | String.t() | nil, atom() | String.t()) ::
+          {:ok, atom()} | {:error, atom()}
+  def ensure_thread_visible(community, thread) do
+    thread_key = normalize_thread(thread)
+
+    case thread_visible?(community, thread_key) do
+      true -> done(thread_key)
+      false -> {:error, :thread_not_visible}
+    end
+  end
+
   @spec thread_mutable?(map() | String.t() | nil, atom() | String.t()) :: boolean()
   def thread_mutable?(community, thread) do
     thread_visible?(community, thread) and not community_frozen?(community)
@@ -78,10 +89,12 @@ defmodule GroupherServer.CMS.CanCan.Communities do
   end
 
   @spec ensure_emotion_allowed(String.t() | nil, scope(), atom() | String.t(), atom()) ::
-          :ok | {:error, atom()}
+          {:ok, atom()} | {:error, atom()}
   def ensure_emotion_allowed(community_slug, scope, thread, emotion) do
+    thread_key = thread_key(scope, thread)
+
     case emotion_allowed?(community_slug, scope, thread, emotion) do
-      true -> :ok
+      true -> done(thread_key)
       false -> {:error, :emotion_not_allowed}
     end
   end
@@ -114,6 +127,10 @@ defmodule GroupherServer.CMS.CanCan.Communities do
   defp dashboard_enable(nil), do: nil
 
   defp dashboard_enable(%{dashboard: %{enable: enable}}), do: enable
+
+  defp dashboard_enable(%{community: community_slug}) when is_binary(community_slug) do
+    dashboard_enable(community_slug)
+  end
 
   defp dashboard_enable(community_slug) when is_binary(community_slug) do
     case FrontDesk.community(community_slug) do

--- a/backend/main/lib/groupher_server/cms/comments/emotion.ex
+++ b/backend/main/lib/groupher_server/cms/comments/emotion.ex
@@ -33,7 +33,7 @@ defmodule GroupherServer.CMS.Comments.Emotion do
   def set(comment_id, emotion, %User{} = user) do
     with {:ok, comment} <- FrontDesk.comment(comment_id) do
       with {:ok, article} <- FrontDesk.article_of(comment),
-           :ok <-
+           {:ok, _thread_key} <-
              CanCan.ensure_emotion_allowed(
                article.community_slug,
                :comment,
@@ -70,7 +70,7 @@ defmodule GroupherServer.CMS.Comments.Emotion do
   def undo(comment_id, emotion, %User{} = user) do
     with {:ok, comment} <- FrontDesk.comment(comment_id) do
       with {:ok, article} <- FrontDesk.article_of(comment),
-           :ok <-
+           {:ok, _thread_key} <-
              CanCan.ensure_emotion_allowed(
                article.community_slug,
                :comment,

--- a/backend/main/lib/groupher_server/cms/comments/emotion.ex
+++ b/backend/main/lib/groupher_server/cms/comments/emotion.ex
@@ -34,7 +34,7 @@ defmodule GroupherServer.CMS.Comments.Emotion do
     with {:ok, comment} <- FrontDesk.comment(comment_id) do
       with {:ok, article} <- FrontDesk.article_of(comment),
            {:ok, _thread_key} <-
-             CanCan.ensure_emotion_allowed(
+             CanCan.allow_emotion(
                article.community_slug,
                :comment,
                comment.thread,
@@ -71,7 +71,7 @@ defmodule GroupherServer.CMS.Comments.Emotion do
     with {:ok, comment} <- FrontDesk.comment(comment_id) do
       with {:ok, article} <- FrontDesk.article_of(comment),
            {:ok, _thread_key} <-
-             CanCan.ensure_emotion_allowed(
+             CanCan.allow_emotion(
                article.community_slug,
                :comment,
                comment.thread,

--- a/backend/main/lib/groupher_server/cms/model/metrics/dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/model/metrics/dashboard.ex
@@ -23,6 +23,7 @@ defmodule GroupherServer.CMS.Model.Metrics.Dashboard do
   def macro_schema(:enable) do
     [
       [:post, :boolean, true],
+      [:blog, :boolean, true],
       [:kanban, :boolean, true],
       [:changelog, :boolean, true],
       # doc

--- a/backend/main/test/groupher_server/cms/can_can/communities_test.exs
+++ b/backend/main/test/groupher_server/cms/can_can/communities_test.exs
@@ -15,9 +15,10 @@ defmodule GroupherServer.Test.CMS.CanCan.Communities do
 
   describe "[emotion policy]" do
     test "falls back to default thread emotions when community has no override", ~m(community)a do
-      assert CanCan.emotion_allowed?(community.slug, :comment, :post, :beer)
-      assert CanCan.emotion_allowed?(community.slug, :article, :post, :upvote)
-      refute CanCan.emotion_allowed?(community.slug, :comment, :post, :upvote)
+      assert {:ok, :post_comment} = CanCan.allow_emotion(community.slug, :comment, :post, :beer)
+      assert {:ok, :post} = CanCan.allow_emotion(community.slug, :article, :post, :upvote)
+      assert {:error, :emotion_not_allowed} =
+               CanCan.allow_emotion(community.slug, :comment, :post, :upvote)
     end
 
     test "reads community dashboard override for comment thread emotions", ~m(community)a do
@@ -26,8 +27,11 @@ defmodule GroupherServer.Test.CMS.CanCan.Communities do
           post_comment: [:heart]
         })
 
-      refute CanCan.emotion_allowed?(community.slug, :comment, :post, :beer)
-      assert CanCan.emotion_allowed?(community.slug, :comment, :post, :heart)
+      assert {:error, :emotion_not_allowed} =
+               CanCan.allow_emotion(community.slug, :comment, :post, :beer)
+
+      assert {:ok, :post_comment} =
+               CanCan.allow_emotion(community.slug, :comment, :post, :heart)
     end
 
     test "reads community dashboard override for article thread emotions", ~m(community)a do
@@ -36,26 +40,29 @@ defmodule GroupherServer.Test.CMS.CanCan.Communities do
           post: [:heart]
         })
 
-      refute CanCan.emotion_allowed?(community.slug, :article, :post, :beer)
-      assert CanCan.emotion_allowed?(community.slug, :article, :post, :heart)
+      assert {:error, :emotion_not_allowed} =
+               CanCan.allow_emotion(community.slug, :article, :post, :beer)
+
+      assert {:ok, :post} = CanCan.allow_emotion(community.slug, :article, :post, :heart)
     end
 
     test "returns false for unsupported emotion keys", ~m(community)a do
-      refute CanCan.emotion_allowed?(community.slug, :comment, :post, :not_exist)
-      refute CanCan.emotion_allowed?(community.slug, :article, :post, :not_exist)
-    end
-
-    test "ensure_emotion_allowed returns done format for allowed emotions", ~m(community)a do
-      assert {:ok, :post_comment} =
-               CanCan.ensure_emotion_allowed(community.slug, :comment, :post, :beer)
-
-      assert {:ok, :post} =
-               CanCan.ensure_emotion_allowed(community.slug, :article, :post, :upvote)
-    end
-
-    test "ensure_emotion_allowed returns cancan error key for disallowed emotions", ~m(community)a do
       assert {:error, :emotion_not_allowed} =
-               CanCan.ensure_emotion_allowed(community.slug, :comment, :post, :upvote)
+               CanCan.allow_emotion(community.slug, :comment, :post, :not_exist)
+
+      assert {:error, :emotion_not_allowed} =
+               CanCan.allow_emotion(community.slug, :article, :post, :not_exist)
+    end
+
+    test "allow_emotion returns done format for allowed emotions", ~m(community)a do
+      assert {:ok, :post_comment} = CanCan.allow_emotion(community.slug, :comment, :post, :beer)
+
+      assert {:ok, :post} = CanCan.allow_emotion(community.slug, :article, :post, :upvote)
+    end
+
+    test "allow_emotion returns cancan error key for disallowed emotions", ~m(community)a do
+      assert {:error, :emotion_not_allowed} =
+               CanCan.allow_emotion(community.slug, :comment, :post, :upvote)
 
       {:ok, _} =
         CMS.Communities.update_dashboard(community, :thread_emotions, %{
@@ -63,23 +70,23 @@ defmodule GroupherServer.Test.CMS.CanCan.Communities do
         })
 
       assert {:error, :emotion_not_allowed} =
-               CanCan.ensure_emotion_allowed(community.slug, :comment, :post, :beer)
+               CanCan.allow_emotion(community.slug, :comment, :post, :beer)
     end
   end
 
   describe "[thread visibility policy]" do
-    test "ensure_thread_visible returns thread in done format when enabled", ~m(community)a do
-      assert {:ok, :post} = CanCan.ensure_thread_visible(community.slug, :post)
+    test "allow_thread returns thread in done format when enabled", ~m(community)a do
+      assert {:ok, :post} = CanCan.allow_thread(community.slug, :post)
     end
 
-    test "ensure_thread_visible returns cancan error key when disabled", ~m(community)a do
+    test "allow_thread returns cancan error key when disabled", ~m(community)a do
       {:ok, _} =
         CMS.Communities.update_dashboard(community, :enable, %{
           post: false
         })
 
       assert {:error, :thread_not_visible} =
-               CanCan.ensure_thread_visible(community.slug, :post)
+               CanCan.allow_thread(community.slug, :post)
     end
   end
 end

--- a/backend/main/test/groupher_server/cms/can_can/communities_test.exs
+++ b/backend/main/test/groupher_server/cms/can_can/communities_test.exs
@@ -45,9 +45,12 @@ defmodule GroupherServer.Test.CMS.CanCan.Communities do
       refute CanCan.emotion_allowed?(community.slug, :article, :post, :not_exist)
     end
 
-    test "ensure_emotion_allowed returns :ok for allowed emotions", ~m(community)a do
-      assert :ok = CanCan.ensure_emotion_allowed(community.slug, :comment, :post, :beer)
-      assert :ok = CanCan.ensure_emotion_allowed(community.slug, :article, :post, :upvote)
+    test "ensure_emotion_allowed returns done format for allowed emotions", ~m(community)a do
+      assert {:ok, :post_comment} =
+               CanCan.ensure_emotion_allowed(community.slug, :comment, :post, :beer)
+
+      assert {:ok, :post} =
+               CanCan.ensure_emotion_allowed(community.slug, :article, :post, :upvote)
     end
 
     test "ensure_emotion_allowed returns cancan error key for disallowed emotions", ~m(community)a do
@@ -61,6 +64,22 @@ defmodule GroupherServer.Test.CMS.CanCan.Communities do
 
       assert {:error, :emotion_not_allowed} =
                CanCan.ensure_emotion_allowed(community.slug, :comment, :post, :beer)
+    end
+  end
+
+  describe "[thread visibility policy]" do
+    test "ensure_thread_visible returns thread in done format when enabled", ~m(community)a do
+      assert {:ok, :post} = CanCan.ensure_thread_visible(community.slug, :post)
+    end
+
+    test "ensure_thread_visible returns cancan error key when disabled", ~m(community)a do
+      {:ok, _} =
+        CMS.Communities.update_dashboard(community, :enable, %{
+          post: false
+        })
+
+      assert {:error, :thread_not_visible} =
+               CanCan.ensure_thread_visible(community.slug, :post)
     end
   end
 end

--- a/backend/main/test/groupher_server_web/query/cms/articles/list/paged_blogs_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/list/paged_blogs_test.exs
@@ -167,6 +167,19 @@ defmodule GroupherServer.Test.Query.PagedArticles.PagedBlogs do
       assert exist_in?(%{id: to_string(community.id)}, blog["communities"])
     end
 
+    test "returns cancan error when community blog thread is disabled",
+         ~m(guest_conn community)a do
+      {:ok, _} =
+        CMS.Communities.update_dashboard(community, :enable, %{
+          blog: false
+        })
+
+      variables = %{filter: %{page: 1, size: 10, community: community.slug}}
+
+      assert guest_conn
+             |> query_error?(Schema.q(:paged_articles, :blog), variables, ecode(:thread_not_visible))
+    end
+
     test "request large size fails", ~m(guest_conn)a do
       variables = %{filter: %{page: 1, size: 200}}
 

--- a/backend/main/test/groupher_server_web/query/cms/articles/list/paged_changelogs_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/list/paged_changelogs_test.exs
@@ -172,6 +172,19 @@ defmodule GroupherServer.Test.Query.PagedArticles.PagedChangelogs do
       assert exist_in?(%{id: to_string(community.id)}, changelog["communities"])
     end
 
+    test "returns cancan error when community changelog thread is disabled",
+         ~m(guest_conn community)a do
+      {:ok, _} =
+        CMS.Communities.update_dashboard(community, :enable, %{
+          changelog: false
+        })
+
+      variables = %{filter: %{page: 1, size: 10, community: community.slug}}
+
+      assert guest_conn
+             |> query_error?(Schema.q(:paged_articles, :changelog), variables, ecode(:thread_not_visible))
+    end
+
     test "request large size fails", ~m(guest_conn)a do
       variables = %{filter: %{page: 1, size: 200}}
 

--- a/backend/main/test/groupher_server_web/query/cms/articles/list/paged_docs_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/list/paged_docs_test.exs
@@ -166,6 +166,19 @@ defmodule GroupherServer.Test.Query.PagedArticles.PagedDocs do
       assert exist_in?(%{id: to_string(community.id)}, doc["communities"])
     end
 
+    test "returns cancan error when community doc thread is disabled",
+         ~m(guest_conn community)a do
+      {:ok, _} =
+        CMS.Communities.update_dashboard(community, :enable, %{
+          doc: false
+        })
+
+      variables = %{filter: %{page: 1, size: 10, community: community.slug}}
+
+      assert guest_conn
+             |> query_error?(Schema.q(:paged_articles, :doc), variables, ecode(:thread_not_visible))
+    end
+
     test "request large size fails", ~m(guest_conn)a do
       variables = %{filter: %{page: 1, size: 200}}
 

--- a/backend/main/test/groupher_server_web/query/cms/articles/list/paged_posts_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/list/paged_posts_test.exs
@@ -201,6 +201,19 @@ defmodule GroupherServer.Test.Query.PagedArticles.PagedPosts do
       assert exist_in?(%{id: to_string(community.id)}, post["communities"])
     end
 
+    test "returns cancan error when community post thread is disabled",
+         ~m(guest_conn community)a do
+      {:ok, _} =
+        CMS.Communities.update_dashboard(community, :enable, %{
+          post: false
+        })
+
+      variables = %{filter: %{page: 1, size: 10, community: community.slug}}
+
+      assert guest_conn
+             |> query_error?(Schema.q(:paged_articles, :post), variables, ecode(:thread_not_visible))
+    end
+
     test "request large size fails", ~m(guest_conn)a do
       variables = %{filter: %{page: 1, size: 200}}
 

--- a/backend/main/test/groupher_server_web/query/cms/articles/read/blog_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/read/blog_test.exs
@@ -70,4 +70,18 @@ defmodule GroupherServer.Test.Query.Articles.Blog do
     assert results |> get_in(["meta", "illegalReason"]) == ["some-reason"]
     assert results |> get_in(["meta", "illegalWords"]) == ["some-word"]
   end
+
+  test "returns cancan error when blog thread is disabled", ~m(guest_conn community blog_attrs user)a do
+    {:ok, blog} = CMS.Articles.create(community, :blog, blog_attrs, user)
+
+    {:ok, _} =
+      CMS.Communities.update_dashboard(community, :enable, %{
+        blog: false
+      })
+
+    variables = %{article: %{inner_id: blog.inner_id, community: blog.community_slug}}
+
+    assert guest_conn
+           |> query_error?(Schema.q(:article, :blog), variables, ecode(:thread_not_visible))
+  end
 end

--- a/backend/main/test/groupher_server_web/query/cms/articles/read/changelog_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/read/changelog_test.exs
@@ -70,4 +70,19 @@ defmodule GroupherServer.Test.Query.Articles.Changelog do
     assert results |> get_in(["meta", "illegalReason"]) == ["some-reason"]
     assert results |> get_in(["meta", "illegalWords"]) == ["some-word"]
   end
+
+  test "returns cancan error when changelog thread is disabled",
+       ~m(guest_conn community changelog_attrs user)a do
+    {:ok, changelog} = CMS.Articles.create(community, :changelog, changelog_attrs, user)
+
+    {:ok, _} =
+      CMS.Communities.update_dashboard(community, :enable, %{
+        changelog: false
+      })
+
+    variables = %{article: %{inner_id: changelog.inner_id, community: changelog.community_slug}}
+
+    assert guest_conn
+           |> query_error?(Schema.q(:article, :changelog), variables, ecode(:thread_not_visible))
+  end
 end

--- a/backend/main/test/groupher_server_web/query/cms/articles/read/doc_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/read/doc_test.exs
@@ -70,4 +70,18 @@ defmodule GroupherServer.Test.Query.Articles.Doc do
     assert results |> get_in(["meta", "illegalReason"]) == ["some-reason"]
     assert results |> get_in(["meta", "illegalWords"]) == ["some-word"]
   end
+
+  test "returns cancan error when doc thread is disabled", ~m(guest_conn community doc_attrs user)a do
+    {:ok, doc} = CMS.Articles.create(community, :doc, doc_attrs, user)
+
+    {:ok, _} =
+      CMS.Communities.update_dashboard(community, :enable, %{
+        doc: false
+      })
+
+    variables = %{article: %{inner_id: doc.inner_id, community: doc.community_slug}}
+
+    assert guest_conn
+           |> query_error?(Schema.q(:article, :doc), variables, ecode(:thread_not_visible))
+  end
 end

--- a/backend/main/test/groupher_server_web/query/cms/articles/read/post_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/articles/read/post_test.exs
@@ -70,4 +70,18 @@ defmodule GroupherServer.Test.Query.Articles.Post do
     assert results |> get_in(["meta", "illegalReason"]) == ["some-reason"]
     assert results |> get_in(["meta", "illegalWords"]) == ["some-word"]
   end
+
+  test "returns cancan error when post thread is disabled", ~m(guest_conn community post_attrs user)a do
+    {:ok, post} = CMS.Articles.create(community, :post, post_attrs, user)
+
+    {:ok, _} =
+      CMS.Communities.update_dashboard(community, :enable, %{
+        post: false
+      })
+
+    variables = %{article: %{inner_id: post.inner_id, community: post.community_slug}}
+
+    assert guest_conn
+           |> query_error?(Schema.q(:article, :post), variables, ecode(:thread_not_visible))
+  end
 end

--- a/backend/main/test/test_helper.exs
+++ b/backend/main/test/test_helper.exs
@@ -1,4 +1,11 @@
-ExUnit.configure(exclude: :later, trace: false, formatters: [ExUnit.CLIFormatter, ExUnitNotifier])
+formatters =
+  case {System.get_env("CI"), :os.type()} do
+    {"true", _} -> [ExUnit.CLIFormatter]
+    {_, {:unix, :darwin}} -> [ExUnit.CLIFormatter, ExUnitNotifier]
+    _ -> [ExUnit.CLIFormatter]
+  end
+
+ExUnit.configure(exclude: :later, trace: false, formatters: formatters)
 ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(GroupherServer.Repo, :manual)


### PR DESCRIPTION
## Summary
- add `CanCan.ensure_thread_visible/2` and apply it to CMS article read and paged list flows
- standardize CanCan public `ensure_*` helpers to return done-style tuples instead of mixing `:ok` with error tuples
- add coverage for disabled thread behavior across post, blog, doc, and changelog read/list GraphQL queries
- extend CanCan community tests for thread visibility and done-format emotion checks

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces dashboard thread visibility for article reads and paged lists, returning `thread_not_visible` when disabled. Standardizes `CanCan` to `allow_thread/2` and `allow_emotion/4` with done-style results.

- **Bug Fixes**
  - Gate article reads and paged lists with `CanCan.allow_thread/2`.
  - Update article/comment reactions to use `CanCan.allow_emotion/4` returning `{:ok, key}`.
  - Include `blog` in dashboard `enable` schema so blog visibility is applied.
  - Use `ExUnitNotifier` only on macOS; never on CI.

- **Refactors**
  - Replace boolean/ensure helpers with `allow_thread/2` and `allow_emotion/4` that return `{:ok, key}` or a CanCan error.
  - Allow `dashboard_enable/1` to accept `%{community: slug}`.

<sup>Written for commit a8773f621603ad8ca9a016290f22a491f76f4443. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced thread visibility for article listings and reads; content from disabled threads (blogs, changelogs, docs, posts) now returns authorization errors.
  * Reaction/comment emotion actions now respect community permission settings and may be blocked when disallowed.

* **Tests**
  * Added coverage asserting access and reaction/emotion blocking when community threads are disabled.

* **Chores**
  * Improved test runner formatter selection for CI and local environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->