### PR TITLE
refactor(fe): dashboard docs carads improve

### DIFF
--- a/frontend/core/lib/i18n/en/dashboard.ts
+++ b/frontend/core/lib/i18n/en/dashboard.ts
@@ -218,7 +218,7 @@ export default {
   'dsb.layout.gauss_blur.opacity.note.light': 'light',
   'dsb.layout.gauss_blur.opacity.note.dark': 'dark',
   'dsb.layout.gauss_blur.opacity.note.suffix': ' themes separately.',
-  'dsb.layout.doc.title': 'Doc directory layout',
+  'dsb.layout.doc.title': 'Doc cover layout',
   'dsb.layout.doc.desc': 'Layout for all docs directories.',
   'dsb.layout.doc.option.blocks': 'Blocks',
   'dsb.layout.doc.option.lists': 'List',

--- a/frontend/core/lib/i18n/en/dashboard.ts
+++ b/frontend/core/lib/i18n/en/dashboard.ts
@@ -219,7 +219,7 @@ export default {
   'dsb.layout.gauss_blur.opacity.note.dark': 'dark',
   'dsb.layout.gauss_blur.opacity.note.suffix': ' themes separately.',
   'dsb.layout.doc.title': 'Doc cover layout',
-  'dsb.layout.doc.desc': 'Layout for all docs directories.',
+  'dsb.layout.doc.desc': 'Layout for all docs cover pages.',
   'dsb.layout.doc.option.blocks': 'Blocks',
   'dsb.layout.doc.option.lists': 'List',
   'dsb.layout.doc.option.cards': 'Cards',

--- a/frontend/core/unit/DashboardThread/Layout/BannerLayout/BannerLayoutPreviewContent.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/BannerLayout/BannerLayoutPreviewContent.tsx
@@ -1,0 +1,160 @@
+import { BANNER_LAYOUT } from '~/const/layout'
+import type { TBannerLayout } from '~/spec'
+
+import useSalon, { cnMerge } from '../../salon/layout/banner_layout'
+
+function HeaderContent({ title }: { title: string }) {
+  const s = useSalon()
+
+  return (
+    <div className={s.frame}>
+      <div className={s.nav}>
+        <h4 className={s.communityTitle}>{title}</h4>
+        <div className={cnMerge(s.bar, s.navBar)} />
+        <div className={s.circle} />
+      </div>
+      <div className={cnMerge(s.hDivider, 'mt-1.5 mb-5')} />
+
+      <div className={s.mainClassic}>
+        <div className={s.contentColumn}>
+          <div className={s.sectionBlock}>
+            <div className={cnMerge(s.bar, s.contentTitleWide)} />
+            <div className={cnMerge(s.bar, s.contentDigest)} />
+          </div>
+          <div className={s.sectionBlock}>
+            <div className={cnMerge(s.bar, s.contentTitle)} />
+            <div className={cnMerge(s.bar, s.contentDigestShort)} />
+          </div>
+          <div className={s.sectionBlock}>
+            <div className={cnMerge(s.bar, s.contentTitle)} />
+            <div className={cnMerge(s.bar, s.contentDigestWide)} />
+          </div>
+          <div className={s.sectionBlock}>
+            <div className={cnMerge(s.bar, s.contentTitleWide)} />
+            <div className={cnMerge(s.bar, s.contentDigestShort)} />
+          </div>
+        </div>
+
+        <div className={s.vDivider} />
+
+        <div className={s.rightRail}>
+          <div className={cnMerge(s.bar, s.primaryBar, s.primaryChip)} />
+          <div className={cnMerge(s.bar, s.railItemShort)} />
+          <div className={cnMerge(s.bar, s.railItemWide)} />
+          <div className={cnMerge(s.bar, s.railItem)} />
+          <div className={cnMerge(s.bar, s.footerItem)} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function CoverContent({ title }: { title: string }) {
+  const s = useSalon()
+
+  return (
+    <div className={s.mainCover}>
+      <div className={s.coverHero} />
+      <div className={s.coverHeader}>
+        <div className={s.coverLead}>
+          <div className={cnMerge(s.bar, s.coverAvatar)} />
+          <h4 className={s.communityTitle}>{title}</h4>
+        </div>
+        <div className={cnMerge(s.bar, s.primaryBar, s.primaryChip, s.coverAction)} />
+      </div>
+
+      <div className={s.coverContent}>
+        <div className={s.coverMain}>
+          <div className={s.coverSection}>
+            <div className={cnMerge(s.bar, s.contentTitle)} />
+            <div className={cnMerge(s.bar, s.coverBodyShort)} />
+          </div>
+          <div className={s.coverSection}>
+            <div className={cnMerge(s.bar, s.contentTitle, 'w-1/2')} />
+            <div className={cnMerge(s.bar, s.coverBodyLong)} />
+          </div>
+          <div className={s.coverSection}>
+            <div className={cnMerge(s.bar, s.contentTitle)} />
+            <div className={cnMerge(s.bar, s.coverBodyLong)} />
+          </div>
+          <div className={s.coverSection}>
+            <div className={cnMerge(s.bar, s.contentTitle, 'w-1/2')} />
+            <div className={cnMerge(s.bar, s.coverBodyLong, 'w-1/3')} />
+          </div>
+        </div>
+
+        <div className={s.rightRail}>
+          <div className={cnMerge(s.bar, s.railItemShort)} />
+          <div className={cnMerge(s.bar, s.railItemWide)} />
+          <div className={cnMerge(s.bar, s.railItem)} />
+          <div className={cnMerge(s.bar, s.footerItem, 'mt-auto')} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarContent({ title }: { title: string }) {
+  const s = useSalon()
+
+  return (
+    <div className={s.frame}>
+      <div className={s.nav}>
+        <h4 className={s.communityTitle}>{title}</h4>
+        <div className={s.navCenter}>
+          <div className={cnMerge(s.bar, 'w-8')} />
+          <div className={cnMerge(s.bar, s.primaryBar, s.primaryChip)} />
+        </div>
+
+        <div className={s.circle} />
+      </div>
+
+      <div className={s.mainSidebar}>
+        <div className={s.sidebarNav}>
+          <div className={cnMerge(s.bar, s.sideNavItem)} />
+          <div className={cnMerge(s.bar, s.sideNavItemWide)} />
+          <div className={cnMerge(s.bar, s.sideNavActive)} />
+          <div className={cnMerge(s.bar, s.sideNavItem)} />
+          <div className={cnMerge(s.bar, s.sideNavItem)} />
+          <div className={cnMerge(s.bar, s.sideNavActive)} />
+          <div className={cnMerge(s.bar, s.sideNavItem)} />
+          <div className={cnMerge(s.bar, s.sidebarBottom, 'mt-auto')} />
+        </div>
+
+        <div className={s.vDivider} />
+
+        <div className={s.sidebarMain}>
+          <div className={s.sectionBlock}>
+            <div className={cnMerge(s.bar, s.contentTitle, 'w-1/2')} />
+            <div className={cnMerge(s.bar, s.contentDigestShort)} />
+          </div>
+          <div className={s.sectionBlock}>
+            <div className={cnMerge(s.bar, s.contentTitle)} />
+            <div className={cnMerge(s.bar, s.contentDigest)} />
+          </div>
+          <div className={s.sectionBlock}>
+            <div className={cnMerge(s.bar, 'w-24')} />
+            <div className={cnMerge(s.bar, s.contentDigestShort)} />
+            <div className={cnMerge(s.bar, 'w-16')} />
+          </div>
+          <div className={s.sectionBlock}>
+            <div className={cnMerge(s.bar, 'w-24')} />
+            <div className={cnMerge(s.bar, s.contentDigestShort)} />
+            <div className={cnMerge(s.bar, 'w-16')} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type TProps = {
+  layout: TBannerLayout
+  title: string
+}
+
+export default function BannerLayoutPreviewContent({ layout, title }: TProps) {
+  if (layout === BANNER_LAYOUT.TABBER) return <CoverContent title={title} />
+  if (layout === BANNER_LAYOUT.SIDEBAR) return <SidebarContent title={title} />
+  return <HeaderContent title={title} />
+}

--- a/frontend/core/unit/DashboardThread/Layout/BannerLayout/index.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/BannerLayout/index.tsx
@@ -19,7 +19,7 @@ function LayoutPreview({
 }: {
   isActive: boolean
   title: string
-  layout: typeof BANNER_LAYOUT[keyof typeof BANNER_LAYOUT]
+  layout: (typeof BANNER_LAYOUT)[keyof typeof BANNER_LAYOUT]
 }) {
   const s = useSalon()
 

--- a/frontend/core/unit/DashboardThread/Layout/BannerLayout/index.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/BannerLayout/index.tsx
@@ -9,155 +9,23 @@ import { FIELD } from '../../constant'
 import useBanner from '../../logic/useBanner'
 import SavingBar from '../../SavingBar'
 import SectionLabel from '../../SectionLabel'
-import useSalon, { cn, cnMerge } from '../../salon/layout/banner_layout'
+import useSalon, { cnMerge } from '../../salon/layout/banner_layout'
+import BannerLayoutPreviewContent from './BannerLayoutPreviewContent'
 
-function HeaderPreview({ isActive, title }: { isActive: boolean; title: string }) {
-  const s = useSalon()
-
-  return (
-    <div className={cn(s.block, isActive && s.blockActive)}>
-      <div className={s.frame}>
-        <div className={s.nav}>
-          <h4 className={s.communityTitle}>{title}</h4>
-          <div className={cnMerge(s.bar, s.navBar)} />
-          <div className={s.circle} />
-        </div>
-        <div className={cnMerge(s.hDivider, 'mt-1.5 mb-5')} />
-
-        <div className={s.mainClassic}>
-          <div className={s.contentColumn}>
-            <div className={s.sectionBlock}>
-              <div className={cnMerge(s.bar, s.contentTitleWide)} />
-              <div className={cnMerge(s.bar, s.contentDigest)} />
-            </div>
-            <div className={s.sectionBlock}>
-              <div className={cnMerge(s.bar, s.contentTitle)} />
-              <div className={cnMerge(s.bar, s.contentDigestShort)} />
-            </div>
-            <div className={s.sectionBlock}>
-              <div className={cnMerge(s.bar, s.contentTitle)} />
-              <div className={cnMerge(s.bar, s.contentDigestWide)} />
-            </div>
-            <div className={s.sectionBlock}>
-              <div className={cnMerge(s.bar, s.contentTitleWide)} />
-              <div className={cnMerge(s.bar, s.contentDigestShort)} />
-            </div>
-          </div>
-
-          <div className={s.vDivider} />
-
-          <div className={s.rightRail}>
-            <div className={cnMerge(s.bar, s.primaryBar, s.primaryChip)} />
-            <div className={cnMerge(s.bar, s.railItemShort)} />
-            <div className={cnMerge(s.bar, s.railItemWide)} />
-            <div className={cnMerge(s.bar, s.railItem)} />
-            <div className={cnMerge(s.bar, s.footerItem)} />
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function CoverPreview({ isActive, title }: { isActive: boolean; title: string }) {
+function LayoutPreview({
+  isActive,
+  title,
+  layout,
+}: {
+  isActive: boolean
+  title: string
+  layout: typeof BANNER_LAYOUT[keyof typeof BANNER_LAYOUT]
+}) {
   const s = useSalon()
 
   return (
     <div className={cnMerge(s.block, isActive && s.blockActive)}>
-      <div className={s.mainCover}>
-        <div className={s.coverHero} />
-        <div className={s.coverHeader}>
-          <div className={s.coverLead}>
-            <div className={cnMerge(s.bar, s.coverAvatar)} />
-            <h4 className={s.communityTitle}>{title}</h4>
-          </div>
-          <div className={cnMerge(s.bar, s.primaryBar, s.primaryChip, s.coverAction)} />
-        </div>
-
-        <div className={s.coverContent}>
-          <div className={s.coverMain}>
-            <div className={s.coverSection}>
-              <div className={cnMerge(s.bar, s.contentTitle)} />
-              <div className={cnMerge(s.bar, s.coverBodyShort)} />
-            </div>
-            <div className={s.coverSection}>
-              <div className={cnMerge(s.bar, s.contentTitle, 'w-1/2')} />
-              <div className={cnMerge(s.bar, s.coverBodyLong)} />
-            </div>
-            <div className={s.coverSection}>
-              <div className={cnMerge(s.bar, s.contentTitle)} />
-              <div className={cnMerge(s.bar, s.coverBodyLong)} />
-            </div>
-            <div className={s.coverSection}>
-              <div className={cnMerge(s.bar, s.contentTitle, 'w-1/2')} />
-              <div className={cnMerge(s.bar, s.coverBodyLong, 'w-1/3')} />
-            </div>
-          </div>
-
-          <div className={s.rightRail}>
-            <div className={cnMerge(s.bar, s.railItemShort)} />
-            <div className={cnMerge(s.bar, s.railItemWide)} />
-            <div className={cnMerge(s.bar, s.railItem)} />
-            <div className={cnMerge(s.bar, s.footerItem, 'mt-auto')} />
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function SidebarPreview({ isActive, title }: { isActive: boolean; title: string }) {
-  const s = useSalon()
-
-  return (
-    <div className={cnMerge(s.block, isActive && s.blockActive)}>
-      <div className={s.frame}>
-        <div className={s.nav}>
-          <h4 className={s.communityTitle}>{title}</h4>
-          <div className={s.navCenter}>
-            <div className={cnMerge(s.bar, 'w-8')} />
-            <div className={cnMerge(s.bar, s.primaryBar, s.primaryChip)} />
-          </div>
-
-          <div className={s.circle} />
-        </div>
-
-        <div className={s.mainSidebar}>
-          <div className={s.sidebarNav}>
-            <div className={cnMerge(s.bar, s.sideNavItem)} />
-            <div className={cnMerge(s.bar, s.sideNavItemWide)} />
-            <div className={cnMerge(s.bar, s.sideNavActive)} />
-            <div className={cnMerge(s.bar, s.sideNavItem)} />
-            <div className={cnMerge(s.bar, s.sideNavItem)} />
-            <div className={cnMerge(s.bar, s.sideNavActive)} />
-            <div className={cnMerge(s.bar, s.sideNavItem)} />
-            <div className={cnMerge(s.bar, s.sidebarBottom, 'mt-auto')} />
-          </div>
-
-          <div className={s.vDivider} />
-
-          <div className={s.sidebarMain}>
-            <div className={s.sectionBlock}>
-              <div className={cnMerge(s.bar, s.contentTitle, 'w-1/2')} />
-              <div className={cnMerge(s.bar, s.contentDigestShort)} />
-            </div>
-            <div className={s.sectionBlock}>
-              <div className={cnMerge(s.bar, s.contentTitle)} />
-              <div className={cnMerge(s.bar, s.contentDigest)} />
-            </div>
-            <div className={s.sectionBlock}>
-              <div className={cnMerge(s.bar, 'w-24')} />
-              <div className={cnMerge(s.bar, s.contentDigestShort)} />
-              <div className={cnMerge(s.bar, 'w-16')} />
-            </div>
-            <div className={s.sectionBlock}>
-              <div className={cnMerge(s.bar, 'w-24')} />
-              <div className={cnMerge(s.bar, s.contentDigestShort)} />
-              <div className={cnMerge(s.bar, 'w-16')} />
-            </div>
-          </div>
-        </div>
-      </div>
+      <BannerLayoutPreviewContent layout={layout} title={title} />
     </div>
   )
 }
@@ -188,7 +56,11 @@ export default function BannerLayout() {
           aria-pressed={layout === BANNER_LAYOUT.HEADER}
           onClick={() => edit(BANNER_LAYOUT.HEADER, FIELD.BANNER_LAYOUT)}
         >
-          <HeaderPreview isActive={layout === BANNER_LAYOUT.HEADER} title={title} />
+          <LayoutPreview
+            isActive={layout === BANNER_LAYOUT.HEADER}
+            title={title}
+            layout={BANNER_LAYOUT.HEADER}
+          />
           <CheckLabel
             title={t('dsb.layout.banner.option.classic')}
             active={layout === BANNER_LAYOUT.HEADER}
@@ -201,7 +73,11 @@ export default function BannerLayout() {
           aria-pressed={layout === BANNER_LAYOUT.TABBER}
           onClick={() => edit(BANNER_LAYOUT.TABBER, FIELD.BANNER_LAYOUT)}
         >
-          <CoverPreview isActive={layout === BANNER_LAYOUT.TABBER} title={title} />
+          <LayoutPreview
+            isActive={layout === BANNER_LAYOUT.TABBER}
+            title={title}
+            layout={BANNER_LAYOUT.TABBER}
+          />
           <CheckLabel
             title={t('dsb.layout.banner.option.cover')}
             active={layout === BANNER_LAYOUT.TABBER}
@@ -214,7 +90,11 @@ export default function BannerLayout() {
           aria-pressed={layout === BANNER_LAYOUT.SIDEBAR}
           onClick={() => edit(BANNER_LAYOUT.SIDEBAR, FIELD.BANNER_LAYOUT)}
         >
-          <SidebarPreview isActive={layout === BANNER_LAYOUT.SIDEBAR} title={title} />
+          <LayoutPreview
+            isActive={layout === BANNER_LAYOUT.SIDEBAR}
+            title={title}
+            layout={BANNER_LAYOUT.SIDEBAR}
+          />
           <CheckLabel
             title={t('dsb.layout.banner.option.sidebar')}
             active={layout === BANNER_LAYOUT.SIDEBAR}

--- a/frontend/core/unit/DashboardThread/Layout/DocLayout/FaqTemplate.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/DocLayout/FaqTemplate.tsx
@@ -9,6 +9,30 @@ type TProps = {
   layout: TDocFAQLayout
 }
 
+const COLLAPSE_ITEMS = [
+  { title: 'w-16', body1: 'w-24', body2: 'w-20' },
+  { title: 'w-16', body1: 'w-20', body2: 'w-14' },
+  { title: 'w-20', body1: 'w-14', body2: 'w-16' },
+] as const
+
+const FLAT_ROWS = [
+  [
+    { title: 'w-10', body1: 'w-16', body2: 'w-12' },
+    { title: 'w-12', body1: 'w-16', body2: 'w-12' },
+    { title: 'w-9', body1: 'w-16', body2: 'w-12' },
+  ],
+  [
+    { title: 'w-8', body1: 'w-12', body2: 'w-8' },
+    { title: 'w-14', body1: 'w-10', body2: 'w-10' },
+  ],
+] as const
+
+const LEFT_RIGHT_ITEMS = [
+  { title: 'w-16', body1: 'w-24', body2: 'w-20' },
+  { title: 'w-16', body1: 'w-20', body2: 'w-14' },
+  { title: 'w-20', body1: 'w-14', body2: 'w-16' },
+] as const
+
 const FaqTemplate: FC<TProps> = ({ layout }) => {
   const s = useSalon()
   const { t } = useTrans()
@@ -16,18 +40,19 @@ const FaqTemplate: FC<TProps> = ({ layout }) => {
   if (layout === DOC_FAQ_LAYOUT.COLLAPSE) {
     return (
       <div className={s.block}>
-        <div className={cnMerge(s.faqTitle, 'top-5 left-28')}>{t('dsb.layout.doc.faq.label')}</div>
-        <div className={cnMerge(s.bar, 'h-1.5 top-14 left-24 w-16')} />
-        <div className={cnMerge(s.bar, 'h-1 top-16 mt-2 left-24 w-24 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1 top-20 mt-1.5 left-24 w-20 opacity-20')} />
+        <div className={s.titleWrap}>
+          <div className={s.faqTitle}>{t('dsb.layout.doc.faq.label')}</div>
+        </div>
 
-        <div className={cnMerge(s.bar, 'h-1.5 top-24 mt-2 left-24 w-16')} />
-        <div className={cnMerge(s.bar, 'h-1 top-28 mt-2 left-24 w-20 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1 top-32 mt-1.5 left-24 w-14 opacity-20')} />
-
-        <div className={cnMerge(s.bar, 'h-1.5 top-36 mt-2 left-24 w-20')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-40 mt-2.5 left-24 w-14')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-44 mt-2.5 left-24 w-16 opacity-30')} />
+        <div className={s.collapseList}>
+          {COLLAPSE_ITEMS.map((item, index) => (
+            <div key={index} className={s.collapseItem}>
+              <div className={cnMerge(s.bar, item.title)} />
+              <div className={cnMerge(s.bar, 'h-1', item.body1, 'opacity-20')} />
+              <div className={cnMerge(s.bar, 'h-1', item.body2, 'opacity-20')} />
+            </div>
+          ))}
+        </div>
       </div>
     )
   }
@@ -35,63 +60,45 @@ const FaqTemplate: FC<TProps> = ({ layout }) => {
   if (layout === DOC_FAQ_LAYOUT.LEFT_RIGHT) {
     return (
       <div className={s.block}>
-        <div className={cnMerge(s.faqTitle, 'top-8 left-7 -ml-1')}>
-          {t('dsb.layout.doc.faq.label')}
+        <div className={s.leftRightMain}>
+          <div className={s.leftRightSide}>
+            <div className={s.faqTitle}>{t('dsb.layout.doc.faq.label')}</div>
+            <div className={cnMerge(s.bar, 'h-1', 'w-16', 'opacity-20')} />
+            <div className={cnMerge(s.bar, 'h-1', 'w-12', 'opacity-10')} />
+          </div>
+
+          <div className={s.leftRightList}>
+            {LEFT_RIGHT_ITEMS.map((item, index) => (
+              <div key={index} className={s.leftRightItem}>
+                <div className={cnMerge(s.bar, item.title)} />
+                <div className={cnMerge(s.bar, 'h-1', item.body1, 'opacity-20')} />
+                <div className={cnMerge(s.bar, 'h-1', item.body2, 'opacity-20')} />
+              </div>
+            ))}
+          </div>
         </div>
-        <div className={cnMerge(s.bar, 'h-1.5 top-14 left-6 w-16 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-16 left-6 w-12 mt-1 opacity-10')} />
-
-        <div className={cnMerge(s.bar, 'h-1.5 top-9 left-32 w-16')} />
-        <div className={cnMerge(s.bar, 'h-1 top-12 mt-2 left-32 w-24 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1 top-16 mt-1.5 left-32 w-20 opacity-20')} />
-
-        <div className={cnMerge(s.bar, 'h-1.5 top-20 mt-2 left-32 w-16')} />
-        <div className={cnMerge(s.bar, 'h-1 top-24 mt-2 left-32 w-20 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1 top-28 mt-1.5 left-32 w-14 opacity-20')} />
-
-        <div className={cnMerge(s.bar, 'h-1.5 top-32 mt-2 left-32 w-20')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-36 mt-2.5 left-32 w-14')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-40 mt-2.5 left-32 w-16 opacity-20')} />
       </div>
     )
   }
 
   return (
     <div className={s.block}>
-      <div className={cnMerge(s.faqTitle, 'top-5 left-28 -ml-1')}>
-        {t('dsb.layout.doc.faq.label')}
+      <div className={s.titleWrap}>
+        <div className={s.faqTitle}>{t('dsb.layout.doc.faq.label')}</div>
       </div>
 
-      <div className={s.list}>
-        <div className={s.box}>
-          <div className={cnMerge(s.bar, 'h-1.5 top-0 left-3 w-10')} />
-          <div className={cnMerge(s.bar, 'h-1 top-2 mt-2 left-3 w-16 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-4 mt-2.5 left-3 w-12 opacity-20')} />
-        </div>
-
-        <div className={s.box}>
-          <div className={cnMerge(s.bar, 'h-1.5 top-0 left-3 w-12')} />
-          <div className={cnMerge(s.bar, 'h-1 top-2 mt-2 left-3 w-16 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-4 mt-2.5 left-3 w-12 opacity-20')} />
-        </div>
-
-        <div className={s.box}>
-          <div className={cnMerge(s.bar, 'h-1.5 top-0 left-3 w-9')} />
-          <div className={cnMerge(s.bar, 'h-1 top-2 mt-2 left-3 w-16 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-4 mt-2.5 left-3 w-12 opacity-20')} />
-        </div>
-
-        <div className={s.box}>
-          <div className={cnMerge(s.bar, 'h-1.5 top-0 left-3 w-8')} />
-          <div className={cnMerge(s.bar, 'h-1 top-2 mt-2 left-3 w-16 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-4 mt-2.5 left-3 w-12 opacity-20')} />
-        </div>
-
-        <div className={s.box}>
-          <div className={cnMerge(s.bar, 'h-1.5 top-0 left-3 w-14')} />
-          <div className={cnMerge(s.bar, 'h-1 top-2 mt-2 left-3 w-20 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-4 mt-2.5 left-3 w-12 opacity-20')} />
-        </div>
+      <div className={s.flatList}>
+        {FLAT_ROWS.map((row, rowIndex) => (
+          <div key={rowIndex} className={s.flatRow}>
+            {row.map((item, index) => (
+              <div key={index} className={s.flatBox}>
+                <div className={cnMerge(s.bar, item.title)} />
+                <div className={cnMerge(s.bar, 'h-1', item.body1, 'opacity-20')} />
+                <div className={cnMerge(s.bar, 'h-1', item.body2, 'opacity-20')} />
+              </div>
+            ))}
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/frontend/core/unit/DashboardThread/Layout/DocLayout/MainTemplate.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/DocLayout/MainTemplate.tsx
@@ -12,7 +12,14 @@ type TProps = {
 const BLOCK_ITEMS = [
   { toneBg: 'redBg', toneFg: 'red', title: 'w-6', body1: 'w-8', body2: 'w-14', body3: 'w-10' },
   { toneBg: 'blueBg', toneFg: 'blue', title: 'w-6', body1: 'w-12', body2: 'w-14', body3: 'w-10' },
-  { toneBg: 'purpleBg', toneFg: 'purple', title: 'w-6', body1: 'w-8', body2: 'w-16', body3: 'w-10' },
+  {
+    toneBg: 'purpleBg',
+    toneFg: 'purple',
+    title: 'w-6',
+    body1: 'w-8',
+    body2: 'w-16',
+    body3: 'w-10',
+  },
   { toneBg: 'brownBg', toneFg: 'brown', title: 'w-6', body1: 'w-10', body2: 'w-12', body3: 'w-10' },
   { toneBg: 'greenBg', toneFg: 'green', title: 'w-6', body1: 'w-12', body2: 'w-14', body3: 'w-8' },
 ] as const

--- a/frontend/core/unit/DashboardThread/Layout/DocLayout/MainTemplate.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/DocLayout/MainTemplate.tsx
@@ -9,66 +9,58 @@ type TProps = {
   layout: TDocLayout
 }
 
+const BLOCK_ITEMS = [
+  { toneBg: 'redBg', toneFg: 'red', title: 'w-6', body1: 'w-8', body2: 'w-14', body3: 'w-10' },
+  { toneBg: 'blueBg', toneFg: 'blue', title: 'w-6', body1: 'w-12', body2: 'w-14', body3: 'w-10' },
+  { toneBg: 'purpleBg', toneFg: 'purple', title: 'w-6', body1: 'w-8', body2: 'w-16', body3: 'w-10' },
+  { toneBg: 'brownBg', toneFg: 'brown', title: 'w-6', body1: 'w-10', body2: 'w-12', body3: 'w-10' },
+  { toneBg: 'greenBg', toneFg: 'green', title: 'w-6', body1: 'w-12', body2: 'w-14', body3: 'w-8' },
+] as const
+const BLOCK_ROWS = [BLOCK_ITEMS.slice(0, 3), BLOCK_ITEMS.slice(3)] as const
+
+const LIST_ITEMS = [
+  { toneBg: 'redBg', toneFg: 'red', title: 'w-14', body1: 'w-28', body2: 'w-16' },
+  { toneBg: 'blueBg', toneFg: 'blue', title: 'w-16', body1: 'w-24', body2: 'w-20' },
+  { toneBg: 'purpleBg', toneFg: 'purple', title: 'w-20', body1: 'w-24', body2: 'w-10' },
+  { toneBg: 'brownBg', toneFg: 'brown', title: 'w-14', body1: 'w-28', body2: 'w-10' },
+  { toneBg: 'greenBg', toneFg: 'green', title: 'w-14', body1: 'w-28', body2: 'w-10' },
+] as const
+
+const CARD_ITEMS = [
+  { title: 'w-6', subtitle: 'w-10', body1: 'w-12', body2: 'w-16', body3: 'w-10' },
+  { title: 'w-6', subtitle: 'w-8', body1: 'w-10', body2: 'w-8', body3: 'w-8' },
+  { title: 'w-6', subtitle: 'w-8', body1: 'w-6', body2: 'w-10', body3: 'w-8' },
+  { title: 'w-6', subtitle: 'w-6', body1: 'w-14', body2: 'w-12', body3: 'w-8' },
+  { title: 'w-6', subtitle: 'w-12', body1: 'w-12', body2: 'w-16', body3: 'w-10' },
+] as const
+const CARD_ROWS = [CARD_ITEMS.slice(0, 3), CARD_ITEMS.slice(3)] as const
+
 const MainTemplate: FC<TProps> = ({ layout }) => {
   const s = useSalon()
 
   if (layout === DOC_LAYOUT.CARDS) {
     return (
-      <div className={cnMerge(s.block, 'gap-x-3 gap-y-1 w-full')}>
-        <div className={s.borderBox}>
-          <div className={cnMerge(s.bar, 'h-1 top-2 left-1 w-6 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1.5 top-4 left-1 w-10 opacity-40')} />
+      <div className={cnMerge(s.block, 'justify-center')}>
+        <div className={s.cardsRows}>
+          {CARD_ROWS.map((row, rowIndex) => (
+            <div key={rowIndex} className={s.cardsRow}>
+              {row.map((item, index) => (
+                <div key={index} className={s.cardBox}>
+                  <div className={s.cardBody}>
+                    <div className={cnMerge(s.bar, 'h-1', item.title, 'opacity-20')} />
+                    <div className={cnMerge(s.bar, item.subtitle, 'opacity-40')} />
+                    <div className={cnMerge(s.bar, 'h-1', item.body1, 'opacity-20')} />
+                    <div className={cnMerge(s.bar, 'h-1', item.body2, 'opacity-15')} />
+                    <div className={cnMerge(s.bar, 'h-1', item.body3, 'opacity-10')} />
+                  </div>
 
-          <div className={cnMerge(s.bar, 'h-1 top-8 left-1 w-12 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-10 left-1 w-16 opacity-15')} />
-          <div className={cnMerge(s.bar, 'h-1 top-12 left-1 w-10 opacity-10')} />
-
-          <div className={cnMerge(s.bar, 'h-3 bottom-1 left-1.5 w-10/12 opacity-10')} />
-          <div className={cnMerge(s.bar, 'h-1 bottom-2 left-5 w-8 opacity-30')} />
-        </div>
-        <div className={s.borderBox}>
-          <div className={cnMerge(s.bar, 'h-1 top-2 left-1 w-6 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1.5 top-4 left-1 w-8 opacity-40')} />
-
-          <div className={cnMerge(s.bar, 'h-1 top-8 left-1 w-10 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-10 left-1 w-8 opacity-15')} />
-          <div className={cnMerge(s.bar, 'h-1 top-12 left-1 w-8 opacity-10')} />
-
-          <div className={cnMerge(s.bar, 'h-3 bottom-1 left-1.5 w-10/12 opacity-10')} />
-          <div className={cnMerge(s.bar, 'h-1 bottom-2 left-5 w-8 opacity-30')} />
-        </div>
-        <div className={s.borderBox}>
-          <div className={cnMerge(s.bar, 'h-1 top-2 left-1 w-6 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1.5 top-4 left-1 w-8 opacity-40')} />
-
-          <div className={cnMerge(s.bar, 'h-1 top-8 left-1 w-6 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-10 left-1 w-10 opacity-15')} />
-          <div className={cnMerge(s.bar, 'h-1 top-12 left-1 w-8 opacity-10')} />
-
-          <div className={cnMerge(s.bar, 'h-3 bottom-1 left-1.5 w-10/12 opacity-10')} />
-          <div className={cnMerge(s.bar, 'h-1 bottom-2 left-5 w-8 opacity-30')} />
-        </div>
-        <div className={s.borderBox}>
-          <div className={cnMerge(s.bar, 'h-1 top-2 left-1 w-6 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1.5 top-4 left-1 w-6 opacity-40')} />
-
-          <div className={cnMerge(s.bar, 'h-1 top-8 left-1 w-14 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-10 left-1 w-12 opacity-15')} />
-          <div className={cnMerge(s.bar, 'h-1 top-12 left-1 w-8 opacity-10')} />
-
-          <div className={cnMerge(s.bar, 'h-3 bottom-1 left-1.5 w-10/12 opacity-10')} />
-          <div className={cnMerge(s.bar, 'h-1 bottom-2 left-5 w-8 opacity-30')} />
-        </div>
-        <div className={s.borderBox}>
-          <div className={cnMerge(s.bar, 'h-1 top-2 left-1 w-6 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1.5 top-4 left-1 w-12 opacity-40')} />
-
-          <div className={cnMerge(s.bar, 'h-1 top-8 left-1 w-12 opacity-20')} />
-          <div className={cnMerge(s.bar, 'h-1 top-10 left-1 w-16 opacity-15')} />
-          <div className={cnMerge(s.bar, 'h-1 top-12 left-1 w-10 opacity-10')} />
-
-          <div className={cnMerge(s.bar, 'h-3 bottom-1 left-1.5 w-10/12 opacity-10')} />
-          <div className={cnMerge(s.bar, 'h-1 bottom-2 left-5 w-8 opacity-30')} />
+                  <div className={s.cardFooter}>
+                    <div className={s.cardFooterBar} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
         </div>
       </div>
     )
@@ -77,100 +69,48 @@ const MainTemplate: FC<TProps> = ({ layout }) => {
   if (layout === DOC_LAYOUT.LISTS) {
     return (
       <div className={s.block}>
-        <div className={cnMerge(s.iconBox, s.redBg, 'top-2 left-12')}>
-          <ToolSVG className={cnMerge(s.icon, s.red)} />
+        <div className={s.list}>
+          {LIST_ITEMS.map((item, index) => (
+            <div key={index} className={s.listEntry}>
+              <div className={cnMerge(s.iconBox, s[item.toneBg])}>
+                <ToolSVG className={cnMerge(s.icon, s[item.toneFg])} />
+              </div>
+
+              <div className={s.listCopy}>
+                <div className={cnMerge(s.bar, item.title)} />
+                <div className={cnMerge(s.bar, 'h-1', item.body1, 'opacity-20')} />
+                <div className={cnMerge(s.bar, 'h-1', item.body2, 'opacity-10')} />
+              </div>
+            </div>
+          ))}
         </div>
-        <div className={cnMerge(s.bar, 'h-1.5 top-3 left-20 w-14')} />
-        <div className={cnMerge(s.bar, 'w-28 h-1 top-6 left-20 opacity-20')} />
-        <div className={cnMerge(s.bar, 'w-16 mt-0.5 h-1 top-8 left-20 opacity-10')} />
-        <div className={cnMerge(s.iconBox, s.blueBg, 'top-12 left-12')}>
-          <ToolSVG className={cnMerge(s.icon, s.blue)} />
-        </div>
-        <div className={cnMerge(s.bar, 'h-1.5 top-14 -mt-1 left-20 w-16')} />
-        <div className={cnMerge(s.bar, 'w-24 h-1 top-16 left-20 opacity-20')} />
-        <div className={cnMerge(s.bar, 'w-20 mt-0.5 h-1 top-20 -mt-1.5 left-20 opacity-10')} />
-        <div className={cnMerge(s.iconBox, s.purpleBg, 'bottom-24 left-12')}>
-          <ToolSVG className={cnMerge(s.icon, s.purple)} />
-        </div>
-        <div className={cnMerge(s.bar, 'h-1.5 bottom-24 mb-3 left-20 w-20')} />
-        <div className={cnMerge(s.bar, 'w-24 h-1 bottom-24 mb-0.5 left-20 opacity-20')} />
-        <div className={cnMerge(s.bar, 'w-10 mt-0.5 h-1 bottom-20 mb-2 left-20 opacity-10')} />
-        <div className={cnMerge(s.iconBox, s.brownBg, 'bottom-14 left-12')}>
-          <ToolSVG className={cnMerge(s.icon, s.brown)} />
-        </div>
-        <div className={cnMerge(s.bar, 'h-1.5 bottom-14 mb-3 left-20 w-14')} />
-        <div className={cnMerge(s.bar, 'w-28 h-1 bottom-14 mb-0.5 left-20 opacity-20')} />
-        <div className={cnMerge(s.bar, 'w-10 mt-0.5 h-1 bottom-12 mt-1 left-20 opacity-10')} />
-        <div className={cnMerge(s.iconBox, s.greenBg, 'bottom-3 left-12')}>
-          <ToolSVG className={cnMerge(s.icon, s.green)} />
-        </div>
-        <div className={cnMerge(s.bar, 'h-1.5 bottom-3 mb-3 left-20 w-14')} />
-        <div className={cnMerge(s.bar, 'w-28 h-1 bottom-3 mb-0.5 left-20 opacity-20')} />
-        <div className={cnMerge(s.bar, 'w-10 mt-0.5 h-1 bottom-1 mt-1 left-20 opacity-10')} />
       </div>
     )
   }
 
   return (
-    <div className={cnMerge(s.block, 'gap-x-7 gap-y-1 w-full')}>
-      <div className={s.box}>
-        <div className={cnMerge(s.iconBox, s.redBg, 'top-0 left-1 scale-125')}>
-          <ToolSVG className={cnMerge(s.icon, s.red)} />
-        </div>
+    <div className={cnMerge(s.block, 'justify-center')}>
+      <div className={s.blocksRows}>
+        {BLOCK_ROWS.map((row, rowIndex) => (
+          <div key={rowIndex} className={s.blocksRow}>
+            {row.map((item, index) => (
+              <div key={index} className={s.blocksCard}>
+                <div className={s.blocksIconWrap}>
+                  <div className={cnMerge(s.iconBox, s[item.toneBg])}>
+                    <ToolSVG className={cnMerge(s.icon, s[item.toneFg])} />
+                  </div>
+                </div>
 
-        <div className={cnMerge(s.bar, 'h-1 top-9 left-1 w-6 mt-0.5 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-12 left-1 w-8 opacity-30')} />
-
-        <div className={cnMerge(s.bar, 'h-1 top-14 mt-1.5 left-1 w-14 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1 top-16 mt-2 left-1 w-10 opacity-10')} />
-      </div>
-
-      <div className={s.box}>
-        <div className={cnMerge(s.iconBox, s.blueBg, 'top-0 left-1 scale-125')}>
-          <ToolSVG className={cnMerge(s.icon, s.blue)} />
-        </div>
-
-        <div className={cnMerge(s.bar, 'h-1 top-9 left-1 w-6 mt-0.5 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-12 left-1 w-12 opacity-30')} />
-
-        <div className={cnMerge(s.bar, 'h-1 top-14 mt-1.5 left-1 w-14 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1 top-16 mt-2 left-1 w-10 opacity-10')} />
-      </div>
-
-      <div className={s.box}>
-        <div className={cnMerge(s.iconBox, s.purpleBg, 'top-0 left-1 scale-125')}>
-          <ToolSVG className={cnMerge(s.icon, s.purple)} />
-        </div>
-
-        <div className={cnMerge(s.bar, 'h-1 top-9 left-1 w-6 mt-0.5 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-12 left-1 w-8 opacity-30')} />
-
-        <div className={cnMerge(s.bar, 'h-1 top-14 mt-1.5 left-1 w-16 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1 top-16 mt-2 left-1 w-10 opacity-10')} />
-      </div>
-
-      <div className={s.box}>
-        <div className={cnMerge(s.iconBox, s.brownBg, 'top-0 left-1 scale-125')}>
-          <ToolSVG className={cnMerge(s.icon, s.brown)} />
-        </div>
-
-        <div className={cnMerge(s.bar, 'h-1 top-9 left-1 w-6 mt-0.5 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-12 left-1 w-10 opacity-30')} />
-
-        <div className={cnMerge(s.bar, 'h-1 top-14 mt-1.5 left-1 w-12 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1 top-16 mt-2 left-1 w-10 opacity-10')} />
-      </div>
-
-      <div className={s.box}>
-        <div className={cnMerge(s.iconBox, s.greenBg, 'top-0 left-1 scale-125')}>
-          <ToolSVG className={cnMerge(s.icon, s.green)} />
-        </div>
-
-        <div className={cnMerge(s.bar, 'h-1 top-9 left-1 w-6 mt-0.5 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1.5 top-12 left-1 w-12 opacity-30')} />
-
-        <div className={cnMerge(s.bar, 'h-1 top-14 mt-1.5 left-1 w-14 opacity-20')} />
-        <div className={cnMerge(s.bar, 'h-1 top-16 mt-2 left-1 w-8 opacity-10')} />
+                <div className={s.blocksText}>
+                  <div className={cnMerge(s.bar, 'h-1', item.title, 'opacity-20')} />
+                  <div className={cnMerge(s.bar, item.body1, 'opacity-30')} />
+                  <div className={cnMerge(s.bar, 'h-1', item.body2, 'opacity-20')} />
+                  <div className={cnMerge(s.bar, 'h-1', item.body3, 'opacity-10')} />
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/frontend/core/unit/DashboardThread/Layout/KanbanLayout/GlobalLayout.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/KanbanLayout/GlobalLayout.tsx
@@ -7,36 +7,7 @@ import useKanban from '../../logic/useKanban'
 import SavingBar from '../../SavingBar'
 import SectionLabel from '../../SectionLabel'
 import useSalon, { cnMerge } from '../../salon/layout/kanban_layout/global_layout'
-
-const CLASSIC_COLUMNS = [
-  ['opacity-35', 'opacity-20'],
-  ['opacity-35', 'opacity-25', 'opacity-15', 'opacity-10'],
-  ['opacity-35', 'opacity-25', 'opacity-15'],
-] as const
-
-const WATERFALL_GROUPS = [
-  {
-    headerWidth: 'w-full',
-    titleWidth: 'w-16 opacity-30',
-    rows: [
-      { left: 'w-32 opacity-30', right: 'w-8 opacity-20' },
-      { left: 'w-24 opacity-20', right: 'w-8 opacity-10' },
-    ],
-  },
-  {
-    headerWidth: 'w-full',
-    titleWidth: 'w-10 opacity-40',
-    rows: [
-      { left: 'w-32 opacity-30', right: 'w-8 opacity-20' },
-      { left: 'w-24 opacity-20', right: 'w-8 opacity-10' },
-    ],
-  },
-  {
-    headerWidth: 'w-full',
-    titleWidth: 'w-12 opacity-25',
-    rows: [{ left: 'w-12 opacity-10', right: 'w-8 opacity-10' }],
-  },
-] as const
+import GlobalLayoutPreview from './GlobalLayoutPreview'
 
 export default function GlobalLayout() {
   const s = useSalon()
@@ -63,19 +34,7 @@ export default function GlobalLayout() {
                 <div className={cnMerge(s.bar, s.toolbarLeft)} />
                 <div className={cnMerge(s.bar, s.toolbarRight)} />
               </div>
-
-              <div className={s.boardGrid}>
-                {CLASSIC_COLUMNS.map((cards, index) => (
-                  <div key={index} className={s.boardColumn}>
-                    <div className={s.boardSurface} />
-                    <div className={s.boardContent}>
-                      {cards.map((opacity, cardIndex) => (
-                        <div key={`${index}-${cardIndex}`} className={cnMerge(s.card, opacity)} />
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
+              <GlobalLayoutPreview layout={KANBAN_LAYOUT.CLASSIC} />
             </div>
           </div>
           <CheckLabel
@@ -96,23 +55,7 @@ export default function GlobalLayout() {
                 <div className={cnMerge(s.bar, s.toolbarLeft)} />
                 <div className={cnMerge(s.bar, s.toolbarRight)} />
               </div>
-
-              <div className={s.waterfall}>
-                {WATERFALL_GROUPS.map((group, index) => (
-                  <div key={index} className={s.waterfallGroup}>
-                    <div className={cnMerge(s.waterfallMain, group.headerWidth)}>
-                      <div className={cnMerge(s.waterfallTitle, group.titleWidth)} />
-                    </div>
-
-                    {group.rows.map((row, rowIndex) => (
-                      <div key={`${index}-${rowIndex}`} className={s.waterfallRow}>
-                        <div className={cnMerge(s.waterfallMeta, row.left)} />
-                        <div className={cnMerge(s.waterfallMeta, row.right)} />
-                      </div>
-                    ))}
-                  </div>
-                ))}
-              </div>
+              <GlobalLayoutPreview layout={KANBAN_LAYOUT.WATERFALL} />
             </div>
           </div>
           <CheckLabel

--- a/frontend/core/unit/DashboardThread/Layout/KanbanLayout/GlobalLayoutPreview.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/KanbanLayout/GlobalLayoutPreview.tsx
@@ -1,0 +1,87 @@
+import { KANBAN_LAYOUT } from '~/const/layout'
+import type { TKanbanLayout } from '~/spec'
+
+import useSalon, { cnMerge } from '../../salon/layout/kanban_layout/global_layout'
+
+const CLASSIC_COLUMNS = [
+  ['opacity-35', 'opacity-20'],
+  ['opacity-35', 'opacity-25', 'opacity-15', 'opacity-10'],
+  ['opacity-35', 'opacity-25', 'opacity-15'],
+] as const
+
+const WATERFALL_GROUPS = [
+  {
+    headerWidth: 'w-full',
+    titleWidth: 'w-16 opacity-30',
+    rows: [
+      { left: 'w-32 opacity-30', right: 'w-8 opacity-20' },
+      { left: 'w-24 opacity-20', right: 'w-8 opacity-10' },
+    ],
+  },
+  {
+    headerWidth: 'w-full',
+    titleWidth: 'w-10 opacity-40',
+    rows: [
+      { left: 'w-32 opacity-30', right: 'w-8 opacity-20' },
+      { left: 'w-24 opacity-20', right: 'w-8 opacity-10' },
+    ],
+  },
+  {
+    headerWidth: 'w-full',
+    titleWidth: 'w-12 opacity-25',
+    rows: [{ left: 'w-12 opacity-10', right: 'w-8 opacity-10' }],
+  },
+] as const
+
+type TProps = {
+  layout: TKanbanLayout
+}
+
+function ClassicPreview() {
+  const s = useSalon()
+
+  return (
+    <div className={s.boardGrid}>
+      {CLASSIC_COLUMNS.map((cards, index) => (
+        <div key={index} className={s.boardColumn}>
+          <div className={s.boardContent}>
+            {cards.map((opacity, cardIndex) => (
+              <div key={`${index}-${cardIndex}`} className={cnMerge(s.card, opacity)} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function WaterfallPreview() {
+  const s = useSalon()
+
+  return (
+    <div className={s.waterfall}>
+      {WATERFALL_GROUPS.map((group, index) => (
+        <div key={index} className={s.waterfallGroup}>
+          <div className={cnMerge(s.waterfallMain, group.headerWidth)}>
+            <div className={cnMerge(s.waterfallTitle, group.titleWidth)} />
+          </div>
+
+          {group.rows.map((row, rowIndex) => (
+            <div key={`${index}-${rowIndex}`} className={s.waterfallRow}>
+              <div className={cnMerge(s.waterfallMeta, row.left)} />
+              <div className={cnMerge(s.waterfallMeta, row.right)} />
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function GlobalLayoutPreview({ layout }: TProps) {
+  if (layout === KANBAN_LAYOUT.WATERFALL) {
+    return <WaterfallPreview />
+  }
+
+  return <ClassicPreview />
+}

--- a/frontend/core/unit/DashboardThread/Layout/TopbarLayout/index.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/TopbarLayout/index.tsx
@@ -1,13 +1,16 @@
 import { TOPBAR_LAYOUT } from '~/const/layout'
 import useTrans from '~/hooks/useTrans'
+import useCommunity from '~/stores/community/hooks'
 import CheckLabel from '~/widgets/CheckLabel'
 import ColorSelector from '~/widgets/ColorSelector'
 
 import { FIELD } from '../../constant'
+import useBanner from '../../logic/useBanner'
 import useTopbar from '../../logic/useTopbar'
 import SavingBar from '../../SavingBar'
 import SectionLabel from '../../SectionLabel'
 import useSalon, { cn } from '../../salon/layout/topbar_layout'
+import BannerLayoutPreviewContent from '../BannerLayout/BannerLayoutPreviewContent'
 
 const TOPBAR_LAYOUT_OPTIONS = [
   {
@@ -23,8 +26,10 @@ const TOPBAR_LAYOUT_OPTIONS = [
 export default function TopbarLayout() {
   const s = useSalon()
   const { t } = useTrans()
+  const { title } = useCommunity()
 
   const { edit, layout, isBgTouched, isLayoutTouched, saving, bg } = useTopbar()
+  const { layout: bannerLayout } = useBanner()
 
   return (
     <div className={s.wrapper}>
@@ -45,10 +50,10 @@ export default function TopbarLayout() {
               aria-pressed={isActive}
               onClick={() => edit(value, FIELD.TOPBAR_LAYOUT)}
             >
+              {value === TOPBAR_LAYOUT.YES && <div className={s.topBar} />}
               <div className={cn(s.block, isActive && s.blockActive)}>
-                {value === TOPBAR_LAYOUT.YES && <div className={s.topBar} />}
-                <div className={cn(s.bar, 'top-8 left-5 h-28 w-6/12 opacity-5')} />
-                <div className={cn(s.bar, 'top-8 right-5 h-24 w-20 opacity-5')} />
+                <div className='mb-2' />
+                <BannerLayoutPreviewContent layout={bannerLayout} title={title} />
               </div>
               <CheckLabel title={t(titleKey)} active={isActive} top={4} />
             </button>

--- a/frontend/core/unit/DashboardThread/Layout/TopbarLayout/tests/index.test.tsx
+++ b/frontend/core/unit/DashboardThread/Layout/TopbarLayout/tests/index.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { TOPBAR_LAYOUT } from '~/const/layout'
+import { BANNER_LAYOUT, TOPBAR_LAYOUT } from '~/const/layout'
 import { FIELD } from '../../../constant'
 import TopbarLayout from '..'
 
@@ -19,6 +19,27 @@ vi.mock('../../../logic/useTopbar', () => ({
     saving: false,
     bg: 'black',
   }),
+}))
+
+vi.mock('../../../logic/useBanner', () => ({
+  default: () => ({
+    layout: BANNER_LAYOUT.HEADER,
+    edit: vi.fn(),
+    isTouched: false,
+    saving: false,
+  }),
+}))
+
+vi.mock('~/stores/community/hooks', () => ({
+  default: () => ({
+    title: 'Home',
+  }),
+}))
+
+vi.mock('../../BannerLayout/BannerLayoutPreviewContent', () => ({
+  default: ({ layout, title }: { layout: string; title: string }) => (
+    <div data-testid='banner-layout-preview' data-layout={layout} data-title={title} />
+  ),
 }))
 
 vi.mock('../../../salon/layout/topbar_layout', () => ({

--- a/frontend/core/unit/DashboardThread/salon/layout/doc_layout/faq_template.ts
+++ b/frontend/core/unit/DashboardThread/salon/layout/doc_layout/faq_template.ts
@@ -9,11 +9,22 @@ export default function useSalon() {
   const base = useBase()
 
   return {
-    block: 'row-center row wrap relative s-full',
-    bar: cnMerge(base.bar, 'h-1.5 w-20 opacity-40'),
+    block: 'column s-full px-5 py-5',
+    bar: cnMerge(base.bar, 'static h-1.5 w-20 opacity-40'),
     icon: 'size-2.5',
-    faqTitle: cn('text-xs absolute -ml-1', fg('title')),
-    list: 'row-center row wrap w-full h-36 gap-x-1.5 mt-16',
-    box: cnMerge(base.box, 'border-none w-20 h-16'),
+    faqTitle: cn('text-xs', fg('title')),
+    titleWrap: 'row-center justify-center w-full mb-8',
+    collapseList: 'column-center gap-3 w-full grow',
+    collapseItem: 'column gap-1.5 w-24',
+    flatList: 'column gap-9 w-fit self-center pt-1',
+    flatRow: 'row gap-6',
+    flatBox: cnMerge(
+      base.box,
+      'column gap-1.5 border-none w-14 h-auto p-0 bg-transparent shadow-none',
+    ),
+    leftRightMain: 'row-start gap-8 w-full grow pt-2',
+    leftRightSide: 'column-start gap-1.5 w-20 pt-1',
+    leftRightList: 'column gap-3.5 grow',
+    leftRightItem: 'column gap-1.5 w-24',
   }
 }

--- a/frontend/core/unit/DashboardThread/salon/layout/doc_layout/main_template.ts
+++ b/frontend/core/unit/DashboardThread/salon/layout/doc_layout/main_template.ts
@@ -10,11 +10,27 @@ export default function useSalon() {
   const base = useBase()
 
   return {
-    block: 'row-center row wrap relative s-full',
-    bar: cnMerge(base.bar, 'h-1.5 w-20 opacity-40'),
-    circle: cnMerge(base.circle, 'size-3.5 opacity-40'),
-    iconBox: 'absolute align-both size-4 rounded mt-2 mr-5',
+    block: 'column s-full px-4 py-3',
+    bar: cnMerge(base.bar, 'static h-1.5 w-20 opacity-40'),
+    circle: cnMerge(base.circle, 'static size-3.5 opacity-40'),
+    blocksRows: 'column gap-10 w-fit self-center pt-1',
+    blocksRow: 'row gap-6',
+    blocksCard: 'column gap-2 w-16',
+    blocksIconWrap: 'row',
+    iconBox: 'align-both size-4 rounded',
     icon: 'size-2.5',
+    blocksText: 'column gap-1 w-full',
+
+    list: 'column gap-4 w-full px-8 py-1',
+    listEntry: 'row-start gap-4',
+    listCopy: 'column gap-1 pt-0.5',
+
+    cardsRows: 'column gap-4 w-fit self-center',
+    cardsRow: 'row gap-2.5',
+    cardBox: cnMerge(base.box, 'column justify-between border-none w-[4.75rem] h-[5.5rem] p-2'),
+    cardBody: 'column gap-1.5',
+    cardFooter: 'row-center justify-center h-3 rounded opacity-10',
+    cardFooterBar: cnMerge(base.bar, 'h-1 w-8 opacity-30'),
 
     red: rainbow(COLOR.RED, 'fill'),
     redBg: rainbow(COLOR.RED, 'bgSoft'),
@@ -26,8 +42,5 @@ export default function useSalon() {
     brownBg: rainbow(COLOR.BROWN, 'bgSoft'),
     purple: rainbow(COLOR.PURPLE, 'fill'),
     purpleBg: rainbow(COLOR.PURPLE, 'bgSoft'),
-
-    box: 'relative w-16 h-24',
-    borderBox: cnMerge(base.box, 'w-20 h-24'),
   }
 }

--- a/frontend/core/unit/DashboardThread/salon/layout/kanban_layout/global_layout.ts
+++ b/frontend/core/unit/DashboardThread/salon/layout/kanban_layout/global_layout.ts
@@ -20,11 +20,10 @@ export default function useSalon() {
 
     bar: cnMerge(base.bar, 'static h-1.5 w-20 opacity-40'),
     boardGrid: 'grid min-h-0 flex-1 grid-cols-3 items-end gap-2.5',
-    boardColumn:
-      cnMerge(
-        'mt-auto flex h-36 min-h-0 flex-col justify-start self-end rounded-lg rounded-b-none px-2 pt-2.5',
-        bg('alphaBg'),
-      ),
+    boardColumn: cnMerge(
+      'mt-auto flex h-36 min-h-0 flex-col justify-start self-end rounded-lg rounded-b-none px-2 pt-2.5',
+      bg('alphaBg'),
+    ),
     boardContent: 'flex min-h-0 flex-col gap-2',
     card: cnMerge(base.bar, 'static h-7 w-full rounded'),
 

--- a/frontend/core/unit/DashboardThread/salon/layout/kanban_layout/global_layout.ts
+++ b/frontend/core/unit/DashboardThread/salon/layout/kanban_layout/global_layout.ts
@@ -4,7 +4,7 @@ import useBase from '..'
 export { cn, cnMerge } from '~/css'
 
 export default function useSalon() {
-  const { cnMerge } = useTwBelt()
+  const { cnMerge, bg } = useTwBelt()
   const base = useBase()
 
   return {
@@ -21,12 +21,11 @@ export default function useSalon() {
     bar: cnMerge(base.bar, 'static h-1.5 w-20 opacity-40'),
     boardGrid: 'grid min-h-0 flex-1 grid-cols-3 items-end gap-2.5',
     boardColumn:
-      'relative mt-auto flex h-36 min-h-0 flex-col justify-start self-end rounded-lg rounded-b-none px-2 pt-2.5',
-    boardSurface: cnMerge(
-      base.bar,
-      'absolute inset-0 h-auto w-auto rounded-lg rounded-b-none opacity-10',
-    ),
-    boardContent: 'relative z-10 flex min-h-0 flex-col gap-2',
+      cnMerge(
+        'mt-auto flex h-36 min-h-0 flex-col justify-start self-end rounded-lg rounded-b-none px-2 pt-2.5',
+        bg('alphaBg'),
+      ),
+    boardContent: 'flex min-h-0 flex-col gap-2',
     card: cnMerge(base.bar, 'static h-7 w-full rounded'),
 
     waterfall: 'flex min-h-0 flex-1 flex-col gap-4',

--- a/frontend/core/unit/DashboardThread/salon/layout/topbar_layout.ts
+++ b/frontend/core/unit/DashboardThread/salon/layout/topbar_layout.ts
@@ -12,15 +12,12 @@ export default function useSalon() {
 
   return {
     wrapper: base.baseSection,
-    block: cn(base.blockBase, 'align-both w-72 h-44'),
+    block: cn(base.blockBase, 'column w-72 h-56 overflow-hidden px-4 pb-3 pt-0'),
     blockActive: base.blockBaseActive,
     select: 'row-center gap-x-8 w-full',
-    layout: 'column-align-both',
-
-    bar: cn(base.bar, 'h-1.5 w-20 opacity-40'),
-    circle: cn(base.circle, 'size-3.5 opacity-40'),
+    layout: 'column-align-both relative overflow-hidden',
     topBar: cn(
-      'row-center absolute top-0 left-0 h-1 w-full -mt-px rounded-tl-md rounded-tr-md',
+      'absolute top-0 left-0 h-1 w-full rounded-tl-md rounded-tr-md z-10',
       rainbow(topbarBg, 'bg'),
     ),
 


### PR DESCRIPTION
- **chore(fe): topbar cards improve**
- **chore(fe): fmt**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored dashboard layout previews and refreshed doc cards for a cleaner, consistent UI; the Topbar option now shows a live banner preview using the community title.

- UI Improvements
  - Topbar layout option renders the current banner preview with the top bar.
  - Doc layout previews (Cards, Lists, FAQ) rebuilt as data-driven flex/grid blocks.
  - Kanban previews polished for Classic and Waterfall with themed backgrounds.
  - Updated i18n: “Doc cover layout” and “Layout for all docs cover pages.”

- Refactors
  - Extracted `BannerLayoutPreviewContent` and `GlobalLayoutPreview` to remove duplicate JSX.
  - Simplified `BannerLayout`, `GlobalLayout`, and Topbar preview to use shared components.
  - Reworked salon styles for doc/kanban previews from absolute to flex/grid utilities.

<sup>Written for commit 3213b7559a09c9b512b29085e1b691347082bd27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer layout preview components for banner and kanban options, and updated topbar previews to show current title.

* **Refactor**
  * Consolidated multiple per-layout preview renderers into unified, reusable preview components and converted repeated placeholders to data-driven rendering.

* **Documentation**
  * Renamed docs layout label to "Doc cover layout" and its description to reference "docs cover pages."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->