### PR TITLE
refactor(be): clean up missing atom usage

### DIFF
--- a/backend/main/lib/groupher_server/accounts/upvotes.ex
+++ b/backend/main/lib/groupher_server/accounts/upvotes.ex
@@ -20,9 +20,7 @@ defmodule GroupherServer.Accounts.Upvotes do
     load_articles(where_query, filter)
   end
 
-  def paged_articles(_user_id, %{thread: _thread} = filter) do
-    load_articles(dynamic([a], false), filter)
-  end
+  def paged_articles(_user_id, %{thread: _thread}), do: {:error, {:custom, "invalid thread"}}
 
   def paged_articles(user_id, filter) do
     where_query = dynamic([a], a.user_id == ^user_id)

--- a/backend/main/lib/groupher_server/cms/can_can.ex
+++ b/backend/main/lib/groupher_server/cms/can_can.ex
@@ -29,11 +29,11 @@ defmodule GroupherServer.CMS.CanCan do
 
   @type scope :: :article | :comment
 
-  @spec allow_thread(map() | String.t() | nil, atom() | String.t()) ::
+  @spec allow_thread(map() | String.t() | nil, atom()) ::
           {:ok, atom()} | {:error, atom()}
   def allow_thread(community, thread), do: Communities.allow_thread(community, thread)
 
-  @spec allow_emotion(String.t() | nil, scope(), atom() | String.t(), atom()) ::
+  @spec allow_emotion(String.t() | nil, scope(), atom(), atom()) ::
           {:ok, atom()} | {:error, atom()}
   def allow_emotion(community, scope, thread, emotion) do
     Communities.allow_emotion(community, scope, thread, emotion)

--- a/backend/main/lib/groupher_server/cms/can_can/communities.ex
+++ b/backend/main/lib/groupher_server/cms/can_can/communities.ex
@@ -45,9 +45,9 @@ defmodule GroupherServer.CMS.CanCan.Communities do
 
   @type scope :: :article | :comment
 
-  @spec allow_thread(map() | String.t() | nil, atom() | String.t()) ::
+  @spec allow_thread(map() | String.t() | nil, atom()) ::
           {:ok, atom()} | {:error, atom() | {:custom, String.t()}}
-  def allow_thread(community, thread) do
+  def allow_thread(community, thread) when is_atom(thread) do
     with {:ok, thread} <- Threads.to_atom(thread) do
       case thread_visible?(community, thread) do
         true -> done(thread)
@@ -56,9 +56,11 @@ defmodule GroupherServer.CMS.CanCan.Communities do
     end
   end
 
-  @spec allow_emotion(String.t() | nil, scope(), atom() | String.t(), atom()) ::
+  def allow_thread(_community, _thread), do: {:error, {:custom, "invalid thread"}}
+
+  @spec allow_emotion(String.t() | nil, scope(), atom(), atom()) ::
           {:ok, atom()} | {:error, atom() | {:custom, String.t()}}
-  def allow_emotion(community_slug, scope, thread, emotion) do
+  def allow_emotion(community_slug, scope, thread, emotion) when is_atom(thread) do
     with {:ok, thread} <- Threads.to_atom(thread) do
       thread_key = thread_key(scope, thread)
 
@@ -68,6 +70,9 @@ defmodule GroupherServer.CMS.CanCan.Communities do
       end
     end
   end
+
+  def allow_emotion(_community_slug, _scope, _thread, _emotion),
+    do: {:error, {:custom, "invalid thread"}}
 
   @spec emotions_whitelist() :: [atom()]
   def emotions_whitelist, do: @emotions_whitelist

--- a/backend/main/lib/groupher_server/cms/comments/helper.ex
+++ b/backend/main/lib/groupher_server/cms/comments/helper.ex
@@ -19,6 +19,7 @@ defmodule GroupherServer.CMS.Comments.Helper do
   @max_participator_count Comment.max_participator_count()
   @default_emotions Embeds.CommentEmotion.default_emotions()
   @default_comment_meta Embeds.CommentMeta.default_meta()
