### PR TITLE
fix(fe): emotion adopt for new schema

### DIFF
--- a/backend/main/scripts/reset_comment_emotions.exs
+++ b/backend/main/scripts/reset_comment_emotions.exs
@@ -1,0 +1,124 @@
+import Ecto.Query, warn: false
+
+import GroupherServer.Support.Factory, only: [db_insert_multi: 2]
+
+alias GroupherServer.{CMS, Repo}
+alias GroupherServer.CMS.Model.{Comment, CommentUserEmotion}
+alias Helper.ORM
+
+supported_comment_emotions =
+  Application.compile_env(:groupher_server, :article, [])
+  |> Keyword.get(:comment_emotions, [])
+
+default_emotions = GroupherServer.CMS.Model.Embeds.CommentEmotion.default_emotions()
+
+comment_id =
+  case System.argv() do
+    [id | _] ->
+      if id == "--" or String.starts_with?(id, "-") do
+        raise "Invalid comment id: '#{id}'."
+      end
+
+      case Integer.parse(id) do
+        {value, ""} when value > 0 -> value
+        _ -> raise "Invalid comment id: '#{id}'. Use a positive integer."
+      end
+
+    _ ->
+      raise "Usage: mix run scripts/reset_comment_emotions.exs -- <comment_id>"
+  end
+
+with {:ok, target_comment} <- CMS.Comments.fetch_comment(comment_id) do
+  IO.puts("Resetting all comment emotions across communities ...")
+
+  {deleted_count, _} =
+    Repo.delete_all(from(c in CommentUserEmotion), timeout: 300_000)
+
+  comments =
+    Repo.all(
+      from(c in Comment,
+        order_by: [asc: c.id]
+      ),
+      timeout: 300_000
+    )
+
+  reset_count =
+    Enum.reduce(comments, 0, fn comment, acc ->
+      {:ok, updated_comment} = ORM.update_embed(comment, :emotions, default_emotions)
+
+      if updated_comment.reply_to_id do
+        {:ok, _} = CMS.FrontDesk.sync_embed_replies(updated_comment)
+      end
+
+      acc + 1
+    end)
+
+  {:ok, article} = CMS.FrontDesk.article_of(target_comment)
+  {:ok, thread} = CMS.FrontDesk.thread_of(target_comment)
+
+  allowed_emotions =
+    Enum.filter(supported_comment_emotions, fn emotion ->
+      match?(
+        {:ok, _},
+        CMS.CanCan.allow_emotion(article.community_slug, :comment, thread, emotion)
+      )
+    end)
+
+  if allowed_emotions == [] do
+    raise "No allowed comment emotions found for comment ##{comment_id}."
+  end
+
+  seed_user_count = Enum.random(4..7)
+  {:ok, users} = db_insert_multi(:user, seed_user_count)
+
+  applied =
+    Enum.reduce(users, [], fn user, acc ->
+      picks =
+        allowed_emotions
+        |> Enum.shuffle()
+        |> Enum.take(Enum.random(1..min(3, length(allowed_emotions))))
+
+      Enum.reduce(picks, acc, fn emotion, inner_acc ->
+        case CMS.Comments.emotion_to_comment(comment_id, emotion, user) do
+          {:ok, _comment} ->
+            [{user.login, emotion} | inner_acc]
+
+          {:error, reason} ->
+            raise "Failed to seed #{emotion} for #{user.login}: #{inspect(reason)}"
+        end
+      end)
+    end)
+    |> Enum.reverse()
+
+  {:ok, seeded_comment} = CMS.Comments.one_comment(comment_id)
+
+  IO.puts("✓ Comment emotions reset complete")
+  IO.puts("  deleted emotion rows: #{deleted_count}")
+  IO.puts("  reset comments: #{reset_count}")
+  IO.puts("  target comment id: #{comment_id}")
+  IO.puts("  article community: #{article.community_slug}")
+  IO.puts("  thread: #{thread}")
+  IO.puts("  allowed emotions: #{Enum.join(Enum.map(allowed_emotions, &to_string/1), ", ")}")
+  IO.puts("  seeded users: #{seed_user_count}")
+  IO.puts("  applied reactions: #{length(applied)}")
+
+  Enum.each(applied, fn {login, emotion} ->
+    IO.puts("    - #{login}: #{emotion}")
+  end)
+
+  IO.puts("  resulting cached emotions:")
+
+  seeded_comment.emotions
+  |> Map.from_struct()
+  |> Enum.reject(fn {key, _value} ->
+    key_str = Atom.to_string(key)
+    String.starts_with?(key_str, "viewer_has_")
+  end)
+  |> Enum.each(fn {key, value} ->
+    IO.puts("    #{key}: #{inspect(value)}")
+  end)
+else
+  {:error, reason} ->
+    IO.puts("✗ Failed to reset comment emotions: #{inspect(reason)}")
+    System.halt(1)
+end

