### PR TITLE
chore: dashboard -> dsb_ naming adjust

### DIFF
--- a/backend/main/lib/groupher_server/cms/can_can/communities.ex
+++ b/backend/main/lib/groupher_server/cms/can_can/communities.ex
@@ -91,7 +91,7 @@ defmodule GroupherServer.CMS.CanCan.Communities do
     fallback = Map.get(@default_thread_emotions, thread_key, [])
 
     community_slug
-    |> community_override(thread_key)
+    |> dsb_thread_emotions_override(thread_key)
     |> case do
       nil -> fallback
       override -> override
@@ -99,24 +99,24 @@ defmodule GroupherServer.CMS.CanCan.Communities do
     |> Enum.filter(&(&1 in @emotions_whitelist))
   end
 
-  defp dashboard_enable(nil), do: nil
+  defp dsb_enable(nil), do: nil
 
-  defp dashboard_enable(%{dashboard: %{enable: enable}}), do: enable
+  defp dsb_enable(%{dashboard: %{enable: enable}}), do: enable
 
-  defp dashboard_enable(%{community: community_slug}) when is_binary(community_slug) do
-    dashboard_enable(community_slug)
+  defp dsb_enable(%{community: community_slug}) when is_binary(community_slug) do
+    dsb_enable(community_slug)
   end
 
-  defp dashboard_enable(community_slug) when is_binary(community_slug) do
+  defp dsb_enable(community_slug) when is_binary(community_slug) do
     case FrontDesk.community(community_slug) do
       {:ok, %{dashboard: %{enable: enable}}} -> enable
       _ -> nil
     end
   end
 
-  defp community_override(nil, _thread_key), do: nil
+  defp dsb_thread_emotions_override(nil, _thread_key), do: nil
 
-  defp community_override(community_slug, thread_key) when is_binary(community_slug) do
+  defp dsb_thread_emotions_override(community_slug, thread_key) when is_binary(community_slug) do
     case FrontDesk.community(community_slug) do
       {:ok, %{dashboard: %{thread_emotions: thread_emotions}}} when not is_nil(thread_emotions) ->
         Map.get(thread_emotions, thread_key)
@@ -126,19 +126,19 @@ defmodule GroupherServer.CMS.CanCan.Communities do
     end
   end
 
-  defp community_override(%{dashboard: %{thread_emotions: thread_emotions}}, thread_key)
+  defp dsb_thread_emotions_override(%{dashboard: %{thread_emotions: thread_emotions}}, thread_key)
        when not is_nil(thread_emotions) do
     Map.get(thread_emotions, thread_key)
   end
 
-  defp community_override(_, _thread_key), do: nil
+  defp dsb_thread_emotions_override(_, _thread_key), do: nil
 
   defp emotion_allowed?(community_slug, scope, thread, emotion) do
     emotion in allowed_emotions(community_slug, scope, thread)
   end
 
   defp thread_visible?(community, thread) do
-    case dashboard_enable(community) do
+    case dsb_enable(community) do
       nil -> true
       enable -> Map.get(enable, thread, true)
     end

--- a/backend/main/lib/groupher_server/cms/communities/dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/communities/dashboard.ex
@@ -11,7 +11,7 @@ defmodule GroupherServer.CMS.Communities.Dashboard do
   alias Helper.{ORM, T, Transaction}
 
   @default_dashboard CommunityDashboard.default()
-  # List-like dashboard sections are replaced as a whole on each update.
+  # List-like dsb sections are replaced as a whole on each update.
   @replace_section_fields [
     :header_links,
     :footer_links,
@@ -54,8 +54,8 @@ defmodule GroupherServer.CMS.Communities.Dashboard do
   defp do_update(%Community{} = community, key, args) do
     with {:ok, community_dashboard} <- ensure_exist(community),
          {:ok, section_payload} <-
-           prepare_dashboard_section_payload(community_dashboard, key, args),
-         {:ok, _} <- apply_dashboard_section_update(community_dashboard, key, section_payload) do
+           prepare_dsb_section_payload(community_dashboard, key, args),
+         {:ok, _} <- apply_dsb_section_update(community_dashboard, key, section_payload) do
       {:ok, community}
     end
   end
@@ -86,7 +86,7 @@ defmodule GroupherServer.CMS.Communities.Dashboard do
 
   # For embeds_one sections, always prepare the merged final payload first so
   # validation and persistence operate on the same data.
-  defp prepare_dashboard_section_payload(%CommunityDashboard{} = community_dashboard, key, args)
+  defp prepare_dsb_section_payload(%CommunityDashboard{} = community_dashboard, key, args)
        when key in @validated_embed_section_fields do
     embed_module = Map.fetch!(@embed_section_modules, key)
     current_embed = community_dashboard[key] || struct(embed_module)
@@ -106,7 +106,7 @@ defmodule GroupherServer.CMS.Communities.Dashboard do
     end
   end
 
-  defp prepare_dashboard_section_payload(%CommunityDashboard{}, key, args)
+  defp prepare_dsb_section_payload(%CommunityDashboard{}, key, args)
        when key in [:header_links, :footer_links] and is_list(args) do
     if Enum.all?(args, &valid_tree_link?/1) do
       {:ok, args}
@@ -116,7 +116,7 @@ defmodule GroupherServer.CMS.Communities.Dashboard do
   end
 
   # Replace-style sections are already the final payload.
-  defp prepare_dashboard_section_payload(%CommunityDashboard{}, _key, args), do: {:ok, args}
+  defp prepare_dsb_section_payload(%CommunityDashboard{}, _key, args), do: {:ok, args}
 
   defp valid_tree_link?(%{id: id, type: type, title: title} = item)
        when is_binary(id) and is_binary(title) do
@@ -142,13 +142,13 @@ defmodule GroupherServer.CMS.Communities.Dashboard do
   defp valid_link_children?(_), do: false
 
   # Replace-style sections are written as a whole on each update.
-  defp apply_dashboard_section_update(%CommunityDashboard{} = community_dashboard, key, args)
+  defp apply_dsb_section_update(%CommunityDashboard{} = community_dashboard, key, args)
        when key in @replace_section_fields do
-    ORM.replace_dashboard_section(community_dashboard, key, args)
+    ORM.replace_dsb_section(community_dashboard, key, args)
   end
 
   # embeds_one sections receive the validated final payload directly.
-  defp apply_dashboard_section_update(%CommunityDashboard{} = community_dashboard, key, args) do
-    ORM.replace_dashboard_section(community_dashboard, key, args)
+  defp apply_dsb_section_update(%CommunityDashboard{} = community_dashboard, key, args) do
+    ORM.replace_dsb_section(community_dashboard, key, args)
   end
 end

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_baseinfo.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_baseinfo.ex
@@ -10,15 +10,15 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardBaseInfo do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_default: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_default: 1, dsb_fields: 1]
 
-  @optional_fields dashboard_cast_fields(:base_info)
+  @optional_fields dsb_cast_fields(:base_info)
 
   @doc "for test usage"
-  def default, do: dashboard_default(:base_info)
+  def default, do: dsb_default(:base_info)
 
   embedded_schema do
-    dashboard_fields(:base_info)
+    dsb_fields(:base_info)
   end
 
   def changeset(struct, params) do

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_enable.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_enable.ex
@@ -10,17 +10,17 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardEnable do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_default: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_default: 1, dsb_fields: 1]
 
-  @optional_fields dashboard_cast_fields(:enable)
+  @optional_fields dsb_cast_fields(:enable)
 
   @doc "for test usage"
   def default do
-    dashboard_default(:enable)
+    dsb_default(:enable)
   end
 
   embedded_schema do
-    dashboard_fields(:enable)
+    dsb_fields(:enable)
   end
 
   @doc "for test usage"

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_faq.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_faq.ex
@@ -10,19 +10,19 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardFAQ do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_default: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_default: 1, dsb_fields: 1]
 
-  @optional_fields dashboard_cast_fields(:faq_section)
+  @optional_fields dsb_cast_fields(:faq_section)
 
   @doc "for test usage"
   def default do
     [
-      dashboard_default(:faq_section)
+      dsb_default(:faq_section)
     ]
   end
 
   embedded_schema do
-    dashboard_fields(:faq_section)
+    dsb_fields(:faq_section)
   end
 
   def changeset(struct, params) do

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_layout.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_layout.ex
@@ -10,7 +10,7 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardLayout do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_fields: 1]
 
   alias GroupherServer.CMS
 
@@ -18,7 +18,7 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardLayout do
   alias CMS.Model.Metrics.Dashboard
   @hex_color_re ~r/^#[0-9a-fA-F]{6}$/
 