+  @article_threads Threads.article_enums()
 
   @spec can_comment?(map(), User.t()) :: boolean()
   def can_comment?(article, _user) do
@@ -32,10 +33,7 @@ defmodule GroupherServer.CMS.Comments.Helper do
 
     with {:ok, payload} <- ContentPipeline.parse(%{body: body}) do
       {:ok, thread} =
-        foreign_key
-        |> to_string()
-        |> String.trim_trailing("_id")
-        |> Threads.to_atom()
+        thread_from_foreign_key(foreign_key)
 
       # 设置 root_comment_id：如果是回复评论，则使用被回复评论的 root_comment_id（如果存在）或其 ID
       root_comment_id =
@@ -157,5 +155,12 @@ defmodule GroupherServer.CMS.Comments.Helper do
       when not is_nil(reply_to_id) do
     # 兼容旧数据，当 root_comment_id 为 nil 时，回退到递归查询
     get_parent_comment(Repo.preload(comment.reply_to, reply_to: :author))
+  end
+
+  defp thread_from_foreign_key(foreign_key) when is_atom(foreign_key) do
+    case Enum.find(@article_threads, fn thread -> foreign_key == :"#{thread}_id" end) do
+      nil -> {:error, {:custom, "invalid article"}}
+      thread -> {:ok, thread}
+    end
   end
 end

--- a/backend/main/lib/groupher_server/cms/events/cite.ex
+++ b/backend/main/lib/groupher_server/cms/events/cite.ex
@@ -199,12 +199,23 @@ defmodule GroupherServer.CMS.Events.Cite do
     path_list = path |> String.split("/")
     article_id = path_list |> Enum.at(2)
 
-    with {:ok, thread} <- Threads.to_atom(path_list |> Enum.at(1)),
+    with {:ok, thread} <- parse_thread_slug(path_list |> Enum.at(1)),
          {:ok, info} <- match(thread),
          {:ok, article} <- FrontDesk.get(info.model, article_id) do
       {:ok, %{type: :article, artiment: article}}
     end
   end
+
+  defp parse_thread_slug(slug) when is_binary(slug) do
+    normalized = String.downcase(slug)
+
+    case Enum.find(Threads.article_enums(), fn thread -> Atom.to_string(thread) == normalized end) do
+      nil -> {:error, {:custom, "invalid thread"}}
+      thread -> {:ok, thread}
+    end
+  end
+
+  defp parse_thread_slug(_), do: {:error, {:custom, "invalid thread"}}
 
   defp citing_itself?(%Comment{id: source_id}, %{type: :comment, artiment: %{id: target_id}}),
     do: source_id == target_id

--- a/backend/main/lib/groupher_server/cms/front_desk.ex
+++ b/backend/main/lib/groupher_server/cms/front_desk.ex
@@ -119,12 +119,12 @@ defmodule GroupherServer.CMS.FrontDesk do
 
   @doc "get thread of comment or article"
   @spec thread_of(Comment.t()) :: {:ok, atom()} | {:error, map()}
-  def thread_of(%Comment{thread: thread}) do
+  def thread_of(%Comment{thread: thread}) when is_atom(thread) do
     Threads.to_atom(thread)
   end
 
   @spec thread_of(map()) :: {:ok, atom()} | {:error, map()}
-  def thread_of(%{meta: %{thread: thread}}) do
+  def thread_of(%{meta: %{thread: thread}}) when is_atom(thread) do
     Threads.to_atom(thread)
   end
 

--- a/backend/main/lib/groupher_server/cms/helper/threads.ex
+++ b/backend/main/lib/groupher_server/cms/helper/threads.ex
@@ -24,20 +24,5 @@ defmodule GroupherServer.CMS.Helper.Threads do
 
   def to_atom(value) when is_atom(value) and value in @values, do: {:ok, value}
 
