### PR TITLE
style(fe): update passport rule count bars

### DIFF
--- a/frontend/core/unit/PassportEditor/StackedRuleItem.tsx
+++ b/frontend/core/unit/PassportEditor/StackedRuleItem.tsx
@@ -28,6 +28,31 @@ const getSelectedCount = (rules: string[], selectedRules: string[], selectAll: b
   return rules.filter((rule) => includes(rule, selectedRules)).length
 }
 
+function RuleCountBars({
+  selectedCount,
+  totalCount,
+  completed,
+  s,
+}: {
+  selectedCount: number
+  totalCount: number
+  completed: boolean
+  s: ReturnType<typeof useSalon>
+}) {
+  const activeBarClass = completed ? s.itemBarDone : s.itemBarPartial
+
+  return (
+    <div className={s.itemBars} aria-label={`${selectedCount}/${totalCount}`}>
+      {Array.from({ length: totalCount }).map((_, index) => (
+        <span
+          key={index}
+          className={`${s.itemBar} ${index < selectedCount ? activeBarClass : s.itemBarEmpty}`}
+        />
+      ))}
+    </div>
+  )
+}
+
 export default function StackedRuleItem({
   title,
   rules,
@@ -45,7 +70,7 @@ export default function StackedRuleItem({
   const checked = selectedCount === rules.length
   const indeterminate = selectedCount > 0 && selectedCount < rules.length
   const completed = selectedCount === rules.length
-  const s = useSalon({ active, completed })
+  const s = useSalon({ active })
 
   const detailPanel = (
     <div className={s.detailPanel}>
@@ -89,14 +114,18 @@ export default function StackedRuleItem({
         placement='bottom'
         offset={[-55, 0]}
         maxWidth={180}
+        hideOnClick={false}
         noPadding
         onShow={() => setActive(true)}
         onHide={() => setActive(false)}
         content={detailPanel}
       >
-        <div className={s.itemCount}>
-          {selectedCount}/{rules.length}
-        </div>
+        <RuleCountBars
+          selectedCount={selectedCount}
+          totalCount={rules.length}
+          completed={completed}
+          s={s}
+        />
       </Tooltip>
     </div>
   )

--- a/frontend/core/unit/PassportEditor/salon/selects.ts
+++ b/frontend/core/unit/PassportEditor/salon/selects.ts
@@ -13,7 +13,7 @@ export default function useSalon() {
     groupDesc: cn('text-sm mt-1 mb-3 w-11/12', fg('digest')),
     groupPanel: cn('w-full rounded-sm border', br('divider')),
     groupBody: 'grid grid-cols-2 gap-x-5 gap-y-1',
-    threadedGroupBody: 'column w-full gap-y-5 p-4',
+    threadedGroupBody: 'column w-full gap-y-5 py-3.5 pl-3 pr-0',
     threadGroup: 'min-w-0 w-full',
     threadTitle: cn('row-center text-xs bold-sm uppercase mb-3 gap-x-1.5', fg('title')),
     primaryThreadTitle: cn('row-center text-xs bold-sm uppercase mb-3 gap-x-1.5', primary('fg')),

--- a/frontend/core/unit/PassportEditor/salon/stacked_rule_item.ts
+++ b/frontend/core/unit/PassportEditor/salon/stacked_rule_item.ts
@@ -1,13 +1,14 @@
 import { COLOR } from '~/const/colors'
+import useTheme from '~/hooks/useTheme'
 import useTwBelt from '~/hooks/useTwBelt'
 
 type TProps = {
   active: boolean
-  completed: boolean
 }
 
-export default function useSalon({ active, completed }: TProps) {
-  const { cn, fg, bg, primary, rainbow, rainbowSoft } = useTwBelt()
+export default function useSalon({ active }: TProps) {
+  const { cn, fg, bg, primary, rainbow } = useTwBelt()
+  const { isDarkTheme } = useTheme()
 
   return {
     wrapper: cn(
@@ -21,10 +22,10 @@ export default function useSalon({ active, completed }: TProps) {
     detailList: 'column gap-y-1',
     itemTitle: cn('text-sm ml-2 min-w-0 flex-1 truncate', fg('digest')),
     primaryItemTitle: cn('text-sm ml-2 min-w-0 flex-1 truncate', primary('fg')),
-    itemCount: cn(
-      'ml-1 text-xs bold-sm shrink-0 rounded-lg px-1.5 py-0.5',
-      rainbow(completed ? COLOR.GREEN : COLOR.ORANGE, 'fg'),
-      active && rainbowSoft(completed ? COLOR.GREEN : COLOR.ORANGE),
-    ),
+    itemBars: cn('ml-2 row-center shrink-0 gap-0.5 rounded px-1 py-0.5 trans-all-100'),
+    itemBar: 'h-3 w-1 rounded-full trans-all-100',
+    itemBarDone: cn(rainbow(COLOR.GREEN, 'bg'), 'opacity-40'),
+    itemBarPartial: cn(rainbow(COLOR.ORANGE, 'bg'), 'opacity-80'),
+    itemBarEmpty: cn(bg('digest'), isDarkTheme ? 'opacity-40' : 'opacity-20'),
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the numeric rule count in the Passport editor with segmented bars that show selected vs total rules. Improves readability, dark mode contrast, and spacing.

- **UI Improvements**
  - Added `RuleCountBars` in `StackedRuleItem` to render per-rule bars (green when complete, orange when partial; empty bars adjust opacity by theme).
  - Kept the detail tooltip open on click (`hideOnClick=false`) for easier interaction.
  - Simplified `useSalon` API (removed `completed` prop) and added new bar styles.
  - Improved a11y with an `aria-label` on the bar container (e.g., "3/5").
  - Tweaked `threadedGroupBody` padding to `py-3.5 pl-3 pr-0` for cleaner layout.

<sup>Written for commit 0dc8bc604505b292aafd23baa4f04722e65309b1. Summary will update on new commits. <a href="https://cubic.dev/pr/groupher/groupher/pull/517?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rule selection now displays as a visual count-bar component instead of numeric text, providing clearer progress indication.

* **Style**
  * Updated spacing and styling adjustments for improved layout consistency, including refined padding values and theme-aware visual styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/groupher/groupher/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->