-  @optional_fields dashboard_cast_fields(:layout)
+  @optional_fields dsb_cast_fields(:layout)
   @layout_schema Dashboard.macro_schema(:layout)
   @enum_fields Enum.flat_map(@layout_schema, fn
                  [key, :enum, _default] -> [key]
@@ -35,7 +35,7 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardLayout do
   def default, do: Dashboard.layout_default()
 
   embedded_schema do
-    dashboard_fields(:layout)
+    dsb_fields(:layout)
   end
 
   @doc "for test usage"
@@ -138,7 +138,12 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardLayout do
   end
 
   defp validate_custom_colors(changeset) do
-    [:primary_custom_color, :primary_custom_color_dark, :sub_primary_custom_color, :sub_primary_custom_color_dark]
+    [
+      :primary_custom_color,
+      :primary_custom_color_dark,
+      :sub_primary_custom_color,
+      :sub_primary_custom_color_dark
+    ]
     |> Enum.reduce(changeset, fn field, acc ->
       validate_change(acc, field, fn ^field, value ->
         cond do

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_media_report.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_media_report.ex
@@ -10,19 +10,19 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardMediaReport do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_default: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_default: 1, dsb_fields: 1]
 
-  @optional_fields dashboard_cast_fields(:media_report)
+  @optional_fields dsb_cast_fields(:media_report)
 
   @doc "for test usage"
   def default do
     [
-      dashboard_default(:media_report)
+      dsb_default(:media_report)
     ]
   end
 
   embedded_schema do
-    dashboard_fields(:media_report)
+    dsb_fields(:media_report)
   end
 
   def changeset(struct, params) do

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_name_alias.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_name_alias.ex
@@ -10,19 +10,19 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardNameAlias do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_default: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_default: 1, dsb_fields: 1]
 
-  @optional_fields dashboard_cast_fields(:name_alias)
+  @optional_fields dsb_cast_fields(:name_alias)
 
   @doc "for test usage"
   def default do
     [
-      dashboard_default(:name_alias)
+      dsb_default(:name_alias)
     ]
   end
 
   embedded_schema do
-    dashboard_fields(:name_alias)
+    dsb_fields(:name_alias)
   end
 
   def changeset(struct, params) do

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_rss.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_rss.ex
@@ -10,15 +10,15 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardRSS do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_default: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_default: 1, dsb_fields: 1]
 
-  @optional_fields dashboard_cast_fields(:rss)
+  @optional_fields dsb_cast_fields(:rss)
 
   @doc "for test usage"
-  def default, do: dashboard_default(:rss)
+  def default, do: dsb_default(:rss)
 
   embedded_schema do
-    dashboard_fields(:rss)
+    dsb_fields(:rss)
   end
 
   def changeset(struct, params) do

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_seo.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_seo.ex
@@ -10,15 +10,15 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardSEO do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_default: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_default: 1, dsb_fields: 1]
 
-  @optional_fields dashboard_cast_fields(:seo)
+  @optional_fields dsb_cast_fields(:seo)
 
   @doc "for test usage"
-  def default, do: dashboard_default(:seo)
+  def default, do: dsb_default(:seo)
 
   embedded_schema do
-    dashboard_fields(:seo)
+    dsb_fields(:seo)
   end
 
   def changeset(struct, params) do

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_social_link.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_social_link.ex
@@ -10,19 +10,19 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardSocialLink do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_default: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_default: 1, dsb_fields: 1]
 
-  @optional_fields dashboard_cast_fields(:social_link)
+  @optional_fields dsb_cast_fields(:social_link)
 
   @doc "for test usage"
   def default do
     [
-      dashboard_default(:social_link)
+      dsb_default(:social_link)
     ]
   end
 
   embedded_schema do
-    dashboard_fields(:social_link)
+    dsb_fields(:social_link)
   end
 
   def changeset(struct, params) do

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard_wallpaper.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard_wallpaper.ex
@@ -10,15 +10,15 @@ defmodule GroupherServer.CMS.Model.Embeds.DashboardWallpaper do
   import Ecto.Changeset
 
   import GroupherServerWeb.Schema.Helper.Fields,
-    only: [dashboard_cast_fields: 1, dashboard_default: 1, dashboard_fields: 1]
+    only: [dsb_cast_fields: 1, dsb_default: 1, dsb_fields: 1]
 
-  @optional_fields dashboard_cast_fields(:wallpaper)
+  @optional_fields dsb_cast_fields(:wallpaper)
 
   @doc "for test usage"
-  def default, do: dashboard_default(:wallpaper)
+  def default, do: dsb_default(:wallpaper)
 
   embedded_schema do
-    dashboard_fields(:wallpaper)
+    dsb_fields(:wallpaper)
   end
 
   def changeset(struct, params) do

--- a/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
+++ b/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
@@ -38,7 +38,7 @@ defmodule GroupherServerWeb.Resolvers.CMS do
     CMS.Communities.update(community, args)
   end
 
-  def update_dashboard(_root, %{community: community, dashboard_section: key} = args, _info) do
+  def update_dashboard(_root, %{community: community, dsb_section: key} = args, _info) do
     special_keys = [
       :header_links,
       :footer_links,
@@ -48,13 +48,13 @@ defmodule GroupherServerWeb.Resolvers.CMS do
       :faqs
     ]
 
-    dashboard_args =
+    dsb_args =
       case key in special_keys do
-        true -> Map.drop(args, [:community, :dashboard_section]) |> Map.get(key)
-        false -> Map.drop(args, [:community, :dashboard_section])
+        true -> Map.drop(args, [:community, :dsb_section]) |> Map.get(key)
+        false -> Map.drop(args, [:community, :dsb_section])
       end
 
-    CMS.Communities.update_dashboard(community, key, dashboard_args)
+    CMS.Communities.update_dashboard(community, key, dsb_args)
   end
 
   def open_graph_info(_root, %{url: url}, _info), do: OgInfo.get(url)

--- a/backend/main/lib/groupher_server_web/schema.ex
+++ b/backend/main/lib/groupher_server_web/schema.ex
@@ -52,7 +52,7 @@ defmodule GroupherServerWeb.Schema do
     import_article_fields(:mutations)
 
     import_fields(:cms_comment_mutations)
-    import_fields(:cms_dashboard_mutations)
+    import_fields(:cms_dsb_mutations)
   end
 
   def middleware(middleware, _field, %{identifier: :query}) do

--- a/backend/main/lib/groupher_server_web/schema/cms/cms_metrics.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/cms_metrics.ex
@@ -47,7 +47,7 @@ defmodule GroupherServerWeb.Schema.CMS.Metrics do
     enum_values(Threads.values())
   end
 
-  enum :dashboard_section do
+  enum :dsb_section do
     value(:seo)
     value(:wallpaper)
     value(:enable)
@@ -319,8 +319,8 @@ defmodule GroupherServerWeb.Schema.CMS.Metrics do
     field(:link, :string)
   end
 
-  input_object :dashboard_alias_map do
-    dashboard_gq_fields(:name_alias)
+  input_object :dsb_alias_map do
+    dsb_gq_fields(:name_alias)
   end
 
   input_object :dsb_link_child_map do
@@ -337,15 +337,15 @@ defmodule GroupherServerWeb.Schema.CMS.Metrics do
     field(:links, list_of(:dsb_link_child_map))
   end
 
-  input_object :dashboard_social_link_map do
-    dashboard_gq_fields(:social_link)
+  input_object :dsb_social_link_map do
+    dsb_gq_fields(:social_link)
   end
 
-  input_object :dashboard_media_report_map do
-    dashboard_gq_fields(:media_report)
+  input_object :dsb_media_report_map do
+    dsb_gq_fields(:media_report)
   end
 
-  input_object :dashboard_faq_map do
-    dashboard_gq_fields(:faq_section)
+  input_object :dsb_faq_map do
+    dsb_gq_fields(:faq_section)
   end
 end

--- a/backend/main/lib/groupher_server_web/schema/cms/cms_types.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/cms_types.ex
@@ -121,17 +121,17 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     field(:records, list_of(:contribute))
   end
 
-  object(:dashboard_rss, do: dashboard_gq_fields(:rss))
-  object(:dashboard_seo, do: dashboard_gq_fields(:seo))
-  object(:dashboard_wallpaper, do: dashboard_gq_fields(:wallpaper))
+  object(:dsb_rss, do: dsb_gq_fields(:rss))
+  object(:dsb_seo, do: dsb_gq_fields(:seo))
+  object(:dsb_wallpaper, do: dsb_gq_fields(:wallpaper))
 
-  object :dashboard_layout do
-    dashboard_gq_fields(:layout)
+  object :dsb_layout do
+    dsb_gq_fields(:layout)
   end
 
-  object(:dashboard_enable, do: dashboard_gq_fields(:enable))
+  object(:dsb_enable, do: dsb_gq_fields(:enable))
 
-  object :dashboard_thread_emotions do
+  object :dsb_thread_emotions do
     field(:post, list_of(:emotion_type))
     field(:blog, list_of(:emotion_type))
     field(:changelog, list_of(:emotion_type))
@@ -142,8 +142,8 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     field(:doc_comment, list_of(:emotion_type))
   end
 
-  object(:dashboard_base_info, do: dashboard_gq_fields(:base_info))
-  object(:dashboard_name_alias, do: dashboard_gq_fields(:name_alias))
+  object(:dsb_base_info, do: dsb_gq_fields(:base_info))
+  object(:dsb_name_alias, do: dsb_gq_fields(:name_alias))
 
   object :dsb_link_child do
     field(:id, :string)
@@ -159,24 +159,24 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     field(:links, list_of(:dsb_link_child))
   end
 
-  object(:dashboard_social_link, do: dashboard_gq_fields(:social_link))
-  object(:dashboard_media_report, do: dashboard_gq_fields(:media_report))
-  object(:dashboard_faq_section, do: dashboard_gq_fields(:faq_section))
+  object(:dsb_social_link, do: dsb_gq_fields(:social_link))
+  object(:dsb_media_report, do: dsb_gq_fields(:media_report))
+  object(:dsb_faq_section, do: dsb_gq_fields(:faq_section))
 
-  object :dashboard do
-    field(:seo, :dashboard_seo)
-    field(:wallpaper, :dashboard_wallpaper)
-    field(:layout, :dashboard_layout)
-    field(:enable, :dashboard_enable)
-    field(:thread_emotions, :dashboard_thread_emotions)
-    field(:base_info, :dashboard_base_info)
-    field(:rss, :dashboard_rss)
-    field(:name_alias, list_of(:dashboard_name_alias))
+  object :dsb do
+    field(:seo, :dsb_seo)
+    field(:wallpaper, :dsb_wallpaper)
+    field(:layout, :dsb_layout)
+    field(:enable, :dsb_enable)
+    field(:thread_emotions, :dsb_thread_emotions)
+    field(:base_info, :dsb_base_info)
+    field(:rss, :dsb_rss)
+    field(:name_alias, list_of(:dsb_name_alias))
     field(:header_links, list_of(:dsb_link))
     field(:footer_links, list_of(:dsb_link))