-  def to_atom(value) when is_binary(value) do
-    normalized =
-      value
-      |> String.downcase()
-      |> String.to_existing_atom()
-
-    if normalized in @values do
-      {:ok, normalized}
-    else
-      {:error, {:custom, "invalid thread"}}
-    end
-  rescue
-    ArgumentError -> {:error, {:custom, "invalid thread"}}
-  end
-
   def to_atom(_), do: {:error, {:custom, "invalid thread"}}
 end

--- a/backend/main/lib/groupher_server/cms/seeds/tags.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/tags.ex
@@ -9,7 +9,7 @@ defmodule GroupherServer.CMS.Seeds.Tags do
   alias CMS.Model.Community
   alias Helper.T
 
-  @tag_colors ["red", "orange", "yellow", "green", "cyan", "blue", "purple", "pink", "grey"]
+  @tag_colors ["red", "orange", "yellow", "green", "cyan", "blue", "purple", "pink"]
   @seed_groups ["General", "Engineering", "Resources", "Ecosystem"]
   @tag_title_zh ["排查", "经验", "讨论", "实战", "建议", "复盘", "教程", "技巧", "案例", "工具"]
   @tag_title_en [
@@ -38,32 +38,44 @@ defmodule GroupherServer.CMS.Seeds.Tags do
 
     with {:ok, bot} <- GroupherServer.CMS.Seeds.Helper.seed_bot(),
          {:ok, existing} <- CMS.Communities.paged_tags(tag_filter(community.id, thread)) do
-      needed = max(count - length(existing.entries), 0)
-
-      Enum.each(1..needed, fn index ->
-        group = Enum.at(groups, rem(index - 1, length(groups)))
-        lang = if index <= div(count, 2), do: :zh, else: :en
-
-        title_seed =
-          case lang do
-            :zh -> Enum.at(@tag_title_zh, rem(index - 1, length(@tag_title_zh)))
-            :en -> Enum.at(@tag_title_en, rem(index - 1, length(@tag_title_en)))
-          end
-
-        attrs = %{
-          title: "#{title_seed}#{index}",
-          slug: "#{thread}-#{lang}-#{index}-#{System.unique_integer([:positive, :monotonic])}",
-          group: group,
-          color: random_color()
-        }
-
-        CMS.Communities.create_tag(community, thread, attrs, bot)
-      end)
-
-      with {:ok, tags} <- CMS.Communities.paged_tags(tag_filter(community.id, thread)) do
+      with :ok <- ensure_tags_count(community, thread, bot, groups, count, length(existing.entries)),
+           {:ok, tags} <- CMS.Communities.paged_tags(tag_filter(community.id, thread)) do
         {:ok, Enum.map(tags.entries, & &1.id)}
       end
     end
+  end
+
+  defp ensure_tags_count(_community, _thread, _bot, _groups, target_count, current_count)
+       when current_count >= target_count,
+       do: :ok
+
+  defp ensure_tags_count(community, thread, bot, groups, target_count, current_count) do
+    index = current_count + 1
+    attrs = build_tag_attrs(thread, groups, target_count, index)
+
+    with {:ok, _tag} <- CMS.Communities.create_tag(community, thread, attrs, bot) do
+      ensure_tags_count(community, thread, bot, groups, target_count, index)
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp build_tag_attrs(thread, groups, target_count, index) do
+    group = Enum.at(groups, rem(index - 1, length(groups)))
+    lang = if index <= div(target_count, 2), do: :zh, else: :en
+
+    title_seed =
+      case lang do
+        :zh -> Enum.at(@tag_title_zh, rem(index - 1, length(@tag_title_zh)))
+        :en -> Enum.at(@tag_title_en, rem(index - 1, length(@tag_title_en)))
+      end
+
+    %{
+      title: "#{title_seed}#{index}",
+      slug: "#{thread}-#{lang}-#{index}-#{System.unique_integer([:positive, :monotonic])}",
+      group: group,
+      color: random_color()
+    }
   end
 
   defp random_range({min, max}) when is_integer(min) and is_integer(max) and min <= max,

--- a/backend/main/lib/groupher_server/messaging/mentions.ex
+++ b/backend/main/lib/groupher_server/messaging/mentions.ex
@@ -74,12 +74,14 @@ defmodule GroupherServer.Messaging.Mentions do
     end
   end
 
-  defp normalize_mention(%{thread: thread} = mention) do
+  defp normalize_mention(%{thread: thread} = mention) when is_atom(thread) do
     case Threads.to_atom(thread) do
       {:ok, thread} -> {:ok, %{mention | thread: thread}}
       {:error, _reason} -> {:error, "insert mentions error"}
     end
   end
+
+  defp normalize_mention(%{thread: _thread}), do: {:error, "insert mentions error"}
 
   defp normalize_mention(mention), do: {:ok, mention}
 

--- a/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
+++ b/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
@@ -7,7 +7,7 @@ defmodule GroupherServerWeb.Resolvers.CMS do
   alias GroupherServer.{Accounts, CMS}
 
   alias Accounts.Model.User
-  alias CMS.Helper.{EmotionFormatter, Threads}
+  alias CMS.Helper.EmotionFormatter
   alias CMS.Model.{Category, Community}
   alias Helper.{OgInfo, ORM}
 
@@ -465,7 +465,6 @@ defmodule GroupherServerWeb.Resolvers.CMS do
 
   defp normalize_thread(nil), do: {:ok, :post}
   defp normalize_thread(thread) when is_atom(thread), do: {:ok, thread}
-  defp normalize_thread(thread) when is_binary(thread), do: Threads.to_atom(thread)
 
   ############
   ############

--- a/backend/main/lib/helper/query_builder.ex
+++ b/backend/main/lib/helper/query_builder.ex
@@ -10,6 +10,7 @@ defmodule Helper.QueryBuilder do
 
   @article_cat ArticleEnums.cat_values()
   @article_state ArticleEnums.state_values()
+  @threads Threads.enums()
 
   @audit_illegal Constant.CMS.pending(:illegal)
   @audit_failed Constant.CMS.pending(:audit_failed)
@@ -221,9 +222,9 @@ defmodule Helper.QueryBuilder do
         )
 
       {:thread, thread}, queryable ->
