### PR TITLE
chore(fe): update biome

### DIFF
--- a/.github/workflows/frontend-linter.yml
+++ b/.github/workflows/frontend-linter.yml
@@ -3,14 +3,14 @@ name: Frontend linter
 on:
   pull_request:
     paths:
-      - "frontend/{main,dashboard,landing,core}/**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}"
+      - "frontend/{main,dashboard,landing,gateway,core}/**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}"
       - "frontend/**/biome.json"
       - "package.json"
       - "yarn.lock"
       - "biome.json"
   push:
     paths:
-      - "frontend/{main,dashboard,landing,core}/**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}"
+      - "frontend/{main,dashboard,landing,gateway,core}/**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}"
       - "frontend/**/biome.json"
       - "package.json"
       - "yarn.lock"
@@ -40,6 +40,8 @@ jobs:
               - 'frontend/dashboard/**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}'
             landing:
               - 'frontend/landing/**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}'
+            gateway:
+              - 'frontend/gateway/**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}'
             shared:
               - 'frontend/core/**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc}'
               - 'frontend/**/biome.json'
@@ -53,6 +55,7 @@ jobs:
           MAIN_CHANGED: ${{ steps.filter.outputs.main }}
           DASHBOARD_CHANGED: ${{ steps.filter.outputs.dashboard }}
           LANDING_CHANGED: ${{ steps.filter.outputs.landing }}