-    field(:social_links, list_of(:dashboard_social_link))
-    field(:media_reports, list_of(:dashboard_media_report))
-    field(:faqs, list_of(:dashboard_faq_section))
+    field(:social_links, list_of(:dsb_social_link))
+    field(:media_reports, list_of(:dsb_media_report))
+    field(:faqs, list_of(:dsb_faq_section))
   end
 
   object :community_moderator do
@@ -203,7 +203,7 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     field(:author, :user, resolve: dataloader(CMS, :author))
     field(:locale, :string)
     field(:categories, list_of(:category), resolve: dataloader(CMS, :categories))
-    field(:dashboard, :dashboard, resolve: dataloader(CMS, :dashboard))
+    field(:dashboard, :dsb, resolve: dataloader(CMS, :dashboard))
 
     # field(:moderators, list_of(:community_moderator), resolve: dataloader(CMS, moderators: :user))
     field(:moderators, list_of(:community_moderator))

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/dashboard.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/dashboard.ex
@@ -4,15 +4,15 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
   """
   use Helper.GqlSchemaSuite
 
-  import GroupherServerWeb.Schema.Helper.Fields, only: [dashboard_args: 1]
+  import GroupherServerWeb.Schema.Helper.Fields, only: [dsb_args: 1]
 
-  object :cms_dashboard_mutations do
+  object :cms_dsb_mutations do
     @desc "update base info in dashboard"
     field :update_dashboard_base_info, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :base_info)
+      arg(:dsb_section, :dsb_section, default_value: :base_info)
 
-      dashboard_args(:base_info)
+      dsb_args(:base_info)
 
       middleware(M.Authorize, :login)
       # middleware(M.PublishThrottle)
@@ -25,9 +25,9 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update seo in dashboard"
     field :update_dashboard_seo, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :seo)
+      arg(:dsb_section, :dsb_section, default_value: :seo)
 
-      dashboard_args(:seo)
+      dsb_args(:seo)
 
       middleware(M.Authorize, :login)
       # middleware(M.PublishThrottle)
@@ -40,9 +40,9 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update wallpaper in dashboard"
     field :update_dashboard_wallpaper, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :wallpaper)
+      arg(:dsb_section, :dsb_section, default_value: :wallpaper)
 
-      dashboard_args(:wallpaper)
+      dsb_args(:wallpaper)
 
       middleware(M.Authorize, :login)
       # middleware(M.PublishThrottle)
@@ -55,9 +55,9 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update enable in dashboard"
     field :update_dashboard_enable, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :enable)
+      arg(:dsb_section, :dsb_section, default_value: :enable)
 
-      dashboard_args(:enable)
+      dsb_args(:enable)
 
       middleware(M.Authorize, :login)
       # middleware(M.PublishThrottle)
@@ -70,7 +70,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update thread-specific emotion settings in dashboard"
     field :update_dashboard_thread_emotions, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :thread_emotions)
+      arg(:dsb_section, :dsb_section, default_value: :thread_emotions)
 
       arg(:post, list_of(:emotion_type))
       arg(:blog, list_of(:emotion_type))
@@ -91,9 +91,9 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update layout in dashboard"
     field :update_dashboard_layout, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :layout)
+      arg(:dsb_section, :dsb_section, default_value: :layout)
 
-      dashboard_args(:layout)
+      dsb_args(:layout)
 
       middleware(M.Authorize, :login)
       # middleware(M.PublishThrottle)
@@ -106,9 +106,9 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update rss in dashboard"
     field :update_dashboard_rss, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :rss)
+      arg(:dsb_section, :dsb_section, default_value: :rss)
 
-      dashboard_args(:rss)
+      dsb_args(:rss)
 
       middleware(M.Authorize, :login)
       middleware(M.Passport, action: "dashboard.rss.update")
@@ -123,9 +123,9 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update name alias in dashboard"
     field :update_dashboard_name_alias, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :name_alias)
+      arg(:dsb_section, :dsb_section, default_value: :name_alias)
 
-      arg(:name_alias, list_of(:dashboard_alias_map))
+      arg(:name_alias, list_of(:dsb_alias_map))
 
       middleware(M.Authorize, :login)
       # middleware(M.PublishThrottle)
@@ -138,7 +138,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update header links in dashboard"
     field :update_dashboard_header_links, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :header_links)
+      arg(:dsb_section, :dsb_section, default_value: :header_links)
 
       arg(:header_links, list_of(:dsb_link_map))
 
@@ -153,7 +153,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update footer links in dashboard"
     field :update_dashboard_footer_links, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :footer_links)
+      arg(:dsb_section, :dsb_section, default_value: :footer_links)
       arg(:footer_links, list_of(:dsb_link_map))
 
       middleware(M.Authorize, :login)
@@ -167,9 +167,9 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update social links in dashboard"
     field :update_dashboard_social_links, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :social_links)
+      arg(:dsb_section, :dsb_section, default_value: :social_links)
 
-      arg(:social_links, list_of(:dashboard_social_link_map))
+      arg(:social_links, list_of(:dsb_social_link_map))
 
       middleware(M.Authorize, :login)
       # middleware(M.PublishThrottle)
@@ -182,8 +182,8 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update media reports in dashboard"
     field :update_dashboard_media_reports, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :media_reports)
-      arg(:media_reports, list_of(:dashboard_media_report_map))
+      arg(:dsb_section, :dsb_section, default_value: :media_reports)
+      arg(:media_reports, list_of(:dsb_media_report_map))
 
       middleware(M.Authorize, :login)
       # middleware(M.PublishThrottle)
@@ -196,9 +196,9 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Dashboard do
     @desc "update faqs in dashboard"
     field :update_dashboard_faqs, :community do
       arg(:community, non_null(:string))
-      arg(:dashboard_section, :dashboard_section, default_value: :faqs)
+      arg(:dsb_section, :dsb_section, default_value: :faqs)
 
-      arg(:faqs, list_of(:dashboard_faq_map))
+      arg(:faqs, list_of(:dsb_faq_map))
 
       middleware(M.Authorize, :login)
       # middleware(M.PublishThrottle)

--- a/backend/main/lib/groupher_server_web/schema/helper/fields.ex
+++ b/backend/main/lib/groupher_server_web/schema/helper/fields.ex
@@ -274,9 +274,9 @@ defmodule GroupherServerWeb.Schema.Helper.Fields do
   end
 
   @doc """
-  fields for dashboard seo
+  fields for dsb seo
   """
-  defmacro dashboard_cast_fields(section \\ :layout) do
+  defmacro dsb_cast_fields(section \\ :layout) do
     schema = Dashboard.macro_schema(section) |> Macro.escape()
 
     quote do
@@ -286,7 +286,7 @@ defmodule GroupherServerWeb.Schema.Helper.Fields do
     end
   end
 
-  defmacro dashboard_args(section \\ :layout) do
+  defmacro dsb_args(section \\ :layout) do
     Dashboard.macro_schema(section)
     |> Enum.map(fn item ->
       [key, type, _default_v] = item
@@ -297,7 +297,7 @@ defmodule GroupherServerWeb.Schema.Helper.Fields do
     end)
   end
 
-  defmacro dashboard_fields(section \\ :layout) do
+  defmacro dsb_fields(section \\ :layout) do
     Dashboard.macro_schema(section)
     |> Enum.map(fn item ->
       [key, type, default_v] = item
@@ -305,7 +305,7 @@ defmodule GroupherServerWeb.Schema.Helper.Fields do
       case type do
         :enum ->
           quote do
-            # Dashboard enums use the default Ecto.Enum flow:
+            # Dsb enums use the default Ecto.Enum flow:
             #   [:quora, :ph] -> internal :quora / :ph -> DB "quora" / "ph"
             field(unquote(key), Ecto.Enum,
               values: unquote(Dashboard.enum_values(key)),
@@ -345,7 +345,7 @@ defmodule GroupherServerWeb.Schema.Helper.Fields do
     end)
   end
 
-  defmacro dashboard_gq_fields(section \\ :layout) do
+  defmacro dsb_gq_fields(section \\ :layout) do
     Dashboard.macro_schema(section)
     |> Enum.map(fn item ->
       [key, type, _default_v] = item
@@ -356,7 +356,7 @@ defmodule GroupherServerWeb.Schema.Helper.Fields do
     end)
   end
 
-  defmacro dashboard_default(section \\ :layout) do
+  defmacro dsb_default(section \\ :layout) do
     schema = Dashboard.macro_schema(section) |> Macro.escape()
 
     quote do
@@ -366,13 +366,13 @@ defmodule GroupherServerWeb.Schema.Helper.Fields do
     end
   end
 
-  # Convert dashboard metric DSL types to Ecto field types.
-  # Supports list-like types in shared dashboard schema definitions.
+  # Convert dsb metric DSL types to Ecto field types.
+  # Supports list-like types in shared dsb schema definitions.
   defp to_ecto_type({:array, inner}), do: {:array, to_ecto_type(inner)}
   defp to_ecto_type(type), do: type
 
-  # Convert dashboard metric DSL types to Absinthe field/arg type AST.
-  # Supports list-like types in shared dashboard schema definitions.
+  # Convert dsb metric DSL types to Absinthe field/arg type AST.
+  # Supports list-like types in shared dsb schema definitions.
   defp to_absinthe_type({:array, inner}, _key),
     do: quote(do: list_of(unquote(to_absinthe_type(inner, nil))))
 

--- a/backend/main/lib/helper/orm.ex
+++ b/backend/main/lib/helper/orm.ex
@@ -509,20 +509,20 @@ defmodule Helper.ORM do
   end
 
   @doc """