-        case Threads.to_atom(thread) do
-          {:ok, thread} -> from(q in queryable, where: q.thread == ^thread)
-          {:error, _} -> from(q in queryable, where: false)
+        case is_atom(thread) and thread in @threads do
+          true -> from(q in queryable, where: q.thread == ^thread)
+          false -> from(q in queryable, where: false)
         end
 
       {:community_id, community_id}, queryable ->
@@ -277,26 +278,11 @@ defmodule Helper.QueryBuilder do
     end
   end
 
-  defp trans_article_cat(queryable, cat) when is_binary(cat) do
-    cat_value = find_article_enum(@article_cat, cat)
-    trans_article_cat(queryable, cat_value || :__invalid__)
-  end
-
   defp trans_article_state(queryable, state) when is_atom(state) do
     case state in @article_state do
       true -> queryable |> where([p], p.state == ^state)
       false -> queryable |> where([p], p.id == -1)
     end
-  end
-
-  defp trans_article_state(queryable, state) when is_binary(state) do
-    state_value = find_article_enum(@article_state, state)
-    trans_article_state(queryable, state_value || :__invalid__)
-  end
-
-  defp find_article_enum(values, input) do
-    input = input |> String.downcase()
-    Enum.find(values, fn value -> Atom.to_string(value) == input end)
   end
 
   defp trans_articles_order(queryable, :upvotes) do

