### PR TITLE
refactor(fe): kanban stiky effect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tools/reports
 # Playwright
 # =====================
 .playwright/
+.playwright-cli/
 playwright-report/
 test-results/
 

--- a/frontend/core/unit/KanbanThread/ClassicLayout/Columns.tsx
+++ b/frontend/core/unit/KanbanThread/ClassicLayout/Columns.tsx
@@ -3,19 +3,64 @@
  *
  */
 
+import type { ReactNode, RefObject, UIEvent } from 'react'
+
 import useKanbanPosts from '~/hooks/useKanbanPosts'
+import useNameAlias from '~/hooks/useNameAlias'
+import useTrans from '~/hooks/useTrans'
 import GtdDoneSVG from '~/icons/GtdDone'
 import GtdTodoSVG from '~/icons/GtdTodo'
 import GtdWipSVG from '~/icons/GtdWip'
 import RejectSVG from '~/icons/Reject'
+import type { TPagedPosts } from '~/spec'
 
 import KanbanItem from '../KanbanItem'
 import EmptyItem from '../KanbanItem/EmptyItem'
 
 import useSalon from '../salon/classic_layout/columns'
 
-export default function Columns() {
+type TColumn = {
+  key: string
+  count: number
+  icon: ReactNode
+  title: string
+  bodyClassName: string
+  posts: TPagedPosts
+}
+
+function HeaderColumn({ column, className = '' }: { column: TColumn; className?: string }) {
   const s = useSalon()
+
+  return (
+    <div className={className}>
+      <div className={s.header}>
+        {column.icon}
+        <h4 className={s.label}>{column.title}</h4>
+        <div className={s.subTitle}>{column.count}</div>
+        <div className='grow' />
+      </div>
+    </div>
+  )
+}
+
+function BodyColumn({ column, className = '' }: { column: TColumn; className?: string }) {
+  const s = useSalon()
+
+  return (
+    <div className={`${s.columnBase} ${className}`.trim()}>
+      <div className={column.bodyClassName}>
+        {column.count === 0 && <EmptyItem />}
+        {column.count !== 0 &&
+          column.posts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
+      </div>
+    </div>
+  )
+}
+
+export function useColumnsData() {
+  const s = useSalon()
+  const { t } = useTrans()
+  const kanbanAlias = useNameAlias('kanban')
 
   const {
     backlog: backlogPosts,
@@ -25,76 +70,94 @@ export default function Columns() {
     rejected: rejectedPosts,
   } = useKanbanPosts()
 
+  const resolveTitle = (key: string, fallback: string) => kanbanAlias[key]?.name || fallback
+
+  const columns: TColumn[] = [
+    {
+      key: 'backlog',
+      title: resolveTitle('backlog', t('article.state.backlog')),
+      count: backlogPosts.totalCount,
+      icon: <GtdTodoSVG className={s.backlogIcon} />,
+      bodyClassName: s.backlogBody,
+      posts: backlogPosts,
+    },
+    {
+      key: 'todo',
+      title: resolveTitle('todo', t('article.state.todo')),
+      count: todoPosts.totalCount,
+      icon: <GtdTodoSVG className={s.todoIcon} />,
+      bodyClassName: s.todoBody,
+      posts: todoPosts,
+    },
+    {
+      key: 'wip',
+      title: resolveTitle('wip', t('article.state.wip')),
+      count: wipPosts.totalCount,
+      icon: <GtdWipSVG className={s.wipIcon} />,
+      bodyClassName: s.wipBody,
+      posts: wipPosts,
+    },
+    {
+      key: 'done',
+      title: resolveTitle('done', t('article.state.done')),
+      count: donePosts.totalCount,
+      icon: <GtdDoneSVG className={s.doneIcon} />,
+      bodyClassName: s.doneBody,
+      posts: donePosts,
+    },
+    {
+      key: 'rejected',
+      title: resolveTitle('rejected', t('article.state.reject')),
+      count: rejectedPosts.totalCount,
+      icon: <RejectSVG className={s.rejectedIcon} />,
+      bodyClassName: s.rejectedBody,
+      posts: rejectedPosts,
+    },
+  ]
+
+  return columns
+}
+
+export function HeaderRow({
+  columns,
+  trackRef,
+  className = '',
+}: {
+  columns: TColumn[]
+  trackRef?: RefObject<HTMLDivElement | null>
+  className?: string
+}) {
+  const s = useSalon()
+
   return (
-    <>
-      <div className={s.column}>
-        <div className={s.header}>
-          <GtdTodoSVG className={s.backlogIcon} />
-          <h4 className={s.label}>需求池</h4>
-          <div className={s.subTitle}>{backlogPosts.totalCount}</div>
-          <div className='grow' />
-        </div>
-        <div className={s.backlogBody}>
-          {backlogPosts.totalCount === 0 && <EmptyItem />}
-          {backlogPosts.totalCount !== 0 &&
-            backlogPosts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
-        </div>
+    <div className={`${s.headerRowViewport} ${className}`.trim()}>
+      <div ref={trackRef} className={s.columnsTrack}>
+        {columns.map((column) => (
+          <HeaderColumn key={column.key} column={column} className={s.scrollColumn} />
+        ))}
       </div>
-      <div className={s.column}>
-        <div className={s.header}>
-          <GtdTodoSVG className={s.todoIcon} />
-          <h4 className={s.label}>待办</h4>
-          <div className={s.subTitle}>{todoPosts.totalCount}</div>
-          <div className='grow' />
-        </div>
-        <div className={s.todoBody}>
-          {todoPosts.totalCount === 0 && <EmptyItem />}
-          {todoPosts.totalCount !== 0 &&
-            todoPosts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
-        </div>
-      </div>
-      <div className={s.column}>
-        <div className={s.header}>
-          <GtdWipSVG className={s.wipIcon} />
-          <h4 className={s.label}>进行中</h4>
-          <div className={s.subTitle}>{wipPosts.totalCount}</div>
-          <div className='grow' />
-        </div>
-        <div className={s.wipBody}>
-          {wipPosts.totalCount === 0 && <EmptyItem />}
+    </div>
+  )
+}
 
-          {wipPosts.totalCount !== 0 &&
-            wipPosts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
-        </div>
-      </div>
-      <div className={s.column}>
-        <div className={s.header}>
-          <GtdDoneSVG className={s.doneIcon} />
-          <h4 className={s.label}>已完成</h4>
-          <div className={s.subTitle}>{donePosts.totalCount}</div>
-          <div className='grow' />
-        </div>
-        <div className={s.doneBody}>
-          {donePosts.totalCount === 0 && <EmptyItem />}
+export function BodyRow({
+  columns,
+  scrollRef,
+  onScroll,
+}: {
+  columns: TColumn[]
+  scrollRef: RefObject<HTMLDivElement | null>
+  onScroll: (event: UIEvent<HTMLDivElement>) => void
+}) {
+  const s = useSalon()
 
-          {donePosts.totalCount !== 0 &&
-            donePosts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
-        </div>
+  return (
+    <div ref={scrollRef} className={s.scroller} onScroll={onScroll}>
+      <div className={s.columnsTrack}>
+        {columns.map((column) => (
+          <BodyColumn key={column.key} column={column} className={s.scrollColumn} />
+        ))}
       </div>
-      <div className={s.column}>
-        <div className={s.header}>
-          <RejectSVG className={s.rejectedIcon} />
-          <h4 className={s.label}>已拒绝</h4>
-          <div className={s.subTitle}>{rejectedPosts.totalCount}</div>
-          <div className='grow' />
-        </div>
-        <div className={s.rejectedBody}>
-          {rejectedPosts.totalCount === 0 && <EmptyItem />}
-
-          {rejectedPosts.totalCount !== 0 &&
-            rejectedPosts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
-        </div>
-      </div>
-    </>
+    </div>
   )
 }

--- a/frontend/core/unit/KanbanThread/ClassicLayout/Columns.tsx
+++ b/frontend/core/unit/KanbanThread/ClassicLayout/Columns.tsx
@@ -45,13 +45,13 @@ function HeaderColumn({ column, className = '' }: { column: TColumn; className?:
 
 function BodyColumn({ column, className = '' }: { column: TColumn; className?: string }) {
   const s = useSalon()
+  const hasEntries = column.posts.entries.length > 0
 
   return (
     <div className={`${s.columnBase} ${className}`.trim()}>
       <div className={column.bodyClassName}>
-        {column.count === 0 && <EmptyItem />}
-        {column.count !== 0 &&
-          column.posts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
+        {!hasEntries && <EmptyItem />}
+        {hasEntries && column.posts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
       </div>
     </div>
   )

--- a/frontend/core/unit/KanbanThread/ClassicLayout/Columns.tsx
+++ b/frontend/core/unit/KanbanThread/ClassicLayout/Columns.tsx
@@ -51,7 +51,8 @@ function BodyColumn({ column, className = '' }: { column: TColumn; className?: s
     <div className={`${s.columnBase} ${className}`.trim()}>
       <div className={column.bodyClassName}>
         {!hasEntries && <EmptyItem />}
-        {hasEntries && column.posts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
+        {hasEntries &&
+          column.posts.entries.map((item) => <KanbanItem key={item.innerId} article={item} />)}
       </div>
     </div>
   )

--- a/frontend/core/unit/KanbanThread/ClassicLayout/index.tsx
+++ b/frontend/core/unit/KanbanThread/ClassicLayout/index.tsx
@@ -20,6 +20,7 @@ export default function ClassicLayout() {
   const headerTrackRef = useRef<HTMLDivElement | null>(null)
   const [isHeaderSticky, setIsHeaderSticky] = useState(false)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const updateStickyState = () => {
       const board = boardRef.current
@@ -33,15 +34,33 @@ export default function ClassicLayout() {
       setIsHeaderSticky(nextSticky)
     }
 
+    const syncHeaderOffset = () => {
+      const scrollLeft = bodyScrollRef.current?.scrollLeft ?? 0
+
+      if (headerTrackRef.current) {
+        headerTrackRef.current.style.transform = `translateX(-${scrollLeft}px)`
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateStickyState()
+      syncHeaderOffset()
+    })
+
+    if (boardRef.current) resizeObserver.observe(boardRef.current)
+    if (headerRef.current) resizeObserver.observe(headerRef.current)
+
     updateStickyState()
+    syncHeaderOffset()
     window.addEventListener('scroll', updateStickyState, { passive: true })
     window.addEventListener('resize', updateStickyState)
 
     return () => {
+      resizeObserver.disconnect()
       window.removeEventListener('scroll', updateStickyState)
       window.removeEventListener('resize', updateStickyState)
     }
-  }, [])
+  }, [columns.length])
 
   const handleBodyScroll = (event: UIEvent<HTMLDivElement>) => {
     if (!headerTrackRef.current) return

--- a/frontend/core/unit/KanbanThread/ClassicLayout/index.tsx
+++ b/frontend/core/unit/KanbanThread/ClassicLayout/index.tsx
@@ -2,18 +2,61 @@
  * KanbanThread
  */
 
+'use client'
+
+import type { UIEvent } from 'react'
+import { useEffect, useRef, useState } from 'react'
+
 import useSalon from '../salon/classic_layout'
 import Actions from './Actions'
-import Columns from './Columns'
+import { BodyRow, HeaderRow, useColumnsData } from './Columns'
 
 export default function ClassicLayout() {
   const s = useSalon()
+  const columns = useColumnsData()
+  const boardRef = useRef<HTMLDivElement | null>(null)
+  const headerRef = useRef<HTMLDivElement | null>(null)
+  const bodyScrollRef = useRef<HTMLDivElement | null>(null)
+  const headerTrackRef = useRef<HTMLDivElement | null>(null)
+  const [isHeaderSticky, setIsHeaderSticky] = useState(false)
+
+  useEffect(() => {
+    const updateStickyState = () => {
+      const board = boardRef.current
+      const header = headerRef.current
+      if (!board || !header) return
+
+      const boardRect = board.getBoundingClientRect()
+      const headerRect = header.getBoundingClientRect()
+      const nextSticky = boardRect.top <= 0 && boardRect.bottom > headerRect.height
+
+      setIsHeaderSticky(nextSticky)
+    }
+
+    updateStickyState()
+    window.addEventListener('scroll', updateStickyState, { passive: true })
+    window.addEventListener('resize', updateStickyState)
+
+    return () => {
+      window.removeEventListener('scroll', updateStickyState)
+      window.removeEventListener('resize', updateStickyState)
+    }
+  }, [])
+
+  const handleBodyScroll = (event: UIEvent<HTMLDivElement>) => {
+    if (!headerTrackRef.current) return
+
+    headerTrackRef.current.style.transform = `translateX(-${event.currentTarget.scrollLeft}px)`
+  }
 
   return (
     <div className={s.wrapper}>
       <Actions />
-      <div className={s.columns}>
-        <Columns />
+      <div ref={boardRef} className={s.boardFrame}>
+        <div ref={headerRef} className={s.headerRow(isHeaderSticky)}>
+          <HeaderRow columns={columns} trackRef={headerTrackRef} />
+        </div>
+        <BodyRow columns={columns} scrollRef={bodyScrollRef} onScroll={handleBodyScroll} />
       </div>
     </div>
   )

--- a/frontend/core/unit/KanbanThread/salon/classic_layout/columns.ts
+++ b/frontend/core/unit/KanbanThread/salon/classic_layout/columns.ts
@@ -8,8 +8,12 @@ export default function useSalon() {
   const body = 'p-2 pb-0 rounded-xl w-full'
 
   return {
-    column: 'column w-[19%] min-w-[19%] min-h-96',
-    header: 'row-center pb-4 w-full pl-0.5',
+    scroller: 'w-full overflow-x-auto overflow-y-visible [scrollbar-gutter:stable] scroll-smooth',
+    headerRowViewport: 'w-full overflow-hidden',
+    columnsTrack: 'flex items-start gap-5 min-w-max',
+    columnBase: 'column min-h-96',
+    scrollColumn: 'shrink-0 w-64',
+    header: 'row-center py-1.5 w-full pl-0.5',
     label: cn('text-base bold ml-2.5', fg('digest')),
     subTitle: cn('text-sm ml-1.5', fg('hint')),
     //

--- a/frontend/core/unit/KanbanThread/salon/classic_layout/index.ts
+++ b/frontend/core/unit/KanbanThread/salon/classic_layout/index.ts
@@ -2,11 +2,13 @@ import useIsSidebarLayout from '~/hooks/useIsSidebarLayout'
 import useTwBelt from '~/hooks/useTwBelt'
 
 export default function useSalon() {
-  const { cn } = useTwBelt()
+  const { cn, bg, br } = useTwBelt()
   const isSidebarLayout = useIsSidebarLayout()
 
   return {
     wrapper: cn('s-full min-h-screen py-2.5', isSidebarLayout && 'pl-12'),
-    columns: 'row items-start justify-between min-h-96 mt-14',
+    boardFrame: 'w-full min-h-96 mt-14',
+    headerRow: (isSticky = false) =>
+      cn('sticky top-0 z-20', bg('pageBg'), isSticky && ['border-b', br('divider')]),
   }
 }

--- a/frontend/main/next-env.d.ts
+++ b/frontend/main/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sticky Kanban header with synced horizontal scrolling, so column labels stay aligned while you scroll. Refactors the columns into smaller components for a smoother and more maintainable UI.

- **New Features**
  - Sticky header row that stays visible while scrolling the board.
  - Header horizontally syncs with body scroll for perfect column alignment.

- **Refactors**
  - Split columns into `HeaderRow`, `BodyRow`, and `useColumnsData` with a `TColumn` model.
  - Column titles now use `useTrans` + `useNameAlias` for i18n/alias support.
  - Updated layout/styles: new board frame, scrolling container + track, sticky header state, and fixed column width (`w-64`).
  - Tooling: ignore `.playwright-cli/`; update Next types path to `./.next/dev/types/routes.d.ts`.

<sup>Written for commit c112fa4a6cb446d8efb318998f5b1cf389b24f78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kanban header remains visible while scrolling vertically.
  * Header and columns now stay horizontally synchronized during scroll.

* **Refactor**
  * Kanban layout split into composable header/body rows and data-driven column structure for better reuse and maintainability.
  * Styling updated to support a scrollable, track-based board layout.

* **Chores**
  * Development tooling ignored and dev-type import path updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->