-  Updates a dashboard embed key.
+  Updates a dsb embed key.
 
   For list-like embed keys (`:header_links`, `:footer_links`, etc), values are replaced.
   For map-like keys, existing and incoming fields are merged.
 
   ## Examples
 
-      iex> ORM.replace_dashboard_section(dashboard, :header_links, [%{title: "Docs"}])
+      iex> ORM.replace_dsb_section(dashboard, :header_links, [%{title: "Docs"}])
       {:ok, %CommunityDashboard{}}
 
-      iex> ORM.merge_dashboard_section(dashboard, :seo, %{title: "Elixir"})
+      iex> ORM.merge_dsb_section(dashboard, :seo, %{title: "Elixir"})
       {:ok, %CommunityDashboard{}}
   """
-  def replace_dashboard_section(%CommunityDashboard{} = community_dashboard, field, args)
+  def replace_dsb_section(%CommunityDashboard{} = community_dashboard, field, args)
       when field in [
              # those fields are array maps
              :header_links,
@@ -538,16 +538,16 @@ defmodule Helper.ORM do
     |> Repo.update()
   end
 
-  def replace_dashboard_section(%CommunityDashboard{} = community_dashboard, key, args) do
+  def replace_dsb_section(%CommunityDashboard{} = community_dashboard, key, args) do
     community_dashboard
     |> Ecto.Changeset.change()
     |> Ecto.Changeset.put_embed(key, args)
     |> Repo.update()
   end
 
-  def merge_dashboard_section(%CommunityDashboard{} = community_dashboard, key, args) do
+  def merge_dsb_section(%CommunityDashboard{} = community_dashboard, key, args) do
     merged_args =
-      community_dashboard[key] |> ensure_dashboard_key_exist |> Map.merge(args) |> strip_struct
+      community_dashboard[key] |> ensure_dsb_key_exist |> Map.merge(args) |> strip_struct
 
     community_dashboard
     |> Ecto.Changeset.change()
@@ -556,8 +556,8 @@ defmodule Helper.ORM do
   end
 
   # the key in dashboard table are all jsonb format
-  defp ensure_dashboard_key_exist(nil), do: %{}
-  defp ensure_dashboard_key_exist(settings), do: settings
+  defp ensure_dsb_key_exist(nil), do: %{}
+  defp ensure_dsb_key_exist(settings), do: settings
 
   @doc """
   Updates embed fields and additional scalar changes in one call.