--- a/backend/main/test/groupher_server/accounts/mailbox/mailbox_test.exs
+++ b/backend/main/test/groupher_server/accounts/mailbox/mailbox_test.exs
@@ -42,7 +42,7 @@ defmodule GroupherServer.Test.Accounts.Mailbox do
 
       mention_contents = [
         %{
-          thread: "POST",
+          thread: :post,
           title: post.title,
           article_id: post.id,
           comment_id: nil,

--- a/backend/main/test/groupher_server/accounts/upvotes/reacted_articles_test.exs
+++ b/backend/main/test/groupher_server/accounts/upvotes/reacted_articles_test.exs
@@ -39,15 +39,11 @@ defmodule GroupherServer.Test.Accounts.ReactedContents do
       assert 1 == articles |> Map.get(:total_count)
     end
 
-    test "invalid thread filter returns empty pagination instead of crashing", ~m(user post)a do
+    test "invalid thread filter returns explicit error", ~m(user post)a do
       {:ok, _} = CMS.Articles.upvote(post, user)
 
       filter = %{thread: "INVALID", page: 1, size: 20}
-      {:ok, articles} = Accounts.paged_articles(user.id, filter)
-
-      assert articles |> is_valid_pagination?(:raw)
-      assert articles.entries == []
-      assert articles.total_count == 0
+      assert {:error, {:custom, "invalid thread"}} = Accounts.paged_articles(user.id, filter)
     end
   end
 end

--- a/backend/main/test/groupher_server/cms/can_can/communities_test.exs
+++ b/backend/main/test/groupher_server/cms/can_can/communities_test.exs
@@ -79,8 +79,8 @@ defmodule GroupherServer.Test.CMS.CanCan.Communities do
       assert {:ok, :post} = CanCan.allow_thread(community.slug, :post)
     end
 
-    test "allow_thread normalizes string threads before visibility checks", ~m(community)a do
-      assert {:ok, :post} = CanCan.allow_thread(community.slug, "POST")
+    test "allow_thread rejects non-atom threads", ~m(community)a do
+      assert {:error, {:custom, "invalid thread"}} = CanCan.allow_thread(community.slug, "POST")
     end
 
     test "allow_thread returns cancan error key when disabled", ~m(community)a do

--- a/backend/main/test/groupher_server/cms/polymorphic_article_constraints_test.exs
+++ b/backend/main/test/groupher_server/cms/polymorphic_article_constraints_test.exs
@@ -32,13 +32,13 @@ defmodule GroupherServer.Test.CMS.PolymorphicArticleConstraintsTest do
                |> Comment.changeset(Map.put(attrs, :blog_id, blog.id))
                |> Repo.insert()
 
-      assert "is invalid" in errors_on(changeset).thread
+      assert "is invalid" in errors_on(changeset).post_id
     end
 
     test "comment rejects thread mismatches article ref", ~m(post user)a do
       attrs =
         valid_comment_attrs(user.id, post.id)
-        |> Map.put(:thread, "BLOG")
+        |> Map.put(:thread, :blog)
 
       assert {:error, changeset} =
                %Comment{}
@@ -49,18 +49,18 @@ defmodule GroupherServer.Test.CMS.PolymorphicArticleConstraintsTest do
     end
 
     test "article upvote rejects multiple article refs", ~m(post blog user)a do
-      attrs = %{user_id: user.id, thread: "POST", post_id: post.id, blog_id: blog.id}
+      attrs = %{user_id: user.id, thread: :post, post_id: post.id, blog_id: blog.id}
 
       assert {:error, changeset} =
                %ArticleUpvote{}
                |> ArticleUpvote.changeset(attrs)
                |> Repo.insert()
 
-      assert "is invalid" in errors_on(changeset).thread
+      assert "is invalid" in errors_on(changeset).post_id
     end
 
     test "article collect rejects thread mismatches article ref", ~m(post user)a do
-      attrs = %{user_id: user.id, thread: "BLOG", post_id: post.id, collect_folders: []}
+      attrs = %{user_id: user.id, thread: :blog, post_id: post.id, collect_folders: []}
 
       assert {:error, changeset} =
                %ArticleCollect{}
@@ -138,7 +138,7 @@ defmodule GroupherServer.Test.CMS.PolymorphicArticleConstraintsTest do
       author_id: user_id,
       body: "comment-body",
       body_html: "<p>comment-body</p>",
-      thread: "POST",
+      thread: :post,
       post_id: post_id,
       emotions: Embeds.CommentEmotion.default_emotions(),
       meta: Embeds.CommentMeta.default_meta()

--- a/backend/main/test/groupher_server/messaging/mention_test.exs
+++ b/backend/main/test/groupher_server/messaging/mention_test.exs
@@ -16,7 +16,7 @@ defmodule GroupherServer.Test.Messaging.Mention do
     {:ok, community} = CMS.Communities.create(community_attrs, user)
 
     mention_attr = %{
-      thread: "POST",
+      thread: :post,
       title: post.title,
       article_id: post.id,
       comment_id: nil,

--- a/backend/main/test/groupher_server/seeds/full_community_test.exs
+++ b/backend/main/test/groupher_server/seeds/full_community_test.exs
@@ -63,7 +63,7 @@ defmodule GroupherServer.Test.Seeds.FullCommunityTest do
           page: 1,
           size: 100,
           community_id: community.id,
-          thread: "POST"
+          thread: :post
         })
 
       assert paged_post_tags.total_count in 10..20

--- a/backend/main/test/groupher_server/seeds/tags_test.exs
+++ b/backend/main/test/groupher_server/seeds/tags_test.exs
@@ -27,7 +27,7 @@ defmodule GroupherServer.Test.Seeds.TagsTest do
 
     test "random_color returns valid color atom" do
       color = Tags.random_color()
-      assert color in [:red, :orange, :yellow, :green, :cyan, :blue, :purple, :pink, :grey]
+      assert color in [:red, :orange, :yellow, :green, :cyan, :blue, :purple, :pink]
     end
   end
 end

--- a/backend/main/test/groupher_server/seeds/tags_test.exs
+++ b/backend/main/test/groupher_server/seeds/tags_test.exs
@@ -19,7 +19,7 @@ defmodule GroupherServer.Test.Seeds.TagsTest do
           page: 1,
           size: 100,
           community_id: community.id,
-          thread: "POST"
+          thread: :post
         })
 
       assert paged_tags.total_count >= 4


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require atom-only threads across the backend, remove string normalization, and return explicit errors for invalid inputs. Also fix cite URL parsing and tag seeds to use atom threads; remove `:grey` from tag colors.

