### PR TITLE
refactor(fe): dsb links dbd layer for header/footer

### DIFF
--- a/frontend/core/unit/DashboardThread/Footer/Editors/FooterDndContext.tsx
+++ b/frontend/core/unit/DashboardThread/Footer/Editors/FooterDndContext.tsx
@@ -1,23 +1,8 @@
-import {
-  DndContext,
-  KeyboardSensor,
-  PointerSensor,
-  closestCorners,
-  pointerWithin,
-  useSensor,
-  useSensors,
-  type CollisionDetection,
-  type DragCancelEvent,
-  type DragEndEvent,
-  type DragOverEvent,
-  type DragStartEvent,
-  type Over,
-} from '@dnd-kit/core'
-import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
-import { type ReactNode, useRef, useState } from 'react'
+import { type ReactNode } from 'react'
 
 import type { TLinkItem } from '~/spec'
 
+import SortableDndContext from '../../LinkEditor/Dnd/SortableDndContext'
 import {
   FOOTER_DND_CONTEXT_ID,
   FOOTER_DND_TYPE,
@@ -40,130 +25,20 @@ type TProps = {
 }
 
 export default function FooterDndContext({ children, links, onCommit }: TProps) {
-  const pointerYRef = useRef<number | null>(null)
-  const lastDragTargetRef = useRef<TFooterDragTarget | null>(null)
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  )
-
-  const [activeDragColumnId, setActiveDragColumnId] = useState<string | null>(null)
-  const [targetDragColumnId, setTargetDragColumnId] = useState<string | null>(null)
-  const {
-    cancelDrag,
-    columns,
-    commitDrag,
-    findColumnWithLink: findCurrentColumnWithLink,
-    moveDrag,
-    startDrag,
-  } = useFooterLinkDnd({
+  const dndController = useFooterLinkDnd({
     links,
     onCommit,
   })
 
-  const getOverRect = (over: Over): DOMRect | typeof over.rect => {
-    const getRect = over.data.current?.getRect
-    const rect = typeof getRect === 'function' ? getRect() : null
-
-    return rect || over.rect
-  }
-
-  const getDragTarget = ({
-    active,
-    over,
-  }: DragOverEvent | DragEndEvent): TFooterDragTarget | undefined => {
-    if (!over) return
-
-    const overData = over.data.current
-
-    if (overData?.type === FOOTER_DND_TYPE.LINK) {
-      const overRect = getOverRect(over)
-      const activeRect = active.rect.current.translated
-      const activeCenterY = activeRect ? activeRect.top + activeRect.height / 2 : overRect.top
-      const targetY = pointerYRef.current ?? activeCenterY
-      const overCenterY = overRect.top + overRect.height / 2
-
-      return {
-        columnId: overData.columnId,
-        itemId: overData.itemId,
-        position: targetY > overCenterY ? 'after' : 'before',
-      }
-    }
-
-    if (overData?.type === FOOTER_DND_TYPE.COLUMN) {
-      return {
-        columnId: overData.columnId,
-      }
-    }
-  }
-
-  const handleDragStart = ({ active }: DragStartEvent): void => {
-    const source = findCurrentColumnWithLink(String(active.id))
-    lastDragTargetRef.current = null
-    setActiveDragColumnId(source?.column.id || null)
-    setTargetDragColumnId(null)
-    startDrag(String(active.id))
-  }
-
-  const handleDragOver = (event: DragOverEvent): void => {
-    const target = getDragTarget(event) || null
-    lastDragTargetRef.current = target
-    setTargetDragColumnId(target?.columnId || null)
-    moveDrag(target)
-  }
-
-  const handleDragEnd = (_event: DragEndEvent): void => {
-    const target = lastDragTargetRef.current
-    lastDragTargetRef.current = null
-    setActiveDragColumnId(null)
-    setTargetDragColumnId(null)
-    commitDrag(target)
-  }
-
-  const handleDragCancel = (_event: DragCancelEvent): void => {
-    lastDragTargetRef.current = null
-    setActiveDragColumnId(null)
-    setTargetDragColumnId(null)
-    cancelDrag()
-  }
-
-  const collisionDetection: CollisionDetection = (args) => {
-    pointerYRef.current = args.pointerCoordinates?.y ?? null
-    const linkContainers = args.droppableContainers.filter(
-      (container) =>
-        container.id !== args.active.id && container.data.current?.type === FOOTER_DND_TYPE.LINK,
-    )
-    const groupContainers = args.droppableContainers.filter(
-      (container) => container.data.current?.type === FOOTER_DND_TYPE.COLUMN,
-    )
-
-    const linkArgs = { ...args, droppableContainers: linkContainers }
-    const pointerCollisions = pointerWithin(linkArgs)
-    if (pointerCollisions.length > 0) return pointerCollisions
-
-    const groupArgs = { ...args, droppableContainers: groupContainers }
-    const groupPointerCollisions = pointerWithin(groupArgs)
-    if (groupPointerCollisions.length > 0) return groupPointerCollisions
-
-    const cornerCollisions = closestCorners(linkArgs)
-    if (cornerCollisions.length > 0) return cornerCollisions
-
-    return closestCorners(groupArgs)
-  }
-
   return (
-    <DndContext
-      id={FOOTER_DND_CONTEXT_ID}
-      sensors={sensors}
-      accessibility={{ announcements: DND_ANNOUNCEMENTS }}
+    <SortableDndContext<TFooterColumn, TFooterDragTarget>
+      contextId={FOOTER_DND_CONTEXT_ID}
+      controller={dndController}
+      dndType={{ link: FOOTER_DND_TYPE.LINK, column: FOOTER_DND_TYPE.COLUMN }}
+      announcements={DND_ANNOUNCEMENTS}
       measuring={DND_MEASURING}
-      collisionDetection={collisionDetection}
-      onDragStart={handleDragStart}
-      onDragOver={handleDragOver}
-      onDragEnd={handleDragEnd}
-      onDragCancel={handleDragCancel}
     >
-      {children({ activeDragColumnId, columns, targetDragColumnId })}
-    </DndContext>
+      {children}
+    </SortableDndContext>
   )
 }

--- a/frontend/core/unit/DashboardThread/Footer/Editors/FooterSortableGroup.tsx
+++ b/frontend/core/unit/DashboardThread/Footer/Editors/FooterSortableGroup.tsx
@@ -1,9 +1,6 @@
-import { useDroppable } from '@dnd-kit/core'
-import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
-import { type ReactNode, memo, useRef } from 'react'
+import { type ReactNode, memo } from 'react'
 
-import { cn } from '~/css'
-
+import SortableGroup from '../../LinkEditor/Dnd/SortableGroup'
 import { FOOTER_DND_TYPE } from './constants'
 
 type TProps = {
@@ -23,30 +20,18 @@ const FooterSortableGroup = memo(function FooterSortableGroup({
   overClassName,
   targetClassName = '',
 }: TProps) {
-  const listRef = useRef<HTMLDivElement | null>(null)
-  const { setNodeRef, isOver } = useDroppable({
-    id: `footer-column:${columnId}`,
-    data: {
-      type: FOOTER_DND_TYPE.COLUMN,
-      columnId,
-      getListRect: () => listRef.current?.getBoundingClientRect(),
-    },
-  })
-
-  const setListNodeRef = (node: HTMLDivElement | null): void => {
-    listRef.current = node
-    setNodeRef(node)
-  }
-
   return (
-    <SortableContext id={columnId} items={ids} strategy={verticalListSortingStrategy}>
-      <div
-        ref={setListNodeRef}
-        className={cn(className, isOver && !targetClassName && overClassName, targetClassName)}
-      >
-        {children}
-      </div>
-    </SortableContext>
+    <SortableGroup
+      className={className}
+      columnId={columnId}
+      dndType={{ link: FOOTER_DND_TYPE.LINK, column: FOOTER_DND_TYPE.COLUMN }}
+      idPrefix='footer-column'
+      ids={ids}
+      overClassName={overClassName}
+      targetClassName={targetClassName}
+    >
+      {children}
+    </SortableGroup>
   )
 })
 

--- a/frontend/core/unit/DashboardThread/Footer/Editors/SortableFooterLinkItem.tsx
+++ b/frontend/core/unit/DashboardThread/Footer/Editors/SortableFooterLinkItem.tsx
@@ -1,11 +1,6 @@
-import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { memo, type ReactNode, useCallback, useRef } from 'react'
+import { memo, type ReactNode } from 'react'
 
-import { cn } from '~/css'
-import GrabDotsSVG from '~/icons/GrabDots'
-
-import useSalon from '../../salon/link_editor/sortable_link_item'
+import SortableItem from '../../LinkEditor/Dnd/SortableItem'
 import { FOOTER_DND_TYPE } from './constants'
 
 type TProps = {
@@ -15,70 +10,22 @@ type TProps = {
   id: string
 }
 
-const clampTranslateX = (x: number): number => Math.max(-18, Math.min(60, x))
-
 const SortableFooterLinkItem = memo(function SortableFooterLinkItem({
   children,
   columnId,
   editing = false,
   id,
 }: TProps) {
-  const s = useSalon()
-  const cardRef = useRef<HTMLDivElement | null>(null)
-  const setCardRef = useCallback((node: HTMLDivElement | null): void => {
-    cardRef.current = node
-  }, [])
-  const {
-    attributes,
-    listeners,
-    setActivatorNodeRef,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({
-    id,
-    data: {
-      type: FOOTER_DND_TYPE.LINK,
-      columnId,
-      itemId: id,
-      getRect: () => cardRef.current?.getBoundingClientRect(),
-    },
-  })
-
-  const style = {
-    transform: transform
-      ? CSS.Transform.toString({
-          ...transform,
-          x: clampTranslateX(transform.x),
-        })
-      : undefined,
-    transition,
-  }
-
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={cn(s.wrapper, !editing && s.hoverable, isDragging && s.dragging)}
+    <SortableItem
+      ariaLabel='Drag footer link'
+      columnId={columnId}
+      dndType={{ link: FOOTER_DND_TYPE.LINK, column: FOOTER_DND_TYPE.COLUMN }}
+      editing={editing}
+      id={id}
     >
-      {!editing && (
-        <button
-          ref={setActivatorNodeRef}
-          type='button'
-          className={s.dragHandle}
-          aria-label='Drag footer link'
-          {...attributes}
-          {...listeners}
-        >
-          <GrabDotsSVG className='size-4' />
-        </button>
-      )}
-
-      <div ref={setCardRef} className='w-full text-left'>
-        {children}
-      </div>
-    </div>
+      {children}
+    </SortableItem>
   )
 })
 

--- a/frontend/core/unit/DashboardThread/Footer/Editors/useFooterLinkDnd.ts
+++ b/frontend/core/unit/DashboardThread/Footer/Editors/useFooterLinkDnd.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo } from 'react'
 
 import type { TLinkItem } from '~/spec'
 
+import useSortableDraft from '../../LinkEditor/Dnd/useSortableDraft'
 import {
   buildFooterColumns,
   findColumnWithLink,
@@ -9,7 +10,7 @@ import {
   moveFooterLinkInColumns,
   sameFooterLinks,
 } from './model'
-import type { TFooterColumn, TFooterDragTarget } from './spec'
+import type { TFooterColumn, TFooterDraftLink, TFooterDragTarget } from './spec'
 
 type TProps = {
   links: readonly TLinkItem[]
@@ -27,102 +28,13 @@ type TRet = {
 
 export default function useFooterLinkDnd({ links, onCommit }: TProps): TRet {
   const sourceColumns = useMemo(() => buildFooterColumns(links), [links])
-  const [columns, setColumns] = useState<TFooterColumn[]>(sourceColumns)
-  const latestColumnsRef = useRef(columns)
-  const baselineColumnsRef = useRef(columns)
-  const activeIdRef = useRef<string | null>(null)
-  const draggingRef = useRef(false)
-  const commitFrameRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    latestColumnsRef.current = columns
-  }, [columns])
-
-  useEffect(() => {
-    if (draggingRef.current) return
-    baselineColumnsRef.current = sourceColumns
-    setColumns(sourceColumns)
-  }, [sourceColumns])
-
-  useEffect(() => {
-    return () => {
-      if (commitFrameRef.current) cancelAnimationFrame(commitFrameRef.current)
-    }
-  }, [])
-
-  const findColumn = useCallback(
-    (itemId: string) => findColumnWithLink(latestColumnsRef.current, itemId),
-    [],
-  )
-
-  const startDrag = useCallback((itemId: string): void => {
-    activeIdRef.current = itemId
-    draggingRef.current = true
-    baselineColumnsRef.current = latestColumnsRef.current
-  }, [])
-
-  const moveDrag = useCallback((target?: TFooterDragTarget | null): void => {
-    const activeId = activeIdRef.current
-    if (!activeId || !target?.columnId) return
-
-    const currentColumns = latestColumnsRef.current
-    const source = findColumnWithLink(currentColumns, activeId)
-    if (!source || source.column.id === target.columnId) return
-
-    const nextColumns = moveFooterLinkInColumns(currentColumns, activeId, target)
-    if (sameFooterLinks(flattenFooterColumns(currentColumns), flattenFooterColumns(nextColumns))) {
-      return
-    }
-
-    latestColumnsRef.current = nextColumns
-    setColumns(nextColumns)
-  }, [])
-
-  const commitDrag = useCallback(
-    (target?: TFooterDragTarget | null): void => {
-      const activeId = activeIdRef.current
-      const currentColumns = latestColumnsRef.current
-      const nextColumns =
-        activeId && target
-          ? moveFooterLinkInColumns(currentColumns, activeId, target)
-          : currentColumns
-
-      activeIdRef.current = null
-      draggingRef.current = false
-
-      if (
-        !sameFooterLinks(flattenFooterColumns(currentColumns), flattenFooterColumns(nextColumns))
-      ) {
-        latestColumnsRef.current = nextColumns
-        setColumns(nextColumns)
-      }
-
-      const baselineLinks = flattenFooterColumns(baselineColumnsRef.current)
-      const nextLinks = flattenFooterColumns(nextColumns)
-      if (sameFooterLinks(baselineLinks, nextLinks)) return
-
-      if (commitFrameRef.current) cancelAnimationFrame(commitFrameRef.current)
-      commitFrameRef.current = requestAnimationFrame(() => {
-        onCommit(nextLinks)
-        commitFrameRef.current = null
-      })
-    },
-    [onCommit],
-  )
-
-  const cancelDrag = useCallback((): void => {
-    activeIdRef.current = null
-    draggingRef.current = false
-    latestColumnsRef.current = baselineColumnsRef.current
-    setColumns(baselineColumnsRef.current)
-  }, [])
-
-  return {
-    columns,
-    findColumnWithLink: findColumn,
-    startDrag,
-    moveDrag,
-    commitDrag,
-    cancelDrag,
-  }
+  return useSortableDraft<TFooterColumn, TFooterDraftLink, TFooterDragTarget, TLinkItem>({
+    sourceColumns,
+    findColumnWithLink,
+    flattenColumns: flattenFooterColumns,
+    moveLinkInColumns: moveFooterLinkInColumns,
+    sameLinks: sameFooterLinks,
+    onCommit,
+  })
 }

--- a/frontend/core/unit/DashboardThread/Header/Editors/HeaderSortableGroup.tsx
+++ b/frontend/core/unit/DashboardThread/Header/Editors/HeaderSortableGroup.tsx
@@ -1,9 +1,6 @@
-import { useDroppable } from '@dnd-kit/core'
-import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
-import { type ReactNode, memo, useRef } from 'react'
+import { type ReactNode, memo } from 'react'
 
-import { cn } from '~/css'
-
+import SortableGroup from '../../LinkEditor/Dnd/SortableGroup'
 import { HEADER_DND_TYPE } from './constants'
 
 type TProps = {
@@ -25,31 +22,19 @@ const HeaderSortableGroup = memo(function HeaderSortableGroup({
   overClassName,
   targetClassName = '',
 }: TProps) {
-  const listRef = useRef<HTMLDivElement | null>(null)
-  const { setNodeRef, isOver } = useDroppable({
-    id: `header-column:${columnId}`,
-    disabled,
-    data: {
-      type: HEADER_DND_TYPE.COLUMN,
-      columnId,
-      getListRect: () => listRef.current?.getBoundingClientRect(),
-    },
-  })
-
-  const setListNodeRef = (node: HTMLDivElement | null): void => {
-    listRef.current = node
-    setNodeRef(node)
-  }
-
   return (
-    <SortableContext id={columnId} items={ids} strategy={verticalListSortingStrategy}>
-      <div
-        ref={setListNodeRef}
-        className={cn(className, isOver && !targetClassName && overClassName, targetClassName)}
-      >
-        {children}
-      </div>
-    </SortableContext>
+    <SortableGroup
+      className={className}
+      columnId={columnId}
+      disabled={disabled}
+      dndType={{ link: HEADER_DND_TYPE.LINK, column: HEADER_DND_TYPE.COLUMN }}
+      idPrefix='header-column'
+      ids={ids}
+      overClassName={overClassName}
+      targetClassName={targetClassName}
+    >
+      {children}
+    </SortableGroup>
   )
 })
 

--- a/frontend/core/unit/DashboardThread/Header/Editors/SortableHeaderLinkItem.tsx
+++ b/frontend/core/unit/DashboardThread/Header/Editors/SortableHeaderLinkItem.tsx
@@ -1,11 +1,6 @@
-import { useSortable } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { memo, type ReactNode, useCallback, useRef } from 'react'
+import { memo, type ReactNode } from 'react'
 
-import { cn } from '~/css'
-import GrabDotsSVG from '~/icons/GrabDots'
-
-import useSalon from '../../salon/link_editor/sortable_link_item'
+import SortableItem from '../../LinkEditor/Dnd/SortableItem'
 import { HEADER_DND_TYPE } from './constants'
 
 type TProps = {
@@ -17,8 +12,6 @@ type TProps = {
   linkId: string
 }
 
-const clampTranslateX = (x: number): number => Math.max(-18, Math.min(60, x))
-
 const SortableHeaderLinkItem = memo(function SortableHeaderLinkItem({
   children,
   columnId,
@@ -27,64 +20,18 @@ const SortableHeaderLinkItem = memo(function SortableHeaderLinkItem({
   id,
   linkId,
 }: TProps) {
-  const s = useSalon()
-  const cardRef = useRef<HTMLDivElement | null>(null)
-  const setCardRef = useCallback((node: HTMLDivElement | null): void => {
-    cardRef.current = node
-  }, [])
-  const {
-    attributes,
-    listeners,
-    setActivatorNodeRef,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({
-    id,
-    disabled,
-    data: {
-      type: HEADER_DND_TYPE.LINK,
-      columnId,
-      linkId,
-      itemId: id,
-      getRect: () => cardRef.current?.getBoundingClientRect(),
-    },
-  })
-
-  const style = {
-    transform: transform
-      ? CSS.Transform.toString({
-          ...transform,
-          x: clampTranslateX(transform.x),
-        })
-      : undefined,
-    transition,
-  }
-
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={cn(s.wrapper, !editing && s.hoverable, isDragging && s.dragging)}
+    <SortableItem
+      ariaLabel='Drag header link'
+      columnId={columnId}
+      data={{ linkId }}
+      disabled={disabled}
+      dndType={{ link: HEADER_DND_TYPE.LINK, column: HEADER_DND_TYPE.COLUMN }}
+      editing={editing}
+      id={id}
     >
-      {!disabled && !editing && (
-        <button
-          ref={setActivatorNodeRef}
-          type='button'
-          className={s.dragHandle}
-          aria-label='Drag header link'
-          {...attributes}
-          {...listeners}
-        >
-          <GrabDotsSVG className='size-4' />
-        </button>
-      )}
-
-      <div ref={setCardRef} className='w-full text-left'>
-        {children}
-      </div>
-    </div>
+      {children}
+    </SortableItem>
   )
 })
 

--- a/frontend/core/unit/DashboardThread/Header/Editors/index.tsx
+++ b/frontend/core/unit/DashboardThread/Header/Editors/index.tsx
@@ -1,21 +1,4 @@
-import {
-  DndContext,
-  KeyboardSensor,
-  PointerSensor,
-  closestCorners,
-  pointerWithin,
-  useSensor,
-  useSensors,
-  type CollisionDetection,
-  type DragCancelEvent,
-  type DragEndEvent,
-  type DragOverEvent,
-  type DragStartEvent,
-  type Over,
-} from '@dnd-kit/core'
-import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import type { Dispatch, FC, SetStateAction } from 'react'
-import { useRef, useState } from 'react'
 
 import useTrans from '~/hooks/useTrans'
 import PlusSVG from '~/icons/Plus'
@@ -23,6 +6,7 @@ import type { THeaderLinkItem } from '~/spec'
 import useCommunity from '~/stores/community/hooks'
 import Button from '~/widgets/Buttons/Button'
 
+import SortableDndContext from '../../LinkEditor/Dnd/SortableDndContext'
 import GroupInputer from '../../LinkEditor/GroupInputer'
 import useSalon from '../../salon/header/editors'
 import {
@@ -33,7 +17,6 @@ import {
 } from './constants'
 import FixedLinks from './FixedLinks'
 import HeaderColumn from './HeaderColumn'
-import type { THeaderDragTarget } from './spec'
 import useHeaderEditorActions from './useHeaderEditorActions'
 import useHeaderLinkDnd from './useHeaderLinkDnd'
 
@@ -47,118 +30,12 @@ const Editor: FC<TProps> = ({ links, makeId, onChange }) => {
   const s = useSalon()
   const { t } = useTrans()
   const { slug } = useCommunity()
-  const pointerYRef = useRef<number | null>(null)
-  const lastDragTargetRef = useRef<THeaderDragTarget | null>(null)
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  )
-
-  const [activeDragColumnId, setActiveDragColumnId] = useState<string | null>(null)
-  const [targetDragColumnId, setTargetDragColumnId] = useState<string | null>(null)
   const editor = useHeaderEditorActions({ links, makeId, onChange })
-  const {
-    cancelDrag,
-    columns,
-    commitDrag,
-    findColumnWithLink: findCurrentColumnWithLink,
-    moveDrag,
-    startDrag,
-  } = useHeaderLinkDnd({
+  const dndController = useHeaderLinkDnd({
     links,
     community: slug,
     onCommit: onChange,
   })
-
-  const getOverRect = (over: Over): DOMRect | typeof over.rect => {
-    const getRect = over.data.current?.getRect
-    const rect = typeof getRect === 'function' ? getRect() : null
-
-    return rect || over.rect
-  }
-
-  const getDragTarget = ({
-    active,
-    over,
-  }: DragOverEvent | DragEndEvent): THeaderDragTarget | undefined => {
-    if (!over) return
-
-    const overData = over.data.current
-
-    if (overData?.type === HEADER_DND_TYPE.LINK) {
-      const overRect = getOverRect(over)
-      const activeRect = active.rect.current.translated
-      const activeCenterY = activeRect ? activeRect.top + activeRect.height / 2 : overRect.top
-      const targetY = pointerYRef.current ?? activeCenterY
-      const overCenterY = overRect.top + overRect.height / 2
-
-      return {
-        columnId: overData.columnId,
-        itemId: overData.itemId,
-        position: targetY > overCenterY ? 'after' : 'before',
-      }
-    }
-
-    if (overData?.type === HEADER_DND_TYPE.COLUMN) {
-      return {
-        columnId: overData.columnId,
-      }
-    }
-  }
-
-  const handleDragStart = ({ active }: DragStartEvent): void => {
-    const source = findCurrentColumnWithLink(String(active.id))
-    lastDragTargetRef.current = null
-    setActiveDragColumnId(source?.column.id || null)
-    setTargetDragColumnId(null)
-    startDrag(String(active.id))
-  }
-
-  const handleDragOver = (event: DragOverEvent): void => {
-    const target = getDragTarget(event) || null
-    lastDragTargetRef.current = target
-    setTargetDragColumnId(target?.columnId || null)
-    moveDrag(target)
-  }
-
-  const handleDragEnd = (_event: DragEndEvent): void => {
-    const target = lastDragTargetRef.current
-    lastDragTargetRef.current = null
-    setActiveDragColumnId(null)
-    setTargetDragColumnId(null)
-    commitDrag(target)
-  }
-
-  const handleDragCancel = (_event: DragCancelEvent): void => {
-    lastDragTargetRef.current = null
-    setActiveDragColumnId(null)
-    setTargetDragColumnId(null)
-    cancelDrag()
-  }
-
-  const collisionDetection: CollisionDetection = (args) => {
-    pointerYRef.current = args.pointerCoordinates?.y ?? null
-    const linkContainers = args.droppableContainers.filter(
-      (container) =>
-        container.id !== args.active.id && container.data.current?.type === HEADER_DND_TYPE.LINK,
-    )
-    const groupContainers = args.droppableContainers.filter(
-      (container) => container.data.current?.type === HEADER_DND_TYPE.COLUMN,
-    )
-
-    const linkArgs = { ...args, droppableContainers: linkContainers }
-    const pointerCollisions = pointerWithin(linkArgs)
-    if (pointerCollisions.length > 0) return pointerCollisions
-
-    const groupArgs = { ...args, droppableContainers: groupContainers }
-    const groupPointerCollisions = pointerWithin(groupArgs)
-    if (groupPointerCollisions.length > 0) return groupPointerCollisions
-
-    const cornerCollisions = closestCorners(linkArgs)
-    if (cornerCollisions.length > 0) return cornerCollisions
-
-    return closestCorners(groupArgs)
-  }
 
   const isAboutLinkFold = links.length > 0
 
@@ -201,37 +78,35 @@ const Editor: FC<TProps> = ({ links, makeId, onChange }) => {
         </div>
       )}
 
-      <DndContext
-        id={HEADER_DND_CONTEXT_ID}
-        sensors={sensors}
-        accessibility={{ announcements: DND_ANNOUNCEMENTS }}
+      <SortableDndContext
+        contextId={HEADER_DND_CONTEXT_ID}
+        controller={dndController}
+        dndType={{ link: HEADER_DND_TYPE.LINK, column: HEADER_DND_TYPE.COLUMN }}
+        announcements={DND_ANNOUNCEMENTS}
         measuring={DND_MEASURING}
-        collisionDetection={collisionDetection}
-        onDragStart={handleDragStart}
-        onDragOver={handleDragOver}
-        onDragEnd={handleDragEnd}
-        onDragCancel={handleDragCancel}
       >
-        <div className={s.linkGroup}>
-          {columns.map((column) => {
-            const isCrossGroupTarget =
-              !!activeDragColumnId &&
-              !!targetDragColumnId &&
-              targetDragColumnId === column.id &&
-              activeDragColumnId !== column.id
+        {({ activeDragColumnId, columns, targetDragColumnId }) => (
+          <div className={s.linkGroup}>
+            {columns.map((column) => {
+              const isCrossGroupTarget =
+                !!activeDragColumnId &&
+                !!targetDragColumnId &&
+                targetDragColumnId === column.id &&
+                activeDragColumnId !== column.id
 
-            return (
-              <HeaderColumn
-                key={column.id}
-                column={column}
-                editor={editor}
-                isCollapsed={editor.collapsedGroups.has(column.id)}
-                isCrossGroupTarget={isCrossGroupTarget}
-              />
-            )
-          })}
-        </div>
-      </DndContext>
+              return (
+                <HeaderColumn
+                  key={column.id}
+                  column={column}
+                  editor={editor}
+                  isCollapsed={editor.collapsedGroups.has(column.id)}
+                  isCrossGroupTarget={isCrossGroupTarget}
+                />
+              )
+            })}
+          </div>
+        )}
+      </SortableDndContext>
     </div>
   )
 }

--- a/frontend/core/unit/DashboardThread/Header/Editors/useHeaderLinkDnd.ts
+++ b/frontend/core/unit/DashboardThread/Header/Editors/useHeaderLinkDnd.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo } from 'react'
 
-import type { THeaderLinkItem } from '~/spec'
+import type { THeaderLinkChild, THeaderLinkItem } from '~/spec'
 
+import useSortableDraft from '../../LinkEditor/Dnd/useSortableDraft'
 import {
   buildHeaderColumns,
   findColumnWithLink,
@@ -30,102 +31,13 @@ type TRet = {
 // cross-group hover, then commits once on drop to avoid expensive parent updates.
 export default function useHeaderLinkDnd({ links, community, onCommit }: TProps): TRet {
   const sourceColumns = useMemo(() => buildHeaderColumns(links, community), [community, links])
-  const [columns, setColumns] = useState<THeaderColumn[]>(sourceColumns)
-  const latestColumnsRef = useRef(columns)
-  const baselineColumnsRef = useRef(columns)
-  const activeIdRef = useRef<string | null>(null)
-  const draggingRef = useRef(false)
-  const commitFrameRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    latestColumnsRef.current = columns
-  }, [columns])
-
-  useEffect(() => {
-    if (draggingRef.current) return
-    baselineColumnsRef.current = sourceColumns
-    setColumns(sourceColumns)
-  }, [sourceColumns])
-
-  useEffect(() => {
-    return () => {
-      if (commitFrameRef.current) cancelAnimationFrame(commitFrameRef.current)
-    }
-  }, [])
-
-  const findColumn = useCallback(
-    (itemId: string) => findColumnWithLink(latestColumnsRef.current, itemId),
-    [],
-  )
-
-  const startDrag = useCallback((itemId: string): void => {
-    activeIdRef.current = itemId
-    draggingRef.current = true
-    baselineColumnsRef.current = latestColumnsRef.current
-  }, [])
-
-  const moveDrag = useCallback((target?: THeaderDragTarget | null): void => {
-    const activeId = activeIdRef.current
-    if (!activeId || !target?.columnId) return
-
-    const currentColumns = latestColumnsRef.current
-    const source = findColumnWithLink(currentColumns, activeId)
-    if (!source || source.column.id === target.columnId) return
-
-    const nextColumns = moveHeaderLinkInColumns(currentColumns, activeId, target)
-    if (sameHeaderLinks(flattenHeaderColumns(currentColumns), flattenHeaderColumns(nextColumns))) {
-      return
-    }
-
-    latestColumnsRef.current = nextColumns
-    setColumns(nextColumns)
-  }, [])
-
-  const commitDrag = useCallback(
-    (target?: THeaderDragTarget | null): void => {
-      const activeId = activeIdRef.current
-      const currentColumns = latestColumnsRef.current
-      const nextColumns =
-        activeId && target
-          ? moveHeaderLinkInColumns(currentColumns, activeId, target)
-          : currentColumns
-
-      activeIdRef.current = null
-      draggingRef.current = false
-
-      if (
-        !sameHeaderLinks(flattenHeaderColumns(currentColumns), flattenHeaderColumns(nextColumns))
-      ) {
-        latestColumnsRef.current = nextColumns
-        setColumns(nextColumns)
-      }
-
-      const baselineLinks = flattenHeaderColumns(baselineColumnsRef.current)
-      const nextLinks = flattenHeaderColumns(nextColumns)
-      if (sameHeaderLinks(baselineLinks, nextLinks)) return
-
-      if (commitFrameRef.current) cancelAnimationFrame(commitFrameRef.current)
-      commitFrameRef.current = requestAnimationFrame(() => {
-        onCommit(nextLinks)
-        commitFrameRef.current = null
-      })
-    },
-    [onCommit],
-  )
-
-  const cancelDrag = useCallback((): void => {
-    activeIdRef.current = null
-    draggingRef.current = false
-    latestColumnsRef.current = baselineColumnsRef.current
-    setColumns(baselineColumnsRef.current)
-  }, [])
-
-  return {
-    columns,
-    findColumnWithLink: findColumn,
-    startDrag,
-    moveDrag,
-    commitDrag,
-    cancelDrag,
-  }
+  return useSortableDraft<THeaderColumn, THeaderLinkChild, THeaderDragTarget, THeaderLinkItem>({
+    sourceColumns,
+    findColumnWithLink,
+    flattenColumns: flattenHeaderColumns,
+    moveLinkInColumns: moveHeaderLinkInColumns,
+    sameLinks: sameHeaderLinks,
+    onCommit,
+  })
 }

--- a/frontend/core/unit/DashboardThread/LinkEditor/Dnd/SortableDndContext.tsx
+++ b/frontend/core/unit/DashboardThread/LinkEditor/Dnd/SortableDndContext.tsx
@@ -1,0 +1,141 @@
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCorners,
+  pointerWithin,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragCancelEvent,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { useRef, useState } from 'react'
+
+import { getOverRect } from './helper'
+import type { TLinkDndColumnBase, TLinkDndTarget, TSortableDndContextProps } from './spec'
+
+export default function SortableDndContext<
+  TColumn extends TLinkDndColumnBase,
+  TTarget extends TLinkDndTarget,
+>({
+  children,
+  contextId,
+  controller,
+  dndType,
+  announcements,
+  measuring,
+}: TSortableDndContextProps<TColumn, TTarget>) {
+  const pointerYRef = useRef<number | null>(null)
+  const lastDragTargetRef = useRef<TTarget | null>(null)
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const [activeDragColumnId, setActiveDragColumnId] = useState<string | null>(null)
+  const [targetDragColumnId, setTargetDragColumnId] = useState<string | null>(null)
+
+  const getDragTarget = ({ active, over }: DragOverEvent | DragEndEvent): TTarget | undefined => {
+    if (!over) return
+
+    const overData = over.data.current
+
+    if (overData?.type === dndType.link) {
+      const overRect = getOverRect(over)
+      const activeRect = active.rect.current.translated
+      const activeCenterY = activeRect ? activeRect.top + activeRect.height / 2 : overRect.top
+      const targetY = pointerYRef.current ?? activeCenterY
+      const overCenterY = overRect.top + overRect.height / 2
+
+      return {
+        columnId: overData.columnId,
+        itemId: overData.itemId,
+        position: targetY > overCenterY ? 'after' : 'before',
+      } as TTarget
+    }
+
+    if (overData?.type === dndType.column) {
+      return {
+        columnId: overData.columnId,
+      } as TTarget
+    }
+  }
+
+  const handleDragStart = ({ active }: DragStartEvent): void => {
+    const source = controller.findColumnWithLink(String(active.id))
+    lastDragTargetRef.current = null
+    setActiveDragColumnId(source?.column.id || null)
+    setTargetDragColumnId(null)
+    controller.startDrag(String(active.id))
+  }
+
+  const handleDragOver = (event: DragOverEvent): void => {
+    const target = getDragTarget(event) || null
+    lastDragTargetRef.current = target
+    setTargetDragColumnId(target?.columnId || null)
+    controller.moveDrag(target)
+  }
+
+  const handleDragEnd = (_event: DragEndEvent): void => {
+    const target = lastDragTargetRef.current
+    lastDragTargetRef.current = null
+    setActiveDragColumnId(null)
+    setTargetDragColumnId(null)
+    controller.commitDrag(target)
+  }
+
+  const handleDragCancel = (_event: DragCancelEvent): void => {
+    lastDragTargetRef.current = null
+    setActiveDragColumnId(null)
+    setTargetDragColumnId(null)
+    controller.cancelDrag()
+  }
+
+  const collisionDetection: CollisionDetection = (args) => {
+    pointerYRef.current = args.pointerCoordinates?.y ?? null
+    const linkContainers = args.droppableContainers.filter(
+      (container) =>
+        container.id !== args.active.id && container.data.current?.type === dndType.link,
+    )
+    const groupContainers = args.droppableContainers.filter(
+      (container) => container.data.current?.type === dndType.column,
+    )
+
+    const linkArgs = { ...args, droppableContainers: linkContainers }
+    const pointerCollisions = pointerWithin(linkArgs)
+    if (pointerCollisions.length > 0) return pointerCollisions
+
+    const groupArgs = { ...args, droppableContainers: groupContainers }
+    const groupPointerCollisions = pointerWithin(groupArgs)
+    if (groupPointerCollisions.length > 0) return groupPointerCollisions
+
+    const cornerCollisions = closestCorners(linkArgs)
+    if (cornerCollisions.length > 0) return cornerCollisions
+
+    return closestCorners(groupArgs)
+  }
+
+  return (
+    <DndContext
+      id={contextId}
+      sensors={sensors}
+      accessibility={{ announcements }}
+      measuring={measuring}
+      collisionDetection={collisionDetection}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      {children({
+        activeDragColumnId,
+        columns: controller.columns,
+        targetDragColumnId,
+      })}
+    </DndContext>
+  )
+}

--- a/frontend/core/unit/DashboardThread/LinkEditor/Dnd/SortableGroup.tsx
+++ b/frontend/core/unit/DashboardThread/LinkEditor/Dnd/SortableGroup.tsx
@@ -1,0 +1,60 @@
+import { useDroppable } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { type ReactNode, memo, useRef } from 'react'
+
+import { cn } from '~/css'
+
+import type { TLinkDndType } from './spec'
+
+type TProps = {
+  children: ReactNode
+  className: string
+  columnId: string
+  dndType: TLinkDndType
+  ids: string[]
+  disabled?: boolean
+  idPrefix: string
+  overClassName: string
+  targetClassName?: string
+}
+
+const SortableGroup = memo(function SortableGroup({
+  children,
+  className,
+  columnId,
+  disabled = false,
+  dndType,
+  idPrefix,
+  ids,
+  overClassName,
+  targetClassName = '',
+}: TProps) {
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const { setNodeRef, isOver } = useDroppable({
+    id: `${idPrefix}:${columnId}`,
+    disabled,
+    data: {
+      type: dndType.column,
+      columnId,
+      getListRect: () => listRef.current?.getBoundingClientRect(),
+    },
+  })
+
+  const setListNodeRef = (node: HTMLDivElement | null): void => {
+    listRef.current = node
+    setNodeRef(node)
+  }
+
+  return (
+    <SortableContext id={columnId} items={ids} strategy={verticalListSortingStrategy}>
+      <div
+        ref={setListNodeRef}
+        className={cn(className, isOver && !targetClassName && overClassName, targetClassName)}
+      >
+        {children}
+      </div>
+    </SortableContext>
+  )
+})
+
+export default SortableGroup

--- a/frontend/core/unit/DashboardThread/LinkEditor/Dnd/SortableItem.tsx
+++ b/frontend/core/unit/DashboardThread/LinkEditor/Dnd/SortableItem.tsx
@@ -1,0 +1,95 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { memo, type ReactNode, useCallback, useRef } from 'react'
+
+import { cn } from '~/css'
+import GrabDotsSVG from '~/icons/GrabDots'
+
+import useSalon from '../../salon/link_editor/sortable_link_item'
+import type { TLinkDndType } from './spec'
+
+type TProps = {
+  ariaLabel: string
+  children: ReactNode
+  columnId: string
+  disabled?: boolean
+  dndType: TLinkDndType
+  editing?: boolean
+  id: string
+  data?: Record<string, unknown>
+}
+
+const clampTranslateX = (x: number): number => Math.max(-18, Math.min(60, x))
+
+const SortableItem = memo(function SortableItem({
+  ariaLabel,
+  children,
+  columnId,
+  data,
+  disabled = false,
+  dndType,
+  editing = false,
+  id,
+}: TProps) {
+  const s = useSalon()
+  const cardRef = useRef<HTMLDivElement | null>(null)
+  const setCardRef = useCallback((node: HTMLDivElement | null): void => {
+    cardRef.current = node
+  }, [])
+  const {
+    attributes,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id,
+    disabled,
+    data: {
+      ...data,
+      type: dndType.link,
+      columnId,
+      itemId: id,
+      getRect: () => cardRef.current?.getBoundingClientRect(),
+    },
+  })
+
+  const style = {
+    transform: transform
+      ? CSS.Transform.toString({
+          ...transform,
+          x: clampTranslateX(transform.x),
+        })
+      : undefined,
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(s.wrapper, !editing && s.hoverable, isDragging && s.dragging)}
+    >
+      {!disabled && !editing && (
+        <button
+          ref={setActivatorNodeRef}
+          type='button'
+          className={s.dragHandle}
+          aria-label={ariaLabel}
+          {...attributes}
+          {...listeners}
+        >
+          <GrabDotsSVG className='size-4' />
+        </button>
+      )}
+
+      <div ref={setCardRef} className='w-full text-left'>
+        {children}
+      </div>
+    </div>
+  )
+})
+
+export default SortableItem

--- a/frontend/core/unit/DashboardThread/LinkEditor/Dnd/helper.ts
+++ b/frontend/core/unit/DashboardThread/LinkEditor/Dnd/helper.ts
@@ -1,0 +1,8 @@
+import type { Over } from '@dnd-kit/core'
+
+export const getOverRect = (over: Over): DOMRect | typeof over.rect => {
+  const getRect = over.data.current?.getRect
+  const rect = typeof getRect === 'function' ? getRect() : null
+
+  return rect || over.rect
+}

--- a/frontend/core/unit/DashboardThread/LinkEditor/Dnd/spec.d.ts
+++ b/frontend/core/unit/DashboardThread/LinkEditor/Dnd/spec.d.ts
@@ -1,0 +1,52 @@
+import type { DndContext } from '@dnd-kit/core'
+import type { ComponentProps, ReactNode } from 'react'
+
+export type TLinkDndTarget = {
+  columnId?: string
+  itemId?: string
+  position?: 'before' | 'after'
+}
+
+export type TLinkDndColumnBase = {
+  id: string
+}
+
+export type TLinkDndType = {
+  link: string
+  column: string
+}
+
+export type TLinkDndColumnResult<TColumn extends TLinkDndColumnBase, TLink> = {
+  column: TColumn
+  link: TLink
+}
+
+export type TLinkDndController<
+  TColumn extends TLinkDndColumnBase,
+  TTarget extends TLinkDndTarget,
+> = {
+  columns: TColumn[]
+  findColumnWithLink: (itemId: string) => { column: TColumn } | null
+  startDrag: (itemId: string) => void
+  moveDrag: (target?: TTarget | null) => void
+  commitDrag: (target?: TTarget | null) => void
+  cancelDrag: () => void
+}
+
+export type TLinkDndRenderProps<TColumn extends TLinkDndColumnBase> = {
+  activeDragColumnId: string | null
+  columns: TColumn[]
+  targetDragColumnId: string | null
+}
+
+export type TSortableDndContextProps<
+  TColumn extends TLinkDndColumnBase,
+  TTarget extends TLinkDndTarget,
+> = {
+  children: (props: TLinkDndRenderProps<TColumn>) => ReactNode
+  contextId: string
+  controller: TLinkDndController<TColumn, TTarget>
+  dndType: TLinkDndType
+  announcements: NonNullable<ComponentProps<typeof DndContext>['accessibility']>['announcements']
+  measuring: ComponentProps<typeof DndContext>['measuring']
+}

--- a/frontend/core/unit/DashboardThread/LinkEditor/Dnd/useSortableDraft.ts
+++ b/frontend/core/unit/DashboardThread/LinkEditor/Dnd/useSortableDraft.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { TLinkDndColumnBase, TLinkDndColumnResult, TLinkDndTarget } from './spec'
+
+type TProps<TColumn extends TLinkDndColumnBase, TLink, TTarget extends TLinkDndTarget, TOutput> = {
+  sourceColumns: readonly TColumn[]
+  findColumnWithLink: (
+    columns: readonly TColumn[],
+    itemId: string,
+  ) => TLinkDndColumnResult<TColumn, TLink> | null
+  flattenColumns: (columns: readonly TColumn[]) => readonly TOutput[]
+  moveLinkInColumns: (columns: readonly TColumn[], itemId: string, target: TTarget) => TColumn[]
+  sameLinks: (left: readonly TOutput[], right: readonly TOutput[]) => boolean
+  onCommit: (links: readonly TOutput[]) => void
+}
+
+type TRet<TColumn extends TLinkDndColumnBase, TLink, TTarget extends TLinkDndTarget> = {
+  columns: TColumn[]
+  findColumnWithLink: (itemId: string) => TLinkDndColumnResult<TColumn, TLink> | null
+  startDrag: (itemId: string) => void
+  moveDrag: (target?: TTarget | null) => void
+  commitDrag: (target?: TTarget | null) => void
+  cancelDrag: () => void
+}
+
+// Keeps a local column draft while dragging links. The draft updates during
+// cross-group hover, then commits once on drop to avoid expensive parent updates.
+export default function useSortableDraft<
+  TColumn extends TLinkDndColumnBase,
+  TLink,
+  TTarget extends TLinkDndTarget,
+  TOutput,
+>({
+  sourceColumns,
+  findColumnWithLink,
+  flattenColumns,
+  moveLinkInColumns,
+  sameLinks,
+  onCommit,
+}: TProps<TColumn, TLink, TTarget, TOutput>): TRet<TColumn, TLink, TTarget> {
+  const [columns, setColumns] = useState<TColumn[]>([...sourceColumns])
+  const latestColumnsRef = useRef<TColumn[]>(columns)
+  const baselineColumnsRef = useRef<TColumn[]>(columns)
+  const activeIdRef = useRef<string | null>(null)
+  const draggingRef = useRef(false)
+  const commitFrameRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    latestColumnsRef.current = columns
+  }, [columns])
+
+  useEffect(() => {
+    if (draggingRef.current) return
+
+    const nextColumns = [...sourceColumns]
+    baselineColumnsRef.current = nextColumns
+    latestColumnsRef.current = nextColumns
+    setColumns(nextColumns)
+  }, [sourceColumns])
+
+  useEffect(() => {
+    return () => {
+      if (commitFrameRef.current) cancelAnimationFrame(commitFrameRef.current)
+    }
+  }, [])
+
+  const findColumn = useCallback(
+    (itemId: string) => findColumnWithLink(latestColumnsRef.current, itemId),
+    [findColumnWithLink],
+  )
+
+  const startDrag = useCallback((itemId: string): void => {
+    activeIdRef.current = itemId
+    draggingRef.current = true
+    baselineColumnsRef.current = latestColumnsRef.current
+  }, [])
+
+  const moveDrag = useCallback(
+    (target?: TTarget | null): void => {
+      const activeId = activeIdRef.current
+      if (!activeId || !target?.columnId) return
+
+      const currentColumns = latestColumnsRef.current
+      const source = findColumnWithLink(currentColumns, activeId)
+      if (!source || source.column.id === target.columnId) return
+
+      const nextColumns = moveLinkInColumns(currentColumns, activeId, target)
+      if (sameLinks(flattenColumns(currentColumns), flattenColumns(nextColumns))) return
+
+      latestColumnsRef.current = nextColumns
+      setColumns(nextColumns)
+    },
+    [findColumnWithLink, flattenColumns, moveLinkInColumns, sameLinks],
+  )
+
+  const commitDrag = useCallback(
+    (target?: TTarget | null): void => {
+      const activeId = activeIdRef.current
+      const currentColumns = latestColumnsRef.current
+      const nextColumns =
+        activeId && target ? moveLinkInColumns(currentColumns, activeId, target) : currentColumns
+
+      activeIdRef.current = null
+      draggingRef.current = false
+
+      if (!sameLinks(flattenColumns(currentColumns), flattenColumns(nextColumns))) {
+        latestColumnsRef.current = nextColumns
+        setColumns(nextColumns)
+      }
+
+      const baselineLinks = flattenColumns(baselineColumnsRef.current)
+      const nextLinks = flattenColumns(nextColumns)
+      if (sameLinks(baselineLinks, nextLinks)) return
+
+      if (commitFrameRef.current) cancelAnimationFrame(commitFrameRef.current)
+      commitFrameRef.current = requestAnimationFrame(() => {
+        onCommit(nextLinks)
+        commitFrameRef.current = null
+      })
+    },
+    [flattenColumns, moveLinkInColumns, onCommit, sameLinks],
+  )
+
+  const cancelDrag = useCallback((): void => {
+    activeIdRef.current = null
+    draggingRef.current = false
+    latestColumnsRef.current = baselineColumnsRef.current
+    setColumns(baselineColumnsRef.current)
+  }, [])
+
+  return {
+    columns,
+    findColumnWithLink: findColumn,
+    startDrag,
+    moveDrag,
+    commitDrag,
+    cancelDrag,
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored header and footer link drag-and-drop to a shared, generic DnD layer. This removes duplicate logic, keeps behavior the same, and makes future link editors easier to maintain.

- **Refactors**
  - Added shared DnD primitives under `LinkEditor/Dnd`: `SortableDndContext`, `SortableGroup`, `SortableItem`, `useSortableDraft` (plus helpers/specs).
  - Migrated header/footer editors and hooks to the shared layer; replaced bespoke contexts, items, and collision logic with reusable components.
  - Preserved behavior and UX: same measuring, announcements, and keyboard support via `@dnd-kit/core` and `@dnd-kit/sortable`.
  - No UI changes expected; this is an internal cleanup for consistency and easier extension.

<sup>Written for commit bce4113af666543f1d4fe3976a16192655ef3ba6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated drag-and-drop functionality across dashboard editors into shared, reusable components. This improves code maintainability and reduces duplication while preserving existing link reorganization capabilities in the footer and header editors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/groupher/groupher/pull/508)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->