--- a/backend/main/schema.graphql
+++ b/backend/main/schema.graphql
@@ -595,60 +595,54 @@ type RootMutationType {
 
   "update base info in dashboard"
   updateDashboardBaseInfo(
-    community: String!, dashboardSection: DashboardSection, favicon: String, title: String, locale: String, logo: String, slug: String, desc: String, introduction: String, homepage: String, city: String, techstack: String
+    community: String!, dsbSection: DsbSection, favicon: String, title: String, locale: String, logo: String, slug: String, desc: String, introduction: String, homepage: String, city: String, techstack: String
   ): Community
 
   "update seo in dashboard"
   updateDashboardSeo(
-    community: String!, dashboardSection: DashboardSection, seoEnable: Boolean, ogSiteName: String, ogTitle: String, ogDescription: String, ogUrl: String, ogImage: String, ogLocale: String, ogPublisher: String, twTitle: String, twDescription: String, twUrl: String, twCard: String, twSite: String, twImage: String, twImageWidth: String, twImageHeight: String
+    community: String!, dsbSection: DsbSection, seoEnable: Boolean, ogSiteName: String, ogTitle: String, ogDescription: String, ogUrl: String, ogImage: String, ogLocale: String, ogPublisher: String, twTitle: String, twDescription: String, twUrl: String, twCard: String, twSite: String, twImage: String, twImageWidth: String, twImageHeight: String
   ): Community
 
   "update wallpaper in dashboard"
   updateDashboardWallpaper(
-    community: String!, dashboardSection: DashboardSection, wallpaperType: String, wallpaper: String, hasPattern: Boolean, direction: String, customColorValue: String, bgSize: String, uploadBgImage: String, hasBlur: Boolean, hasShadow: Boolean
+    community: String!, dsbSection: DsbSection, wallpaperType: String, wallpaper: String, hasPattern: Boolean, direction: String, customColorValue: String, bgSize: String, uploadBgImage: String, hasBlur: Boolean, hasShadow: Boolean
   ): Community
 
   "update enable in dashboard"
   updateDashboardEnable(
-    community: String!, dashboardSection: DashboardSection, post: Boolean, blog: Boolean, kanban: Boolean, changelog: Boolean, doc: Boolean, docLastUpdate: Boolean, docReaction: Boolean, about: Boolean, aboutTechstack: Boolean, aboutLocation: Boolean, aboutLinks: Boolean, aboutMediaReport: Boolean
+    community: String!, dsbSection: DsbSection, post: Boolean, blog: Boolean, kanban: Boolean, changelog: Boolean, doc: Boolean, docLastUpdate: Boolean, docReaction: Boolean, about: Boolean, aboutTechstack: Boolean, aboutLocation: Boolean, aboutLinks: Boolean, aboutMediaReport: Boolean
   ): Community
 
   "update thread-specific emotion settings in dashboard"
   updateDashboardThreadEmotions(
-    community: String!, dashboardSection: DashboardSection, post: [EmotionType], blog: [EmotionType], changelog: [EmotionType], doc: [EmotionType], postComment: [EmotionType], blogComment: [EmotionType], changelogComment: [EmotionType], docComment: [EmotionType]
+    community: String!, dsbSection: DsbSection, post: [EmotionType], blog: [EmotionType], changelog: [EmotionType], doc: [EmotionType], postComment: [EmotionType], blogComment: [EmotionType], changelogComment: [EmotionType], docComment: [EmotionType]
   ): Community
 
   "update layout in dashboard"
   updateDashboardLayout(
-    community: String!, dashboardSection: DashboardSection, pageBg: String, pageBgDark: String, pageCustomBg: Int, pageCustomBgDark: Int, pageCustomIntensity: Int, pageCustomIntensityDark: Int, primaryColor: RainbowColor, primaryCustomColor: String, primaryCustomColorDark: String, subPrimaryColor: RainbowColor, subPrimaryCustomColor: String, subPrimaryCustomColorDark: String, kanbanBgColors: [RainbowColor], kanbanBoards: [KanbanBoard], postLayout: DsbPostLayout, kanbanLayout: DsbKanbanLayout, kanbanCardLayout: DsbKanbanCardLayout, docCoverLayout: DsbDocCoverLayout, docFaqLayout: DsbDocFaqLayout, tagLayout: DsbTagLayout, inlineTagLayout: DsbInlineTagLayout, avatarLayout: DsbAvatarLayout, brandLayout: DsbBrandLayout, communityLayout: DsbCommunityLayout, navActiveLayout: DsbNavActiveLayout, topbarEnabled: Boolean, topbarBg: RainbowColor, topbarBgCustomColor: String, broadcastLayout: DsbBroadcastLayout, broadcastBg: RainbowColor, broadcastCustomBg: String, broadcastEnable: Boolean, broadcastArticleLayout: DsbBroadcastArticleLayout, broadcastArticleBg: RainbowColor, broadcastArticleCustomBg: String, broadcastArticleEnable: Boolean, changelogLayout: DsbChangelogLayout, footerLayout: DsbFooterLayout, headerLayout: DsbHeaderLayout, glowType: String, glowFixed: Boolean, glowOpacity: String, overlayDark: Boolean, gaussBlur: Int, gaussBlurDark: Int
+    community: String!, dsbSection: DsbSection, pageBg: String, pageBgDark: String, pageCustomBg: Int, pageCustomBgDark: Int, pageCustomIntensity: Int, pageCustomIntensityDark: Int, primaryColor: RainbowColor, primaryCustomColor: String, primaryCustomColorDark: String, subPrimaryColor: RainbowColor, subPrimaryCustomColor: String, subPrimaryCustomColorDark: String, kanbanBgColors: [RainbowColor], kanbanBoards: [KanbanBoard], postLayout: DsbPostLayout, kanbanLayout: DsbKanbanLayout, kanbanCardLayout: DsbKanbanCardLayout, docCoverLayout: DsbDocCoverLayout, docFaqLayout: DsbDocFaqLayout, tagLayout: DsbTagLayout, inlineTagLayout: DsbInlineTagLayout, avatarLayout: DsbAvatarLayout, brandLayout: DsbBrandLayout, communityLayout: DsbCommunityLayout, navActiveLayout: DsbNavActiveLayout, topbarEnabled: Boolean, topbarBg: RainbowColor, topbarBgCustomColor: String, broadcastLayout: DsbBroadcastLayout, broadcastBg: RainbowColor, broadcastCustomBg: String, broadcastEnable: Boolean, broadcastArticleLayout: DsbBroadcastArticleLayout, broadcastArticleBg: RainbowColor, broadcastArticleCustomBg: String, broadcastArticleEnable: Boolean, changelogLayout: DsbChangelogLayout, footerLayout: DsbFooterLayout, headerLayout: DsbHeaderLayout, glowType: String, glowFixed: Boolean, glowOpacity: String, overlayDark: Boolean, gaussBlur: Int, gaussBlurDark: Int
   ): Community
 
   "update rss in dashboard"
-  updateDashboardRss(
-    community: String!, dashboardSection: DashboardSection, rssFeedType: DsbRssFeedType, rssFeedCount: Int
-  ): Community
+  updateDashboardRss(community: String!, dsbSection: DsbSection, rssFeedType: DsbRssFeedType, rssFeedCount: Int): Community
 
   "update name alias in dashboard"
-  updateDashboardNameAlias(community: String!, dashboardSection: DashboardSection, nameAlias: [DashboardAliasMap]): Community
+  updateDashboardNameAlias(community: String!, dsbSection: DsbSection, nameAlias: [DsbAliasMap]): Community
 
   "update header links in dashboard"
-  updateDashboardHeaderLinks(community: String!, dashboardSection: DashboardSection, headerLinks: [DsbLinkMap]): Community
+  updateDashboardHeaderLinks(community: String!, dsbSection: DsbSection, headerLinks: [DsbLinkMap]): Community
 
   "update footer links in dashboard"
-  updateDashboardFooterLinks(community: String!, dashboardSection: DashboardSection, footerLinks: [DsbLinkMap]): Community
+  updateDashboardFooterLinks(community: String!, dsbSection: DsbSection, footerLinks: [DsbLinkMap]): Community
 
   "update social links in dashboard"
-  updateDashboardSocialLinks(
-    community: String!, dashboardSection: DashboardSection, socialLinks: [DashboardSocialLinkMap]
-  ): Community
+  updateDashboardSocialLinks(community: String!, dsbSection: DsbSection, socialLinks: [DsbSocialLinkMap]): Community
 
   "update media reports in dashboard"
-  updateDashboardMediaReports(
-    community: String!, dashboardSection: DashboardSection, mediaReports: [DashboardMediaReportMap]
-  ): Community
+  updateDashboardMediaReports(community: String!, dsbSection: DsbSection, mediaReports: [DsbMediaReportMap]): Community
 
   "update faqs in dashboard"
-  updateDashboardFaqs(community: String!, dashboardSection: DashboardSection, faqs: [DashboardFaqMap]): Community
+  updateDashboardFaqs(community: String!, dsbSection: DsbSection, faqs: [DsbFaqMap]): Community
 }
 
 type CheckState {
@@ -840,12 +834,12 @@ type ContributeMap {
   records: [Contribute]
 }
 
-type DashboardRss {
+type DsbRss {
   rssFeedType: DsbRssFeedType
   rssFeedCount: Int
 }
 
-type DashboardSeo {
+type DsbSeo {
   seoEnable: Boolean
   ogSiteName: String
   ogTitle: String
@@ -864,7 +858,7 @@ type DashboardSeo {
   twImageHeight: String
 }
 
-type DashboardWallpaper {
+type DsbWallpaper {
   wallpaperType: String
   wallpaper: String
   hasPattern: Boolean
@@ -876,7 +870,7 @@ type DashboardWallpaper {
   hasShadow: Boolean
 }
 
-type DashboardLayout {
+type DsbLayout {
   pageBg: String
   pageBgDark: String
   pageCustomBg: Int
@@ -924,7 +918,7 @@ type DashboardLayout {
   gaussBlurDark: Int
 }
 
-type DashboardEnable {
+type DsbEnable {
   post: Boolean
   blog: Boolean
   kanban: Boolean
@@ -939,7 +933,7 @@ type DashboardEnable {
   aboutMediaReport: Boolean
 }
 
-type DashboardThreadEmotions {
+type DsbThreadEmotions {
   post: [EmotionType]
   blog: [EmotionType]
   changelog: [EmotionType]
@@ -950,7 +944,7 @@ type DashboardThreadEmotions {
   docComment: [EmotionType]
 }
 
-type DashboardBaseInfo {
+type DsbBaseInfo {
   favicon: String
   title: String
   locale: String
@@ -963,7 +957,7 @@ type DashboardBaseInfo {
   techstack: String
 }
 
-type DashboardNameAlias {
+type DsbNameAlias {
   slug: String
   name: String
   original: String
@@ -984,12 +978,12 @@ type DsbLink {
   links: [DsbLinkChild]
 }
 
-type DashboardSocialLink {
+type DsbSocialLink {
   type: String
   link: String
 }
 
-type DashboardMediaReport {
+type DsbMediaReport {
   index: Int
   title: String
   favicon: String
@@ -998,26 +992,26 @@ type DashboardMediaReport {
   url: String
 }
 
-type DashboardFaqSection {
+type DsbFaqSection {
   title: String
   body: String
   index: Int
 }
 
-type Dashboard {
-  seo: DashboardSeo
-  wallpaper: DashboardWallpaper
-  layout: DashboardLayout
-  enable: DashboardEnable
-  threadEmotions: DashboardThreadEmotions
-  baseInfo: DashboardBaseInfo
-  rss: DashboardRss
-  nameAlias: [DashboardNameAlias]
+type Dsb {
+  seo: DsbSeo
+  wallpaper: DsbWallpaper
+  layout: DsbLayout
+  enable: DsbEnable
+  threadEmotions: DsbThreadEmotions
+  baseInfo: DsbBaseInfo
+  rss: DsbRss
+  nameAlias: [DsbNameAlias]
   headerLinks: [DsbLink]
   footerLinks: [DsbLink]
-  socialLinks: [DashboardSocialLink]
-  mediaReports: [DashboardMediaReport]
-  faqs: [DashboardFaqSection]
+  socialLinks: [DsbSocialLink]
+  mediaReports: [DsbMediaReport]
+  faqs: [DsbFaqSection]
 }
 
 type CommunityModerator {
@@ -1043,7 +1037,7 @@ type Community {
   author: User
   locale: String
   categories: [Category]
-  dashboard: Dashboard
+  dashboard: Dsb
   moderators: [CommunityModerator]
   meta: CommunityMeta
   views: Int
@@ -1404,7 +1398,7 @@ enum Thread {
   USER
 }
 
-enum DashboardSection {
+enum DsbSection {
   SEO
   WALLPAPER
   ENABLE
@@ -1802,7 +1796,7 @@ input ReportFilter {
   size: Int
 }
 
-input DashboardAliasMap {
+input DsbAliasMap {
   slug: String
   name: String
   original: String
@@ -1823,12 +1817,12 @@ input DsbLinkMap {
   links: [DsbLinkChildMap]
 }
 
-input DashboardSocialLinkMap {
+input DsbSocialLinkMap {
   type: String
   link: String
 }
 
-input DashboardMediaReportMap {
+input DsbMediaReportMap {
   index: Int
   title: String
   favicon: String
@@ -1837,7 +1831,7 @@ input DashboardMediaReportMap {
   url: String
 }
 
-input DashboardFaqMap {
+input DsbFaqMap {
   title: String
   body: String
   index: Int

--- a/backend/main/test/groupher_server_web/mutation/cms/dashboard_test.exs
+++ b/backend/main/test/groupher_server_web/mutation/cms/dashboard_test.exs
@@ -400,7 +400,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
     end
 
     @update_alias_query """
-    mutation($community: String!, $nameAlias: [DashboardAliasMap]) {
+    mutation($community: String!, $nameAlias: [DsbAliasMap]) {
       updateDashboardNameAlias(community: $community, nameAlias: $nameAlias) {
         id
         title
@@ -581,7 +581,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
     end
 
     @update_social_links_query """
-    mutation($community: String!, $socialLinks: [DashboardSocialLinkMap]) {
+    mutation($community: String!, $socialLinks: [DsbSocialLinkMap]) {
       updateDashboardSocialLinks(community: $community, socialLinks: $socialLinks) {
         id
         title
@@ -620,7 +620,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
     end
 
     @update_media_reports_query """
-    mutation($community: String!, $mediaReports: [DashboardMediaReportMap]) {
+    mutation($community: String!, $mediaReports: [DsbMediaReportMap]) {
       updateDashboardMediaReports(community: $community, mediaReports: $mediaReports) {
         id
         title
@@ -660,7 +660,7 @@ defmodule GroupherServer.Test.Mutation.CMS.Dashboard do
     end
 
     @update_faqs_query """
-    mutation($community: String!, $faqs: [DashboardFaqMap]) {
+    mutation($community: String!, $faqs: [DsbFaqMap]) {
       updateDashboardFaqs(community: $community, faqs: $faqs) {
         id
         title

--- a/frontend/core/unit/DashboardThread/schema.ts
+++ b/frontend/core/unit/DashboardThread/schema.ts
@@ -82,7 +82,7 @@ const updateDashboardBaseInfo = gql`
   }
 `
 const updateDashboardMediaReports = gql`
-  mutation ($community: String!, $mediaReports: [DashboardMediaReportMap]) {
+  mutation ($community: String!, $mediaReports: [DsbMediaReportMap]) {
     updateDashboardMediaReports(community: $community, mediaReports: $mediaReports) {
       title
       dashboard {
@@ -255,7 +255,7 @@ const updateDashboardLayout = gql`
 `
 
 const updateDashboardSocialLinks = gql`
-  mutation ($community: String!, $socialLinks: [DashboardSocialLinkMap]) {
+  mutation ($community: String!, $socialLinks: [DsbSocialLinkMap]) {
     updateDashboardSocialLinks(community: $community, socialLinks: $socialLinks) {
       slug
     }
@@ -263,7 +263,7 @@ const updateDashboardSocialLinks = gql`
 `
 
 const updateDashboardNameAlias = gql`
-  mutation ($community: String!, $nameAlias: [DashboardAliasMap]) {
+  mutation ($community: String!, $nameAlias: [DsbAliasMap]) {
     updateDashboardNameAlias(community: $community, nameAlias: $nameAlias) {
       slug
     }

--- a/frontend/dashboard/graphql/schema.graphql
+++ b/frontend/dashboard/graphql/schema.graphql
@@ -595,60 +595,54 @@ type RootMutationType {
 
   "update base info in dashboard"
   updateDashboardBaseInfo(
-    community: String!, dashboardSection: DashboardSection, favicon: String, title: String, locale: String, logo: String, slug: String, desc: String, introduction: String, homepage: String, city: String, techstack: String
+    community: String!, dsbSection: DsbSection, favicon: String, title: String, locale: String, logo: String, slug: String, desc: String, introduction: String, homepage: String, city: String, techstack: String
   ): Community
 
   "update seo in dashboard"
   updateDashboardSeo(
-    community: String!, dashboardSection: DashboardSection, seoEnable: Boolean, ogSiteName: String, ogTitle: String, ogDescription: String, ogUrl: String, ogImage: String, ogLocale: String, ogPublisher: String, twTitle: String, twDescription: String, twUrl: String, twCard: String, twSite: String, twImage: String, twImageWidth: String, twImageHeight: String
+    community: String!, dsbSection: DsbSection, seoEnable: Boolean, ogSiteName: String, ogTitle: String, ogDescription: String, ogUrl: String, ogImage: String, ogLocale: String, ogPublisher: String, twTitle: String, twDescription: String, twUrl: String, twCard: String, twSite: String, twImage: String, twImageWidth: String, twImageHeight: String
   ): Community
 
   "update wallpaper in dashboard"
   updateDashboardWallpaper(
-    community: String!, dashboardSection: DashboardSection, wallpaperType: String, wallpaper: String, hasPattern: Boolean, direction: String, customColorValue: String, bgSize: String, uploadBgImage: String, hasBlur: Boolean, hasShadow: Boolean
+    community: String!, dsbSection: DsbSection, wallpaperType: String, wallpaper: String, hasPattern: Boolean, direction: String, customColorValue: String, bgSize: String, uploadBgImage: String, hasBlur: Boolean, hasShadow: Boolean
   ): Community
 
   "update enable in dashboard"
   updateDashboardEnable(
-    community: String!, dashboardSection: DashboardSection, post: Boolean, blog: Boolean, kanban: Boolean, changelog: Boolean, doc: Boolean, docLastUpdate: Boolean, docReaction: Boolean, about: Boolean, aboutTechstack: Boolean, aboutLocation: Boolean, aboutLinks: Boolean, aboutMediaReport: Boolean
+    community: String!, dsbSection: DsbSection, post: Boolean, blog: Boolean, kanban: Boolean, changelog: Boolean, doc: Boolean, docLastUpdate: Boolean, docReaction: Boolean, about: Boolean, aboutTechstack: Boolean, aboutLocation: Boolean, aboutLinks: Boolean, aboutMediaReport: Boolean
   ): Community
 
   "update thread-specific emotion settings in dashboard"
   updateDashboardThreadEmotions(
-    community: String!, dashboardSection: DashboardSection, post: [EmotionType], blog: [EmotionType], changelog: [EmotionType], doc: [EmotionType], postComment: [EmotionType], blogComment: [EmotionType], changelogComment: [EmotionType], docComment: [EmotionType]
+    community: String!, dsbSection: DsbSection, post: [EmotionType], blog: [EmotionType], changelog: [EmotionType], doc: [EmotionType], postComment: [EmotionType], blogComment: [EmotionType], changelogComment: [EmotionType], docComment: [EmotionType]
   ): Community
 
   "update layout in dashboard"
   updateDashboardLayout(
-    community: String!, dashboardSection: DashboardSection, pageBg: String, pageBgDark: String, pageCustomBg: Int, pageCustomBgDark: Int, pageCustomIntensity: Int, pageCustomIntensityDark: Int, primaryColor: RainbowColor, primaryCustomColor: String, primaryCustomColorDark: String, subPrimaryColor: RainbowColor, subPrimaryCustomColor: String, subPrimaryCustomColorDark: String, kanbanBgColors: [RainbowColor], kanbanBoards: [KanbanBoard], postLayout: DsbPostLayout, kanbanLayout: DsbKanbanLayout, kanbanCardLayout: DsbKanbanCardLayout, docCoverLayout: DsbDocCoverLayout, docFaqLayout: DsbDocFaqLayout, tagLayout: DsbTagLayout, inlineTagLayout: DsbInlineTagLayout, avatarLayout: DsbAvatarLayout, brandLayout: DsbBrandLayout, communityLayout: DsbCommunityLayout, navActiveLayout: DsbNavActiveLayout, topbarEnabled: Boolean, topbarBg: RainbowColor, topbarBgCustomColor: String, broadcastLayout: DsbBroadcastLayout, broadcastBg: RainbowColor, broadcastCustomBg: String, broadcastEnable: Boolean, broadcastArticleLayout: DsbBroadcastArticleLayout, broadcastArticleBg: RainbowColor, broadcastArticleCustomBg: String, broadcastArticleEnable: Boolean, changelogLayout: DsbChangelogLayout, footerLayout: DsbFooterLayout, headerLayout: DsbHeaderLayout, glowType: String, glowFixed: Boolean, glowOpacity: String, overlayDark: Boolean, gaussBlur: Int, gaussBlurDark: Int
+    community: String!, dsbSection: DsbSection, pageBg: String, pageBgDark: String, pageCustomBg: Int, pageCustomBgDark: Int, pageCustomIntensity: Int, pageCustomIntensityDark: Int, primaryColor: RainbowColor, primaryCustomColor: String, primaryCustomColorDark: String, subPrimaryColor: RainbowColor, subPrimaryCustomColor: String, subPrimaryCustomColorDark: String, kanbanBgColors: [RainbowColor], kanbanBoards: [KanbanBoard], postLayout: DsbPostLayout, kanbanLayout: DsbKanbanLayout, kanbanCardLayout: DsbKanbanCardLayout, docCoverLayout: DsbDocCoverLayout, docFaqLayout: DsbDocFaqLayout, tagLayout: DsbTagLayout, inlineTagLayout: DsbInlineTagLayout, avatarLayout: DsbAvatarLayout, brandLayout: DsbBrandLayout, communityLayout: DsbCommunityLayout, navActiveLayout: DsbNavActiveLayout, topbarEnabled: Boolean, topbarBg: RainbowColor, topbarBgCustomColor: String, broadcastLayout: DsbBroadcastLayout, broadcastBg: RainbowColor, broadcastCustomBg: String, broadcastEnable: Boolean, broadcastArticleLayout: DsbBroadcastArticleLayout, broadcastArticleBg: RainbowColor, broadcastArticleCustomBg: String, broadcastArticleEnable: Boolean, changelogLayout: DsbChangelogLayout, footerLayout: DsbFooterLayout, headerLayout: DsbHeaderLayout, glowType: String, glowFixed: Boolean, glowOpacity: String, overlayDark: Boolean, gaussBlur: Int, gaussBlurDark: Int
   ): Community
 
   "update rss in dashboard"
-  updateDashboardRss(
-    community: String!, dashboardSection: DashboardSection, rssFeedType: DsbRssFeedType, rssFeedCount: Int
-  ): Community
+  updateDashboardRss(community: String!, dsbSection: DsbSection, rssFeedType: DsbRssFeedType, rssFeedCount: Int): Community
 
   "update name alias in dashboard"
-  updateDashboardNameAlias(community: String!, dashboardSection: DashboardSection, nameAlias: [DashboardAliasMap]): Community
+  updateDashboardNameAlias(community: String!, dsbSection: DsbSection, nameAlias: [DsbAliasMap]): Community
 
   "update header links in dashboard"
-  updateDashboardHeaderLinks(community: String!, dashboardSection: DashboardSection, headerLinks: [DsbLinkMap]): Community
+  updateDashboardHeaderLinks(community: String!, dsbSection: DsbSection, headerLinks: [DsbLinkMap]): Community
 
   "update footer links in dashboard"
-  updateDashboardFooterLinks(community: String!, dashboardSection: DashboardSection, footerLinks: [DsbLinkMap]): Community
+  updateDashboardFooterLinks(community: String!, dsbSection: DsbSection, footerLinks: [DsbLinkMap]): Community
 
   "update social links in dashboard"
-  updateDashboardSocialLinks(
-    community: String!, dashboardSection: DashboardSection, socialLinks: [DashboardSocialLinkMap]
-  ): Community
+  updateDashboardSocialLinks(community: String!, dsbSection: DsbSection, socialLinks: [DsbSocialLinkMap]): Community
 
   "update media reports in dashboard"
-  updateDashboardMediaReports(
-    community: String!, dashboardSection: DashboardSection, mediaReports: [DashboardMediaReportMap]
-  ): Community
+  updateDashboardMediaReports(community: String!, dsbSection: DsbSection, mediaReports: [DsbMediaReportMap]): Community
 
   "update faqs in dashboard"
-  updateDashboardFaqs(community: String!, dashboardSection: DashboardSection, faqs: [DashboardFaqMap]): Community
+  updateDashboardFaqs(community: String!, dsbSection: DsbSection, faqs: [DsbFaqMap]): Community
 }
 
 type CheckState {
@@ -840,12 +834,12 @@ type ContributeMap {
   records: [Contribute]
 }
 
-type DashboardRss {
+type DsbRss {
   rssFeedType: DsbRssFeedType
   rssFeedCount: Int
 }
 
-type DashboardSeo {
+type DsbSeo {
   seoEnable: Boolean
   ogSiteName: String
   ogTitle: String
@@ -864,7 +858,7 @@ type DashboardSeo {
   twImageHeight: String
 }
 
-type DashboardWallpaper {
+type DsbWallpaper {
   wallpaperType: String
   wallpaper: String
   hasPattern: Boolean
@@ -876,7 +870,7 @@ type DashboardWallpaper {
   hasShadow: Boolean
 }
 
-type DashboardLayout {
+type DsbLayout {
   pageBg: String
   pageBgDark: String
   pageCustomBg: Int
@@ -924,7 +918,7 @@ type DashboardLayout {
   gaussBlurDark: Int
 }
 
-type DashboardEnable {
+type DsbEnable {
   post: Boolean
   blog: Boolean
   kanban: Boolean
@@ -939,7 +933,7 @@ type DashboardEnable {
   aboutMediaReport: Boolean
 }
 
-type DashboardThreadEmotions {
+type DsbThreadEmotions {
   post: [EmotionType]
   blog: [EmotionType]
   changelog: [EmotionType]
@@ -950,7 +944,7 @@ type DashboardThreadEmotions {
   docComment: [EmotionType]
 }
 
-type DashboardBaseInfo {
+type DsbBaseInfo {
   favicon: String
   title: String
   locale: String
@@ -963,7 +957,7 @@ type DashboardBaseInfo {
   techstack: String
 }
 
-type DashboardNameAlias {
+type DsbNameAlias {
   slug: String
   name: String
   original: String
@@ -984,12 +978,12 @@ type DsbLink {
   links: [DsbLinkChild]
 }
 
-type DashboardSocialLink {
+type DsbSocialLink {
   type: String
   link: String
 }
 
-type DashboardMediaReport {
+type DsbMediaReport {
   index: Int
   title: String
   favicon: String
@@ -998,26 +992,26 @@ type DashboardMediaReport {
   url: String
 }
 
-type DashboardFaqSection {
+type DsbFaqSection {
   title: String
   body: String
   index: Int
 }
 
-type Dashboard {
-  seo: DashboardSeo
-  wallpaper: DashboardWallpaper
-  layout: DashboardLayout
-  enable: DashboardEnable
-  threadEmotions: DashboardThreadEmotions
-  baseInfo: DashboardBaseInfo
-  rss: DashboardRss
-  nameAlias: [DashboardNameAlias]
+type Dsb {
+  seo: DsbSeo
+  wallpaper: DsbWallpaper
+  layout: DsbLayout
+  enable: DsbEnable
+  threadEmotions: DsbThreadEmotions
+  baseInfo: DsbBaseInfo
+  rss: DsbRss
+  nameAlias: [DsbNameAlias]
   headerLinks: [DsbLink]
   footerLinks: [DsbLink]
-  socialLinks: [DashboardSocialLink]
-  mediaReports: [DashboardMediaReport]
-  faqs: [DashboardFaqSection]
+  socialLinks: [DsbSocialLink]
+  mediaReports: [DsbMediaReport]
+  faqs: [DsbFaqSection]
 }
 
 type CommunityModerator {
@@ -1043,7 +1037,7 @@ type Community {
   author: User
   locale: String
   categories: [Category]
-  dashboard: Dashboard
+  dashboard: Dsb
   moderators: [CommunityModerator]
   meta: CommunityMeta
   views: Int
@@ -1404,7 +1398,7 @@ enum Thread {
   USER
 }
 
-enum DashboardSection {
+enum DsbSection {
   SEO
   WALLPAPER
   ENABLE
@@ -1802,7 +1796,7 @@ input ReportFilter {
   size: Int
 }
 
-input DashboardAliasMap {
+input DsbAliasMap {
   slug: String
   name: String
   original: String
@@ -1823,12 +1817,12 @@ input DsbLinkMap {
   links: [DsbLinkChildMap]
 }
 
-input DashboardSocialLinkMap {
+input DsbSocialLinkMap {
   type: String
   link: String
 }
 
-input DashboardMediaReportMap {
+input DsbMediaReportMap {
   index: Int
   title: String
   favicon: String
@@ -1837,7 +1831,7 @@ input DashboardMediaReportMap {
   url: String
 }
 
-input DashboardFaqMap {
+input DsbFaqMap {
   title: String
   body: String
   index: Int

--- a/frontend/main/graphql/schema.graphql
+++ b/frontend/main/graphql/schema.graphql
@@ -595,60 +595,54 @@ type RootMutationType {
 
   "update base info in dashboard"
   updateDashboardBaseInfo(
-    community: String!, dashboardSection: DashboardSection, favicon: String, title: String, locale: String, logo: String, slug: String, desc: String, introduction: String, homepage: String, city: String, techstack: String
+    community: String!, dsbSection: DsbSection, favicon: String, title: String, locale: String, logo: String, slug: String, desc: String, introduction: String, homepage: String, city: String, techstack: String
   ): Community
 
   "update seo in dashboard"
   updateDashboardSeo(
-    community: String!, dashboardSection: DashboardSection, seoEnable: Boolean, ogSiteName: String, ogTitle: String, ogDescription: String, ogUrl: String, ogImage: String, ogLocale: String, ogPublisher: String, twTitle: String, twDescription: String, twUrl: String, twCard: String, twSite: String, twImage: String, twImageWidth: String, twImageHeight: String
+    community: String!, dsbSection: DsbSection, seoEnable: Boolean, ogSiteName: String, ogTitle: String, ogDescription: String, ogUrl: String, ogImage: String, ogLocale: String, ogPublisher: String, twTitle: String, twDescription: String, twUrl: String, twCard: String, twSite: String, twImage: String, twImageWidth: String, twImageHeight: String
   ): Community
 
   "update wallpaper in dashboard"
   updateDashboardWallpaper(
-    community: String!, dashboardSection: DashboardSection, wallpaperType: String, wallpaper: String, hasPattern: Boolean, direction: String, customColorValue: String, bgSize: String, uploadBgImage: String, hasBlur: Boolean, hasShadow: Boolean
+    community: String!, dsbSection: DsbSection, wallpaperType: String, wallpaper: String, hasPattern: Boolean, direction: String, customColorValue: String, bgSize: String, uploadBgImage: String, hasBlur: Boolean, hasShadow: Boolean
   ): Community
 
   "update enable in dashboard"
   updateDashboardEnable(
-    community: String!, dashboardSection: DashboardSection, post: Boolean, blog: Boolean, kanban: Boolean, changelog: Boolean, doc: Boolean, docLastUpdate: Boolean, docReaction: Boolean, about: Boolean, aboutTechstack: Boolean, aboutLocation: Boolean, aboutLinks: Boolean, aboutMediaReport: Boolean
+    community: String!, dsbSection: DsbSection, post: Boolean, blog: Boolean, kanban: Boolean, changelog: Boolean, doc: Boolean, docLastUpdate: Boolean, docReaction: Boolean, about: Boolean, aboutTechstack: Boolean, aboutLocation: Boolean, aboutLinks: Boolean, aboutMediaReport: Boolean
   ): Community
 
   "update thread-specific emotion settings in dashboard"
   updateDashboardThreadEmotions(
-    community: String!, dashboardSection: DashboardSection, post: [EmotionType], blog: [EmotionType], changelog: [EmotionType], doc: [EmotionType], postComment: [EmotionType], blogComment: [EmotionType], changelogComment: [EmotionType], docComment: [EmotionType]
+    community: String!, dsbSection: DsbSection, post: [EmotionType], blog: [EmotionType], changelog: [EmotionType], doc: [EmotionType], postComment: [EmotionType], blogComment: [EmotionType], changelogComment: [EmotionType], docComment: [EmotionType]
   ): Community
 
   "update layout in dashboard"
   updateDashboardLayout(
-    community: String!, dashboardSection: DashboardSection, pageBg: String, pageBgDark: String, pageCustomBg: Int, pageCustomBgDark: Int, pageCustomIntensity: Int, pageCustomIntensityDark: Int, primaryColor: RainbowColor, primaryCustomColor: String, primaryCustomColorDark: String, subPrimaryColor: RainbowColor, subPrimaryCustomColor: String, subPrimaryCustomColorDark: String, kanbanBgColors: [RainbowColor], kanbanBoards: [KanbanBoard], postLayout: DsbPostLayout, kanbanLayout: DsbKanbanLayout, kanbanCardLayout: DsbKanbanCardLayout, docCoverLayout: DsbDocCoverLayout, docFaqLayout: DsbDocFaqLayout, tagLayout: DsbTagLayout, inlineTagLayout: DsbInlineTagLayout, avatarLayout: DsbAvatarLayout, brandLayout: DsbBrandLayout, communityLayout: DsbCommunityLayout, navActiveLayout: DsbNavActiveLayout, topbarEnabled: Boolean, topbarBg: RainbowColor, topbarBgCustomColor: String, broadcastLayout: DsbBroadcastLayout, broadcastBg: RainbowColor, broadcastCustomBg: String, broadcastEnable: Boolean, broadcastArticleLayout: DsbBroadcastArticleLayout, broadcastArticleBg: RainbowColor, broadcastArticleCustomBg: String, broadcastArticleEnable: Boolean, changelogLayout: DsbChangelogLayout, footerLayout: DsbFooterLayout, headerLayout: DsbHeaderLayout, glowType: String, glowFixed: Boolean, glowOpacity: String, overlayDark: Boolean, gaussBlur: Int, gaussBlurDark: Int
+    community: String!, dsbSection: DsbSection, pageBg: String, pageBgDark: String, pageCustomBg: Int, pageCustomBgDark: Int, pageCustomIntensity: Int, pageCustomIntensityDark: Int, primaryColor: RainbowColor, primaryCustomColor: String, primaryCustomColorDark: String, subPrimaryColor: RainbowColor, subPrimaryCustomColor: String, subPrimaryCustomColorDark: String, kanbanBgColors: [RainbowColor], kanbanBoards: [KanbanBoard], postLayout: DsbPostLayout, kanbanLayout: DsbKanbanLayout, kanbanCardLayout: DsbKanbanCardLayout, docCoverLayout: DsbDocCoverLayout, docFaqLayout: DsbDocFaqLayout, tagLayout: DsbTagLayout, inlineTagLayout: DsbInlineTagLayout, avatarLayout: DsbAvatarLayout, brandLayout: DsbBrandLayout, communityLayout: DsbCommunityLayout, navActiveLayout: DsbNavActiveLayout, topbarEnabled: Boolean, topbarBg: RainbowColor, topbarBgCustomColor: String, broadcastLayout: DsbBroadcastLayout, broadcastBg: RainbowColor, broadcastCustomBg: String, broadcastEnable: Boolean, broadcastArticleLayout: DsbBroadcastArticleLayout, broadcastArticleBg: RainbowColor, broadcastArticleCustomBg: String, broadcastArticleEnable: Boolean, changelogLayout: DsbChangelogLayout, footerLayout: DsbFooterLayout, headerLayout: DsbHeaderLayout, glowType: String, glowFixed: Boolean, glowOpacity: String, overlayDark: Boolean, gaussBlur: Int, gaussBlurDark: Int
   ): Community
 
   "update rss in dashboard"
-  updateDashboardRss(
-    community: String!, dashboardSection: DashboardSection, rssFeedType: DsbRssFeedType, rssFeedCount: Int
-  ): Community
+  updateDashboardRss(community: String!, dsbSection: DsbSection, rssFeedType: DsbRssFeedType, rssFeedCount: Int): Community
 
   "update name alias in dashboard"
-  updateDashboardNameAlias(community: String!, dashboardSection: DashboardSection, nameAlias: [DashboardAliasMap]): Community
+  updateDashboardNameAlias(community: String!, dsbSection: DsbSection, nameAlias: [DsbAliasMap]): Community
 
   "update header links in dashboard"
-  updateDashboardHeaderLinks(community: String!, dashboardSection: DashboardSection, headerLinks: [DsbLinkMap]): Community
+  updateDashboardHeaderLinks(community: String!, dsbSection: DsbSection, headerLinks: [DsbLinkMap]): Community
 
   "update footer links in dashboard"
-  updateDashboardFooterLinks(community: String!, dashboardSection: DashboardSection, footerLinks: [DsbLinkMap]): Community
+  updateDashboardFooterLinks(community: String!, dsbSection: DsbSection, footerLinks: [DsbLinkMap]): Community
 
   "update social links in dashboard"
-  updateDashboardSocialLinks(
-    community: String!, dashboardSection: DashboardSection, socialLinks: [DashboardSocialLinkMap]
-  ): Community
+  updateDashboardSocialLinks(community: String!, dsbSection: DsbSection, socialLinks: [DsbSocialLinkMap]): Community
 
   "update media reports in dashboard"
-  updateDashboardMediaReports(
-    community: String!, dashboardSection: DashboardSection, mediaReports: [DashboardMediaReportMap]
-  ): Community
+  updateDashboardMediaReports(community: String!, dsbSection: DsbSection, mediaReports: [DsbMediaReportMap]): Community
 
   "update faqs in dashboard"
-  updateDashboardFaqs(community: String!, dashboardSection: DashboardSection, faqs: [DashboardFaqMap]): Community
+  updateDashboardFaqs(community: String!, dsbSection: DsbSection, faqs: [DsbFaqMap]): Community
 }
 
 type CheckState {
@@ -840,12 +834,12 @@ type ContributeMap {
   records: [Contribute]
 }
 
-type DashboardRss {
+type DsbRss {
   rssFeedType: DsbRssFeedType
   rssFeedCount: Int
 }
 
-type DashboardSeo {
+type DsbSeo {
   seoEnable: Boolean
   ogSiteName: String
   ogTitle: String
@@ -864,7 +858,7 @@ type DashboardSeo {
   twImageHeight: String
 }
 
-type DashboardWallpaper {
+type DsbWallpaper {
   wallpaperType: String
   wallpaper: String
   hasPattern: Boolean
@@ -876,7 +870,7 @@ type DashboardWallpaper {
   hasShadow: Boolean
 }
 
-type DashboardLayout {
+type DsbLayout {
   pageBg: String
   pageBgDark: String
   pageCustomBg: Int
@@ -924,7 +918,7 @@ type DashboardLayout {
   gaussBlurDark: Int
 }
 
-type DashboardEnable {
+type DsbEnable {
   post: Boolean
   blog: Boolean
   kanban: Boolean
@@ -939,7 +933,7 @@ type DashboardEnable {
   aboutMediaReport: Boolean
 }
 
-type DashboardThreadEmotions {
+type DsbThreadEmotions {
   post: [EmotionType]
   blog: [EmotionType]
   changelog: [EmotionType]
@@ -950,7 +944,7 @@ type DashboardThreadEmotions {
   docComment: [EmotionType]
 }
 
-type DashboardBaseInfo {
+type DsbBaseInfo {
   favicon: String
   title: String
   locale: String
@@ -963,7 +957,7 @@ type DashboardBaseInfo {
   techstack: String
 }
 
-type DashboardNameAlias {
+type DsbNameAlias {
   slug: String
   name: String
   original: String
@@ -984,12 +978,12 @@ type DsbLink {
   links: [DsbLinkChild]
 }
 
-type DashboardSocialLink {
+type DsbSocialLink {
   type: String
   link: String
 }
 
-type DashboardMediaReport {
+type DsbMediaReport {
   index: Int
   title: String
   favicon: String
@@ -998,26 +992,26 @@ type DashboardMediaReport {
   url: String
 }
 
-type DashboardFaqSection {
+type DsbFaqSection {
   title: String
   body: String
   index: Int
 }
 
-type Dashboard {
-  seo: DashboardSeo
-  wallpaper: DashboardWallpaper
-  layout: DashboardLayout
-  enable: DashboardEnable
-  threadEmotions: DashboardThreadEmotions
-  baseInfo: DashboardBaseInfo
-  rss: DashboardRss
-  nameAlias: [DashboardNameAlias]
+type Dsb {
+  seo: DsbSeo
+  wallpaper: DsbWallpaper
+  layout: DsbLayout
+  enable: DsbEnable
+  threadEmotions: DsbThreadEmotions
+  baseInfo: DsbBaseInfo
+  rss: DsbRss
+  nameAlias: [DsbNameAlias]
   headerLinks: [DsbLink]
   footerLinks: [DsbLink]
-  socialLinks: [DashboardSocialLink]
-  mediaReports: [DashboardMediaReport]
-  faqs: [DashboardFaqSection]
+  socialLinks: [DsbSocialLink]
+  mediaReports: [DsbMediaReport]
+  faqs: [DsbFaqSection]
 }
 
 type CommunityModerator {
@@ -1043,7 +1037,7 @@ type Community {
   author: User
   locale: String
   categories: [Category]
-  dashboard: Dashboard
+  dashboard: Dsb
   moderators: [CommunityModerator]
   meta: CommunityMeta
   views: Int
@@ -1404,7 +1398,7 @@ enum Thread {
   USER
 }
 
-enum DashboardSection {
+enum DsbSection {
   SEO
   WALLPAPER
   ENABLE
@@ -1802,7 +1796,7 @@ input ReportFilter {
   size: Int
 }
 
-input DashboardAliasMap {
+input DsbAliasMap {
   slug: String
   name: String
   original: String
@@ -1823,12 +1817,12 @@ input DsbLinkMap {
   links: [DsbLinkChildMap]
 }
 
-input DashboardSocialLinkMap {
+input DsbSocialLinkMap {
   type: String
   link: String
 }
 
-input DashboardMediaReportMap {
+input DsbMediaReportMap {
   index: Int
   title: String
   favicon: String
@@ -1837,7 +1831,7 @@ input DashboardMediaReportMap {
   url: String
 }
 
-input DashboardFaqMap {
+input DsbFaqMap {
   title: String
   body: String
   index: Int


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed dashboard-related code to the `dsb_` prefix across backend and GraphQL to standardize naming. No behavior changes; some client mutations and input types must be updated.

- **Refactors**
  - Renamed Elixir helpers/macros/functions from `dashboard_*` to `dsb_*` (e.g., `dsb_enable`, `prepare_dsb_section_payload`, `ORM.replace_dsb_section`).
  - GraphQL: types/inputs/enums moved from `Dashboard*` to `Dsb*`, and mutation arg `dashboardSection` -> `dsbSection`. Community field remains `dashboard`, now typed as `Dsb`.
  - Schema import renamed to `:cms_dsb_mutations`. Updated tests and frontend schemas/queries to new names.

- **Migration**
  - Update client mutations to use `dsbSection` and new input types (`DsbAliasMap`, `DsbSocialLinkMap`, `DsbMediaReportMap`, `DsbFaqMap`, etc.).
  - Queries can still use `community { dashboard { ... } }`. Regenerate GraphQL types/codegen to pick up renamed types and enums.

<sup>Written for commit f114ab51959db2f4098146202d898d821f9a92e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized internal naming conventions across the dashboard configuration system for improved code consistency. Updated GraphQL schema definitions, backend helper functions, and resolver layers to align with new naming standards throughout the codebase. Internal refactoring enhances maintainability with no impact on user-visible functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/groupher/groupher/pull/507)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->