- **Refactors**
  - Require atom threads in permission checks, mentions, comments (derive from foreign key), front desk, query filters, upvotes, GraphQL, and tag seeds; reject non-atom values with `{:error, {:custom, "invalid thread"}}` (mentions return "insert mentions error"; upvotes pagination returns explicit error). Drop `:grey` from tag color palette.
  - Remove binary-to-atom normalization in `Threads.to_atom/1` and query helpers; validate using guards and whitelists (e.g., `@threads`).
  - Add `thread_from_foreign_key/1` to derive comment threads from `*_id` atoms using article enums; invalid refs return `{:error, {:custom, "invalid article"}}`.
  - Parse cite URL slugs to atom threads via enum whitelist; invalid slugs return `{:error, {:custom, "invalid thread"}}`.

- **Migration**
  - Pass atom threads (e.g., `:post`) and states to all APIs; stop sending strings.
  - Update mention/comment creation to use atom threads and correct `*_id` fields.
  - Handle `{:error, {:custom, "invalid thread"}}` from thread-dependent calls like `Accounts.paged_articles/2` and `CanCan.allow_thread/allow_emotion`.

<sup>Written for commit 03adceaf6d44d5c46cc42ef5c8c4b702d4871212. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread validation now enforces stricter type requirements with explicit error messages.
  * Improved error handling in comment creation, filtering, and upvote operations.
  * Enhanced API consistency by properly rejecting malformed parameters.
  * Fixed edge cases where invalid inputs previously resulted in empty datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->