+          GATEWAY_CHANGED: ${{ steps.filter.outputs.gateway }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
         run: |
           targets=()
@@ -71,6 +74,10 @@ jobs:
 
           if [ "$SHARED_CHANGED" = "true" ] || [ "$LANDING_CHANGED" = "true" ]; then
             targets+=('{"target":"landing","path":"frontend/landing"}')
+          fi
+
+          if [ "$SHARED_CHANGED" = "true" ] || [ "$GATEWAY_CHANGED" = "true" ]; then
+            targets+=('{"target":"gateway","path":"frontend/gateway"}')
           fi
 
           if [ ${#targets[@]} -eq 0 ]; then

--- a/frontend/core/config/biome.json
+++ b/frontend/core/config/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "root": false,
   "files": {
     "includes": [

--- a/frontend/core/hooks/useNaviArticle.ts
+++ b/frontend/core/hooks/useNaviArticle.ts
@@ -1,5 +1,5 @@
-import { useContext } from 'react'
 import { findIndex, includes, values } from 'ramda'
+import { useContext } from 'react'
 import { ARTICLE_THREAD } from '~/const/thread'
 import { EMPTY_PAGED_ARTICLES } from '~/const/utils'
 import { plural } from '~/fmt'

--- a/frontend/core/unit/ArticleView/DrawerHeader/index.tsx
+++ b/frontend/core/unit/ArticleView/DrawerHeader/index.tsx
@@ -1,5 +1,5 @@
-import { lazy, Suspense } from 'react'
 import { useRouter } from 'next/navigation'
+import { lazy, Suspense } from 'react'
 
 import ArrowSVG from '~/icons/Arrow'
 import WarningSVG from '~/icons/Warning'

--- a/frontend/core/unit/ArticleView/schema.ts
+++ b/frontend/core/unit/ArticleView/schema.ts
@@ -1,8 +1,8 @@
 import { gql } from 'urql'
 import { F } from '~/schemas'
 import { setTag as setTagMutation, unsetTag as unsetTagMutation } from '../../schemas/pages/action'
-import { doc } from '../../schemas/pages/doc'
 import { changelog } from '../../schemas/pages/changelog'
+import { doc } from '../../schemas/pages/doc'
 import { post } from '../../schemas/pages/post'
 
 const ARTICLE_SCHEMA = {

--- a/frontend/core/unit/ChangelogArticle/Digest.tsx
+++ b/frontend/core/unit/ChangelogArticle/Digest.tsx
@@ -2,9 +2,9 @@
  * PostLayout
  */
 
-import { lazy, Suspense } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { lazy, Suspense } from 'react'
 import { ARTICLE_THREAD } from '~/const/thread'
 import Img from '~/Img'
 import ArrowSVG from '~/icons/Arrow'

--- a/frontend/core/unit/PostArticle/Digest.tsx
+++ b/frontend/core/unit/PostArticle/Digest.tsx
@@ -2,9 +2,9 @@
  * PostLayout
  */
 
-import { lazy, Suspense } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { lazy, Suspense } from 'react'
 import { ARTICLE_THREAD } from '~/const/thread'
 import Img from '~/Img'
 import ArrowSVG from '~/icons/Arrow'

--- a/frontend/core/unit/PostThread/schema.ts
+++ b/frontend/core/unit/PostThread/schema.ts
@@ -1,8 +1,8 @@
 import { gql } from 'urql'
 import { F } from '~/schemas'
+import { pagedChangelogs } from '../../schemas/pages/changelog'
 import { pagedCommunityTags as pagedCommunityTagsQuery } from '../../schemas/pages/misc'
 import { pagedPosts } from '../../schemas/pages/post'
-import { pagedChangelogs } from '../../schemas/pages/changelog'
 
 const PAGED_ARTICLE_SCHEMA = {
   post: pagedPosts,

--- a/frontend/gateway/biome.json
+++ b/frontend/gateway/biome.json
@@ -1,3 +1,4 @@
 {
+  "root": false,
   "extends": ["@groupher/frontend-core/biome"]
 }

--- a/frontend/gateway/vercel.json
+++ b/frontend/gateway/vercel.json
@@ -1,4 +1,4 @@
 {
-	"version": 2,
-	"builds": [{ "src": "package.json", "use": "@vercel/next" }]
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@vercel/next" }]
 }

--- a/frontend/main/src/app/[community]/_preview/index.ts
+++ b/frontend/main/src/app/[community]/_preview/index.ts
@@ -8,8 +8,8 @@ export {
   getPreviewReadyState,
   markPreviewPending,
   markPreviewReady,
-  setPreviewIntentKey,
   setPreviewCacheEntry,
+  setPreviewIntentKey,
   usePreviewCacheState,
   usePreviewIntentKey,
 } from './hooks'

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "valtio": "2.3.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.8",
+    "@biomejs/biome": "2.4.10",
     "@commitlint/cli": "^17.6.6",
     "@commitlint/config-conventional": "^8.2.0",
     "@graphql-tools/mock": "^9.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,18 +598,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:2.4.8":
-  version: 2.4.8
-  resolution: "@biomejs/biome@npm:2.4.8"
+"@biomejs/biome@npm:2.4.10":
+  version: 2.4.10
+  resolution: "@biomejs/biome@npm:2.4.10"
   dependencies:
-    "@biomejs/cli-darwin-arm64": "npm:2.4.8"
-    "@biomejs/cli-darwin-x64": "npm:2.4.8"
-    "@biomejs/cli-linux-arm64": "npm:2.4.8"
-    "@biomejs/cli-linux-arm64-musl": "npm:2.4.8"
-    "@biomejs/cli-linux-x64": "npm:2.4.8"
-    "@biomejs/cli-linux-x64-musl": "npm:2.4.8"
-    "@biomejs/cli-win32-arm64": "npm:2.4.8"
-    "@biomejs/cli-win32-x64": "npm:2.4.8"
+    "@biomejs/cli-darwin-arm64": "npm:2.4.10"
+    "@biomejs/cli-darwin-x64": "npm:2.4.10"
+    "@biomejs/cli-linux-arm64": "npm:2.4.10"
+    "@biomejs/cli-linux-arm64-musl": "npm:2.4.10"
+    "@biomejs/cli-linux-x64": "npm:2.4.10"
+    "@biomejs/cli-linux-x64-musl": "npm:2.4.10"
+    "@biomejs/cli-win32-arm64": "npm:2.4.10"
+    "@biomejs/cli-win32-x64": "npm:2.4.10"
   dependenciesMeta:
     "@biomejs/cli-darwin-arm64":
       optional: true
@@ -629,62 +629,62 @@ __metadata:
       optional: true
   bin:
     biome: bin/biome
-  checksum: 10c0/aa77037ee9e49d3ee8d3efcbe11750a84a3536f9ef05457c77ce34dfb5f06da23630cd701ef98b06abf7c691b64ebebcde9fbfb32abadf6b55bdc825ee600662
+  checksum: 10c0/80d10d5e6fa41a24efb9020ee73b79b0aca46942b55ea96e880c3bb45ea14c71e49fb1be9f134bee23b2d940bb8cad51a70351ca051e09a43613018dba693bd6
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-arm64@npm:2.4.8":
-  version: 2.4.8
-  resolution: "@biomejs/cli-darwin-arm64@npm:2.4.8"
+"@biomejs/cli-darwin-arm64@npm:2.4.10":
+  version: 2.4.10
+  resolution: "@biomejs/cli-darwin-arm64@npm:2.4.10"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-x64@npm:2.4.8":
-  version: 2.4.8
-  resolution: "@biomejs/cli-darwin-x64@npm:2.4.8"
+"@biomejs/cli-darwin-x64@npm:2.4.10":
+  version: 2.4.10
+  resolution: "@biomejs/cli-darwin-x64@npm:2.4.10"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64-musl@npm:2.4.8":
-  version: 2.4.8
-  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.4.8"
+"@biomejs/cli-linux-arm64-musl@npm:2.4.10":
+  version: 2.4.10
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.4.10"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64@npm:2.4.8":
-  version: 2.4.8
-  resolution: "@biomejs/cli-linux-arm64@npm:2.4.8"
+"@biomejs/cli-linux-arm64@npm:2.4.10":
+  version: 2.4.10
+  resolution: "@biomejs/cli-linux-arm64@npm:2.4.10"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64-musl@npm:2.4.8":
-  version: 2.4.8
-  resolution: "@biomejs/cli-linux-x64-musl@npm:2.4.8"
+"@biomejs/cli-linux-x64-musl@npm:2.4.10":
+  version: 2.4.10
+  resolution: "@biomejs/cli-linux-x64-musl@npm:2.4.10"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64@npm:2.4.8":
-  version: 2.4.8
-  resolution: "@biomejs/cli-linux-x64@npm:2.4.8"
+"@biomejs/cli-linux-x64@npm:2.4.10":
+  version: 2.4.10
+  resolution: "@biomejs/cli-linux-x64@npm:2.4.10"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-arm64@npm:2.4.8":
-  version: 2.4.8
-  resolution: "@biomejs/cli-win32-arm64@npm:2.4.8"
+"@biomejs/cli-win32-arm64@npm:2.4.10":
+  version: 2.4.10
+  resolution: "@biomejs/cli-win32-arm64@npm:2.4.10"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-x64@npm:2.4.8":
-  version: 2.4.8
-  resolution: "@biomejs/cli-win32-x64@npm:2.4.8"
+"@biomejs/cli-win32-x64@npm:2.4.10":
+  version: 2.4.10
+  resolution: "@biomejs/cli-win32-x64@npm:2.4.10"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1629,7 +1629,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@groupher/root@workspace:."
   dependencies:
-    "@biomejs/biome": "npm:2.4.8"
+    "@biomejs/biome": "npm:2.4.10"
     "@commitlint/cli": "npm:^17.6.6"
     "@commitlint/config-conventional": "npm:^8.2.0"
     "@formkit/auto-animate": "npm:^0.8.0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Biome to 2.4.10, adds `gateway` to the frontend linter workflow, and cleans up import order/formatting to match the new rules.

- **Dependencies**
  - Bumped `@biomejs/biome` from 2.4.8 to 2.4.10; updated `$schema` references and `yarn.lock`.

- **Refactors**
  - CI: included `frontend/gateway` in linter paths, filters, and target generation; runs when `gateway` or shared config changes.
  - Config: set `"root": false` in `frontend/gateway/biome.json` to extend `@groupher/frontend-core/biome`.
  - Code style: reordered imports and minor formatting tweaks across `frontend/core`, `frontend/main`, and `frontend/gateway` (e.g., import order, JSON indentation, export order) to satisfy Biome 2.4.10 rules.

<sup>Written for commit 424c8974cc6c196cc8c29350010baedbd12d4197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline extended to include the gateway frontend module in linting/validation runs.
  * Development tool upgraded from 2.4.8 to 2.4.10 and linter/schema references updated accordingly.

* **Style**
  * Minor formatting and import-order tidy-ups across frontend modules to maintain consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->