--- a/backend/main/test/groupher_server/cms/comments/emotion/blog_comment_emotions_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/emotion/blog_comment_emotions_test.exs
@@ -16,7 +16,7 @@ defmodule GroupherServer.Test.CMS.Comments.BlogCommentEmotions do
   end
 
   describe "[emotion in paged article comment]" do
-    test "login user should got viewer has emotioned status", ~m(community blog user)a do
+    test "login user should get viewer reacted status", ~m(community blog user)a do
       total_count = 0
       page_number = 10
       page_size = 20
@@ -65,7 +65,7 @@ defmodule GroupherServer.Test.CMS.Comments.BlogCommentEmotions do
       assert target.emotions.viewer_has_popcorned
     end
 
-    test "emotioned comment should return valid viewer_has status",
+    test "reacted comment should return valid viewer_has status",
          ~m(community blog user user2)a do
       total_count = 3
 

--- a/backend/main/test/groupher_server/cms/comments/emotion/changelog_comment_emotions_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/emotion/changelog_comment_emotions_test.exs
@@ -16,7 +16,7 @@ defmodule GroupherServer.Test.CMS.Comments.ChangelogCommentEmotions do
   end
 
   describe "[emotion in paged article comment]" do
-    test "login user should got viewer has emotioned status", ~m(community changelog user)a do
+    test "login user should get viewer reacted status", ~m(community changelog user)a do
       total_count = 0
       page_number = 10
       page_size = 20
@@ -65,7 +65,7 @@ defmodule GroupherServer.Test.CMS.Comments.ChangelogCommentEmotions do
       assert target.emotions.viewer_has_popcorned
     end
 
-    test "emotioned comment should return valid viewer_has status",
+    test "reacted comment should return valid viewer_has status",
          ~m(community changelog user user2)a do
       total_count = 3
 

--- a/backend/main/test/groupher_server/cms/comments/emotion/doc_comment_emotions_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/emotion/doc_comment_emotions_test.exs
@@ -16,7 +16,7 @@ defmodule GroupherServer.Test.CMS.Comments.DocCommentEmotions do
   end
 
   describe "[emotion in paged article comment]" do
-    test "login user should got viewer has emotioned status", ~m(community doc user)a do
+    test "login user should get viewer reacted status", ~m(community doc user)a do
       total_count = 0
       page_number = 10
       page_size = 20
@@ -65,7 +65,7 @@ defmodule GroupherServer.Test.CMS.Comments.DocCommentEmotions do
       assert target.emotions.viewer_has_popcorned
     end
 
-    test "emotioned comment should return valid viewer_has status",
+    test "reacted comment should return valid viewer_has status",
          ~m(community doc user user2)a do
       total_count = 3
 

--- a/backend/main/test/groupher_server/cms/comments/emotion/post_comment_emotions_test.exs
+++ b/backend/main/test/groupher_server/cms/comments/emotion/post_comment_emotions_test.exs
@@ -16,7 +16,7 @@ defmodule GroupherServer.Test.CMS.Comments.PostCommentEmotions do
   end
 
   describe "[emotion in paged article comment]" do
-    test "login user should got viewer has emotion status", ~m(community post user)a do
+    test "login user should get viewer reacted status", ~m(community post user)a do
       total_count = 0
       page_number = 10
       page_size = 20
@@ -59,7 +59,7 @@ defmodule GroupherServer.Test.CMS.Comments.PostCommentEmotions do
       assert target.emotions.viewer_has_popcorned
     end
 
-    test "emotion comment should return valid viewer_has status",
+    test "reacted comment should return valid viewer_has status",
          ~m(community post user user2)a do
       total_count = 3
 

--- a/frontend/core/constant/emotion.ts
+++ b/frontend/core/constant/emotion.ts
@@ -2,6 +2,8 @@ const EMOTION = {
   DOWNVOTE: 'downvote',
   BEER: 'beer',
   HEART: 'heart',
+  BICEPS: 'biceps',
+  ORZ: 'orz',
   CONFUSED: 'confused',
   POPCORN: 'popcorn',
   PILL: 'pill',

--- a/frontend/core/hooks/usePagedPosts/useFetchPagedPosts.ts
+++ b/frontend/core/hooks/usePagedPosts/useFetchPagedPosts.ts
@@ -23,6 +23,24 @@ export default function useFetchPagedPosts() {
   const requestSeq = useRef(0)
   const loadingState = TYPE.RES_STATE.LOADING as TResState
   const doneState = TYPE.RES_STATE.DONE as TResState
+  const page = searchParams.get(URL_PARAM.PAGE)
+  const tag = searchParams.get(URL_PARAM.TAG)
+  const cat = searchParams.get(URL_PARAM.CAT)
+  const state = searchParams.get(URL_PARAM.STATE)
+  const order = searchParams.get(URL_PARAM.ORDER)
+  // Do not depend on the useSearchParams() object identity directly here.
+  // Opening/closing the post preview drawer changes the route tree and can
+  // produce a new searchParams object even when the actual list filters stay
+  // exactly the same. If the effect below watched searchParams itself, each
+  // preview open/close cycle would trigger an unnecessary posts refetch.
+  const requestKey = JSON.stringify({
+    slug,
+    page: page || '1',
+    tag: tag || '',
+    cat: cat || '',
+    state: state || '',
+    order: order || '',
+  })
 
   const refreshPagedPosts = async (payload: TRefreshPayload = {}) => {
     const seq = ++requestSeq.current
@@ -33,10 +51,10 @@ export default function useFetchPagedPosts() {
       const pagedPosts = await fetchPagedPosts({
         community: slug,
         page: payload.page,
-        tag: searchParams.get(URL_PARAM.TAG),
-        cat: searchParams.get(URL_PARAM.CAT),
-        state: searchParams.get(URL_PARAM.STATE),
-        order: searchParams.get(URL_PARAM.ORDER),
+        tag,
+        cat,
+        state,
+        order,
       })
 
       if (seq !== requestSeq.current || !pagedPosts) return
@@ -53,7 +71,7 @@ export default function useFetchPagedPosts() {
     }
   }
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: searchParams identity is the route-change trigger here
+  // biome-ignore lint/correctness/useExhaustiveDependencies: requestKey narrows refreshes to real post-list filter changes and avoids duplicate fetches during preview drawer open/close route transitions.
   useEffect(() => {
     if (!initialSyncSkipped.current) {
       initialSyncSkipped.current = true
@@ -61,13 +79,13 @@ export default function useFetchPagedPosts() {
     }
 
     void refreshPagedPosts()
-  }, [searchParams, slug])
+  }, [requestKey])
 
   useEvent<TRefreshPayload>(
     EVENT.REFRESH_ARTICLES,
     (_msg, payload) => {
       void refreshPagedPosts({ page: payload?.page ?? 1 })
     },
-    [searchParams, slug],
+    [requestKey],
   )
 }

--- a/frontend/core/schemas/fragments/base.ts
+++ b/frontend/core/schemas/fragments/base.ts
@@ -1,7 +1,4 @@
-import { flatten, values } from 'ramda'
 import { gql } from 'urql'
-
-import EMOTION from '~/const/emotion'
 import { titleCase } from '~/fmt'
 
 export const community = `
@@ -207,15 +204,16 @@ export const userContributes = `
   totalCount
 `
 
-export const emotionQuery = flatten(
-  values(EMOTION).map((emotion) => {
-    return [
-      `${emotion}Count`,
-      `viewerHas${titleCase(emotion)}ed`,
-      `latest${titleCase(emotion)}Users { login nickname }`,
-    ]
-  }),
-).join(' ')
+export const emotionQuery = `
+  type
+  count
+  viewerHasReacted
+  latestUsers {
+    login
+    nickname
+    avatar
+  }
+`
 
 // comment
 

--- a/frontend/core/spec/article.d.ts
+++ b/frontend/core/spec/article.d.ts
@@ -146,7 +146,7 @@ export type TComment = {
   upvotesCount?: number
   viewerHasUpvoted?: boolean
   isArticleAuthor?: boolean
-  emotions?: TEmotion
+  emotions?: TEmotion[]
   meta?: {
     isArticleAuthorUpvoted?: boolean
     isReplyToOthers?: boolean

--- a/frontend/core/spec/emotion.d.ts
+++ b/frontend/core/spec/emotion.d.ts
@@ -2,23 +2,12 @@ import type EMOTION from '~/const/emotion'
 import type { TConstValues } from '~/spec'
 import type { TSimpleUser } from './account'
 
-// see https://stackoverflow.com/a/67301712/4050784
-// TODO: move tu utils
-type TTitleCase<T extends string, D extends string = ' '> = string extends T
-  ? never
-  : T extends `${infer F}${D}${infer R}`
-    ? `${Capitalize<F>}${D}${TTitleCase<R, D>}`
-    : Capitalize<T>
-
 export type TEmotionType = TConstValues<typeof EMOTION>
-
-export type TEmotionCountKey = `${TEmotionType}Count`
-export type TEmotionViewerHasKey = `viewerHas${TTitleCase<TEmotionType>}ed`
+export type TEmotionRawType = Uppercase<TEmotionType> | 'UPVOTE'
 
 export type TEmotion = {
-  [key: string]: number | boolean | string | TSimpleUser[]
-  // [key in TEmotionCountKey]: number
-  // [key in TEmotionViewerHasKey]: boolean
-  // [key in TEmotionType]: number
-  // [key in TEmotionViewerHasKey]: boolean
+  type?: TEmotionRawType
+  count?: number
+  viewerHasReacted?: boolean
+  latestUsers?: TSimpleUser[]
 }

--- a/frontend/core/unit/ChangelogThread/ChangelogItem/constant.ts
+++ b/frontend/core/unit/ChangelogThread/ChangelogItem/constant.ts
@@ -1,4 +1,5 @@
 import { COLOR } from '~/const/colors'
+import type { TEmotion } from '~/spec'
 
 export const demoTags = [
   {
@@ -13,39 +14,50 @@ export const demoTags = [
   },
 ]
 
-export const demoEmotion = {
-  beerCount: 2,
-  confusedCount: 0,
-  downvoteCount: 0,
-  heartCount: 0,
-  latestBeerUsers: [
-    {
-      login: 'porter172',
-      nickname: 'Immanuel172',
-      bio: null,
-      shortbio: null,
-      avatar: null,
-    },
-    {
-      login: 'cp_bot',
-      nickname: 'botman',
-      bio: null,
-      shortbio: null,
-      avatar: null,
-    },
-  ],
-  latestConfusedUsers: [],
-  latestDownvoteUsers: [],
-  latestHeartUsers: [],
-  latestPillUsers: [],
-  length: 2,
-  latestPopcornUsers: [],
-  pillCount: 0,
-  popcornCount: 0,
-  viewerHasBeered: false,
-  viewerHasConfuseded: false,
-  viewerHasDownvoteed: false,
-  viewerHasHearted: false,
-  viewerHasPilled: false,
-  viewerHasPopcorned: false,
-}
+export const demoEmotion: TEmotion[] = [
+  {
+    type: 'BEER',
+    count: 2,
+    viewerHasReacted: false,
+    latestUsers: [
+      {
+        login: 'porter172',
+        nickname: 'Immanuel172',
+        bio: null,
+        shortbio: null,
+        avatar: null,
+      },
+      {
+        login: 'cp_bot',
+        nickname: 'botman',
+        bio: null,
+        shortbio: null,
+        avatar: null,
+      },
+    ],
+  },
+  {
+    type: 'DOWNVOTE',
+    count: 0,
+    viewerHasReacted: false,
+    latestUsers: [],
+  },
+  {
+    type: 'HEART',
+    count: 0,
+    viewerHasReacted: false,
+    latestUsers: [],
+  },
+  {
+    type: 'PILL',
+    count: 0,
+    viewerHasReacted: false,
+    latestUsers: [],
+  },
+  {
+    type: 'POPCORN',
+    count: 0,
+    viewerHasReacted: false,
+    latestUsers: [],
+  },
+]

--- a/frontend/core/unit/Comments/Comment/Footer.tsx
+++ b/frontend/core/unit/Comments/Comment/Footer.tsx
@@ -69,9 +69,9 @@ const Footer: FC<TProps> = ({ data, apiMode }) => {
         <EmotionSelector
           isLegal={isLegal}
           emotions={data.emotions}
-          onAction={(name, hasEmotioned) => {
+          onAction={(name, hasReacted) => {
             if (!accountInfo) return authWarn()
-            handleEmotion(data, name, hasEmotioned)
+            handleEmotion(data, name, hasReacted)
           }}
         />
 

--- a/frontend/core/unit/Comments/useLogic/useHelper.ts
+++ b/frontend/core/unit/Comments/useLogic/useHelper.ts
@@ -8,7 +8,7 @@ import type { TEditMode } from '../spec'
 
 type TRet = {
   updateOneComment: (comment: TComment, fields?: Partial<TComment>) => void
-  upvoteEmotion: (comment: TComment, emotion: TEmotion) => void
+  upvoteEmotion: (comment: TComment, emotion: TEmotion[]) => void
   addToReplies: (parentId: TID, replies: TComment[]) => void
   published: () => void
   resetPublish: (mode: TEditMode) => void
@@ -53,9 +53,10 @@ export default function useHelper(): TRet {
     }
   }
 
-  const upvoteEmotion = (comment: TComment, emotion: TEmotion): void => {
+  const upvoteEmotion = (comment: TComment, emotions: TEmotion[]): void => {
     const { id, replyToId } = comment
     const { entries } = comments.pagedComments
+    const nextComments = [...entries]
 
     if (comments.mode === MODE.REPLIES && replyToId) {
       const parentIndex = findIndex(propEq(replyToId, 'id'), entries)
@@ -63,27 +64,21 @@ export default function useHelper(): TRet {
       const parentComment = entries[parentIndex]
       const replyIndex = findIndex(propEq(id, 'id'), parentComment.replies)
       if (replyIndex < 0) return
-      // const replyComment = parentComment.replies[replyIndex]
-
-      console.log('## TODO updateEmotion: ', emotion)
-      // const newEmotions = {
-      //   ...replyComment.emotions,
-      //   ...emotion,
-      // }
-
-      // snap.pagedComments.entries[parentIndex].replies[replyIndex].emotions = {
-      //   ...replyComment.emotions,
-      //   ...emotion,
-      // }
+      const nextReplies = [...(parentComment.replies || [])]
+      nextReplies[replyIndex] = { ...nextReplies[replyIndex], emotions }
+      nextComments[parentIndex] = { ...parentComment, replies: nextReplies }
     } else {
       const index = findIndex(propEq(id, 'id'), entries)
       if (index < 0) return
-      console.log('## TODO updateEmotion: ', emotion)
-      // snap.pagedComments.entries[index].emotions = {
-      //   ...entries[index].emotions,
-      //   ...emotion,
-      // }
+      nextComments[index] = { ...nextComments[index], emotions }
     }
+
+    commentsStore.commit({
+      pagedComments: {
+        ...comments.pagedComments,
+        entries: nextComments,
+      },
+    })
   }
 
   const addToReplies = (parentId: TID, replies: TComment[]): void => {

--- a/frontend/core/unit/Comments/useLogic/useQuery.ts
+++ b/frontend/core/unit/Comments/useLogic/useQuery.ts
@@ -1,10 +1,9 @@
 import { type MutableRefObject, useContext, useEffect, useRef } from 'react'
 import { ANCHOR } from '~/const/dom'
 import { scrollIntoEle } from '~/dom'
-import { titleCase } from '~/fmt'
 import useGraphQLClient from '~/hooks/useGraphQLClient'
 import useViewingArticle from '~/hooks/useViewingArticle'
-import type { TComment, TEmotionType, TID } from '~/spec'
+import type { TComment, TEmotion, TEmotionType, TID } from '~/spec'
 import { StoreContext as CommentsStoreContext } from '~/stores/comments/provider'
 import uid from '~/utils/uid'
 
@@ -22,7 +21,7 @@ export type TRet = {
   onPageChange: (page: number) => void
   onMentionSearch: (name: string) => void
   deleteComment: () => void
-  handleEmotion: (comment: TComment, name: TEmotionType, viewerHasEmotioned: boolean) => void
+  handleEmotion: (comment: TComment, name: TEmotionType, viewerHasReacted: boolean) => void
   handleUpvote: (comment: TComment, viewerHasUpvoted: boolean) => void
   replyComment: () => void
   updateComment: () => void
@@ -215,31 +214,19 @@ export default function useQuery(): TRet {
   const handleEmotion = (
     comment: TComment,
     name: TEmotionType,
-    viewerHasEmotioned: boolean,
+    viewerHasReacted: boolean,
   ): void => {
     const { id } = comment
     const emotion = name.toUpperCase()
+    const nextEmotions = updateEmotionState(comment.emotions || [], name, !viewerHasReacted)
 
-    // comment.emotions
-    if (viewerHasEmotioned) {
-      // instantFresh
-      const emotionInfo = {
-        // @ts-expect-error
-        [`${name}Count`]: comment.emotions[`${name}Count`] - 1,
-        [`viewerHas${titleCase(name)}ed`]: false,
-      }
-      upvoteEmotion(comment, emotionInfo)
+    if (viewerHasReacted) {
+      upvoteEmotion(comment, nextEmotions)
       mutate(S.undoEmotionToComment, { id, emotion }).then(({ undoEmotionToComment }) => {
         upvoteEmotion(undoEmotionToComment, undoEmotionToComment.emotions)
       })
     } else {
-      const emotionInfo = {
-        // @ts-expect-error
-        [`${name}Count`]: comment.emotions[`${name}Count`] + 1,
-        [`viewerHas${titleCase(name)}ed`]: true,
-      }
-      upvoteEmotion(comment, emotionInfo)
-      // instantFresh
+      upvoteEmotion(comment, nextEmotions)
       mutate(S.emotionToComment, { id, emotion }).then(({ emotionToComment }) => {
         upvoteEmotion(emotionToComment, emotionToComment.emotions)
       })
@@ -324,4 +311,37 @@ export default function useQuery(): TRet {
     replyComment,
     updateComment,
   }
+}
+
+const updateEmotionState = (
+  emotions: TEmotion[],
+  name: TEmotionType,
+  nextViewerState: boolean,
+): TEmotion[] => {
+  const emotionType = name.toUpperCase() as TEmotion['type']
+  const index = emotions.findIndex((item) => item.type === emotionType)
+
+  if (index < 0) {
+    return [
+      ...emotions,
+      {
+        type: emotionType,
+        count: nextViewerState ? 1 : 0,
+        viewerHasReacted: nextViewerState,
+        latestUsers: [],
+      },
+    ]
+  }
+
+  return emotions.map((item, itemIndex) => {
+    if (itemIndex !== index) return item
+
+    const count = item.count || 0
+
+    return {
+      ...item,
+      count: nextViewerState ? count + 1 : Math.max(count - 1, 0),
+      viewerHasReacted: nextViewerState,
+    }
+  })
 }

--- a/frontend/core/unit/EmotionSelector/Panel.tsx
+++ b/frontend/core/unit/EmotionSelector/Panel.tsx
@@ -5,13 +5,15 @@ import EMOTION from '~/const/emotion'
 import Img from '~/Img'
 import type { TEmotion, TEmotionType } from '~/spec'
 
-import { isViewerEmotioned } from './helper'
+import { isViewerReacted } from './helper'
 import useSalon, { cn } from './salon/panel'
 
 const Trans = {
   downvote: '踩',
   beer: '啤酒',
   heart: '感谢',
+  biceps: '强',
+  orz: '跪了',
   confused: '狗头',
   popcorn: '吃瓜',
   pill: '药丸',
@@ -19,21 +21,21 @@ const Trans = {
 
 type TProps = {
   emotions: TEmotion[]
-  onAction?: (name: TEmotionType, hasEmotioned: boolean) => void
+  onAction?: (name: TEmotionType, hasReacted: boolean) => void
 }
 
 const EmojiPanel: FC<TProps> = ({ emotions, onAction }) => {
   const s = useSalon()
 
   return (
-    <div className={s.wrapper}>
+      <div className={s.wrapper}>
       {values(EMOTION).map((name) => {
-        const viewerHasEmotioned = isViewerEmotioned(emotions, name)
+        const viewerHasReacted = isViewerReacted(emotions, name)
 
         return (
-          <div className={s.item} key={name} onClick={() => onAction(name, viewerHasEmotioned)}>
+          <div className={s.item} key={name} onClick={() => onAction(name, viewerHasReacted)}>
             <Img className={s.icon} src={`${ICON}/emotion/${name}.png`} noLazy />
-            <div className={cn(s.name, viewerHasEmotioned && s.nameActive)}>{Trans[name]}</div>
+            <div className={cn(s.name, viewerHasReacted && s.nameActive)}>{Trans[name]}</div>
           </div>
         )
       })}

--- a/frontend/core/unit/EmotionSelector/Panel.tsx
+++ b/frontend/core/unit/EmotionSelector/Panel.tsx
@@ -28,7 +28,7 @@ const EmojiPanel: FC<TProps> = ({ emotions, onAction }) => {
   const s = useSalon()
 
   return (
-      <div className={s.wrapper}>
+    <div className={s.wrapper}>
       {values(EMOTION).map((name) => {
         const viewerHasReacted = isViewerReacted(emotions, name)
 

--- a/frontend/core/unit/EmotionSelector/SelectedEmotions/EmotionIcon.tsx
+++ b/frontend/core/unit/EmotionSelector/SelectedEmotions/EmotionIcon.tsx
@@ -9,10 +9,15 @@ type TProps = {
   name: TEmotionType
 }
 
+const EMOTION_ICON: Partial<Record<TEmotionType, string>> = {
+  orz: 'pao',
+}
+
 const EmotionIcon: FC<TProps> = ({ name }) => {
   const s = useSalon()
+  const iconName = EMOTION_ICON[name] || name
 
-  return <Img src={`/icons/emotion/${name}.png`} className={s.icon} noLazy />
+  return <Img src={`/icons/emotion/${iconName}.png`} className={s.icon} noLazy />
 }
 
 export default memo(EmotionIcon)

--- a/frontend/core/unit/EmotionSelector/SelectedEmotions/EmotionUnit.tsx
+++ b/frontend/core/unit/EmotionSelector/SelectedEmotions/EmotionUnit.tsx
@@ -3,7 +3,6 @@
  */
 
 import { type FC, memo } from 'react'
-import { titleCase } from '~/fmt'
 import type { TEmotion, TEmotionType, TSimpleUser } from '~/spec'
 import AnimatedCount from '~/widgets/AnimatedCount'
 import Tooltip from '~/widgets/Tooltip'
@@ -14,16 +13,16 @@ import UsersPanel from './UsersPanel'
 
 type TProps = {
   item: TEmotion
-  onAction?: (name: TEmotionType, hasEmotioned: boolean) => void
+  onAction?: (name: TEmotionType, hasReacted: boolean) => void
 }
 
 const EmotionUnit: FC<TProps> = ({ item, onAction }) => {
   const s = useSalon()
 
   const name = getEmotionName(item)
-  const count = item[`${name}Count`] as number
-  const users = item[`latest${titleCase(name)}Users`] as TSimpleUser[]
-  const hasEmotioned = item[`viewerHas${titleCase(name)}ed`] as boolean
+  const count = item.count || 0
+  const users = (item.latestUsers || []) as TSimpleUser[]
+  const hasReacted = Boolean(item.viewerHasReacted)
 
   return (
     <Tooltip
@@ -31,10 +30,10 @@ const EmotionUnit: FC<TProps> = ({ item, onAction }) => {
       interactive={false}
       noPadding
     >
-      <div className={s.wrapper} onClick={() => onAction(name as TEmotionType, hasEmotioned)}>
+      <div className={s.wrapper} onClick={() => onAction(name as TEmotionType, hasReacted)}>
         <EmotionIcon name={name} />
         <div className={s.count}>
-          <AnimatedCount count={count} size='small' active={hasEmotioned} />
+          <AnimatedCount count={count} size='small' active={hasReacted} />
         </div>
       </div>
     </Tooltip>

--- a/frontend/core/unit/EmotionSelector/SelectedEmotions/UsersPanel.tsx
+++ b/frontend/core/unit/EmotionSelector/SelectedEmotions/UsersPanel.tsx
@@ -16,7 +16,7 @@ type TProps = {
 
 const UsersPanel: FC<TProps> = ({ name, count, users }) => {
   const s = useSalon()
-  const showUnit = users.length > count
+  const showUnit = count > users.length
 
   return (
     <div className={s.wrapper}>

--- a/frontend/core/unit/EmotionSelector/SelectedEmotions/index.tsx
+++ b/frontend/core/unit/EmotionSelector/SelectedEmotions/index.tsx
@@ -11,7 +11,7 @@ import EmotionUnit from './EmotionUnit'
 
 type TProps = {
   emotions: TEmotion[]
-  onAction?: (name: TEmotionType, hasEmotioned: boolean) => void
+  onAction?: (name: TEmotionType, hasReacted: boolean) => void
 }
 
 const SelectedEmotions: FC<TProps> = ({ emotions, onAction }) => {

--- a/frontend/core/unit/EmotionSelector/helper.ts
+++ b/frontend/core/unit/EmotionSelector/helper.ts
@@ -1,37 +1,32 @@
-import { forEach, includes, keys, reject, values } from 'ramda'
+import { find, values } from 'ramda'
 
 import EMOTION from '~/const/emotion'
-import { titleCase } from '~/fmt'
 import type { TEmotion, TEmotionType } from '~/spec'
 
 export const getEmotionName = (item: TEmotion): TEmotionType => {
-  const eCountKey = keys(item)[0] as string
-  return eCountKey.split('Count')[0] as TEmotionType
+  return (item.type || '').toLowerCase() as TEmotionType
 }
 
-export const emotionsCoverter = (selectedEmotions: TEmotion): TEmotion[] => {
-  const converted = []
-  forEach(
-    (emotion) =>
-      converted.push({
-        [`${emotion}Count`]: selectedEmotions[`${emotion}Count`],
-        [`latest${titleCase(emotion)}Users`]: selectedEmotions[`latest${titleCase(emotion)}Users`],
-        [`viewerHas${titleCase(emotion)}ed`]: selectedEmotions[`viewerHas${titleCase(emotion)}ed`],
-      }),
-    values(EMOTION),
-  )
-
-  return reject((e) => includes(0, values(e)), converted)
+export const visibleEmotions = (emotions: TEmotion[] = []): TEmotion[] => {
+  return emotions.filter((emotion) => (emotion.count || 0) > 0)
 }
 
-export const isViewerEmotioned = (emotions: TEmotion[], name: TEmotionType): boolean => {
-  for (let i = 0; i < emotions.length; i += 1) {
-    const emotionUnit = emotions[i]
+export const isViewerReacted = (emotions: TEmotion[], name: TEmotionType): boolean => {
+  const emotion = find((item) => getEmotionName(item) === name, emotions)
+  return Boolean(emotion?.viewerHasReacted)
+}
 
-    if (emotionUnit[`viewerHas${titleCase(name)}ed`]) {
-      return true
-    }
-  }
+export const ensureEmotion = (emotions: TEmotion[] = []): TEmotion[] => {
+  const known = new Set(emotions.map((emotion) => getEmotionName(emotion)))
 
-  return false
+  const missing = values(EMOTION)
+    .filter((emotion) => !known.has(emotion))
+    .map((emotion) => ({
+      type: emotion.toUpperCase() as TEmotion['type'],
+      count: 0,
+      viewerHasReacted: false,
+      latestUsers: [],
+    }))
+
+  return [...emotions, ...missing]
 }

--- a/frontend/core/unit/EmotionSelector/index.tsx
+++ b/frontend/core/unit/EmotionSelector/index.tsx
@@ -8,7 +8,7 @@ import type { TEmotion, TEmotionType } from '~/spec'
 import IconButton from '~/widgets/Buttons/IconButton'
 import Tooltip from '~/widgets/Tooltip'
 
-import { emotionsCoverter } from './helper'
+import { ensureEmotion, visibleEmotions } from './helper'
 import Panel from './Panel'
 import SelectedEmotions from './SelectedEmotions'
 
@@ -16,20 +16,21 @@ import useSalon from './salon'
 
 type TProps = {
   isLegal?: boolean
-  emotions: TEmotion
-  onAction?: (name: TEmotionType, hasEmotioned: boolean) => void
+  emotions?: TEmotion[]
+  onAction?: (name: TEmotionType, hasReacted: boolean) => void
 }
 
 const EmotionSelector: FC<TProps> = ({ onAction = console.log, isLegal = true, emotions }) => {
   const s = useSalon()
-  const validEmotions = emotionsCoverter(emotions)
+  const preparedEmotions = ensureEmotion(emotions)
+  const selectedEmotions = visibleEmotions(preparedEmotions)
 
   return (
     <>
-      <SelectedEmotions emotions={validEmotions} onAction={onAction} />
+      <SelectedEmotions emotions={selectedEmotions} onAction={onAction} />
       {isLegal && (
         <Tooltip
-          content={<Panel emotions={validEmotions} onAction={onAction} />}
+          content={<Panel emotions={preparedEmotions} onAction={onAction} />}
           trigger='click'
           noPadding
         >

--- a/frontend/core/widgets/@Drawer/index.tsx
+++ b/frontend/core/widgets/@Drawer/index.tsx
@@ -42,19 +42,25 @@ export default function Drawer({
 
   const closeTimerRef = useRef<number | null>(null)
   const didCloseRef = useRef(false)
+  const didUnlockRef = useRef(false)
 
   const { rightOffset, fromContentEdge } = useDrawerOffset()
   const s = useSalon({ visible, closing, type, rightOffset, fromContentEdge })
 
   useEffect(() => {
     lockPage()
+    didUnlockRef.current = false
 
     return () => {
       if (closeTimerRef.current) {
         window.clearTimeout(closeTimerRef.current)
         closeTimerRef.current = null
       }
-      unlockPage()
+
+      if (!didUnlockRef.current) {
+        unlockPage()
+        didUnlockRef.current = true
+      }
     }
   }, [])
 
@@ -78,6 +84,12 @@ export default function Drawer({
   const commitRouteBack = useCallback(() => {
     if (didCloseRef.current) return
     didCloseRef.current = true
+
+    if (!didUnlockRef.current) {
+      unlockPage()
+      didUnlockRef.current = true
+    }
+
     router.back()
   }, [router])
 

--- a/frontend/main/next-env.d.ts
+++ b/frontend/main/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/main/src/app/[community]/_preview/PreviewHost.tsx
+++ b/frontend/main/src/app/[community]/_preview/PreviewHost.tsx
@@ -82,8 +82,7 @@ const usePreviewRouteState = <TEntry extends TPreviewCacheEntryBase>(
   const params = useParams<{ community?: string | string[]; id?: string | string[] }>()
   const community = resolveParamValue(params.community)
   const id = resolveParamValue(params.id)
-  const routePreviewKey =
-    activeSegment && community && id ? resolvePreviewKey(community, id) : null
+  const routePreviewKey = activeSegment && community && id ? resolvePreviewKey(community, id) : null
   const intentKey = usePreviewIntentKey()
   const previewKey = routePreviewKey ?? intentKey
   const cacheState = usePreviewCacheState<TEntry>(previewKey)

--- a/frontend/main/src/app/[community]/_preview/PreviewHost.tsx
+++ b/frontend/main/src/app/[community]/_preview/PreviewHost.tsx
@@ -82,7 +82,8 @@ const usePreviewRouteState = <TEntry extends TPreviewCacheEntryBase>(
   const params = useParams<{ community?: string | string[]; id?: string | string[] }>()
   const community = resolveParamValue(params.community)
   const id = resolveParamValue(params.id)
-  const routePreviewKey = resolvePreviewKey(community, id)
+  const routePreviewKey =
+    activeSegment && community && id ? resolvePreviewKey(community, id) : null
   const intentKey = usePreviewIntentKey()
   const previewKey = routePreviewKey ?? intentKey
   const cacheState = usePreviewCacheState<TEntry>(previewKey)


### PR DESCRIPTION
- **chore(fe): use new schema for comment emotions**
- **chore(fe): fmt**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted the new comment emotion schema across the app, switching from flat fields to an array of emotion objects with viewer-reacted state and latest users. Also reduced redundant fetches and fixed drawer/preview edge cases to avoid page locks and unnecessary reloads.

- **Refactors**
  - Switched comments to the new emotion schema: GraphQL fragment now returns type/count/viewerHasReacted/latestUsers (with avatar); `TComment.emotions` is now `TEmotion[]`; updated `EmotionSelector`, comments hooks, and helpers to use reacted state.
  - Added `biceps` and `orz` to `EMOTION` and mapped `orz` -> `pao` icon; added `backend/main/scripts/reset_comment_emotions.exs` to reset/seed comment emotions; updated test wording to “reacted”.

- **Bug Fixes**
  - Prevented duplicate post-list refetches during preview open/close by deriving a stable request key in `useFetchPagedPosts`; adjusted event deps accordingly.
  - Ensured the drawer always unlocks the page on close/unmount; guarded preview route keys to avoid null access; fixed users panel count comparison and Next.js types path.

<sup>Written for commit dad7a1fe1af250a519ef2950317f098f5c83b05e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new reaction types: Biceps and Orz.
  * Improved emotion data structure for better performance and clarity.

* **Bug Fixes**
  * Fixed emotion display and selection logic across comment interfaces.
  * Corrected icon mapping for specific reaction types.
  * Fixed page unlock behavior in drawer navigation.

* **Refactor**
  * Streamlined emotion handling system with standardized data format.
  * Updated terminology from "emotioned" to "reacted" for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->