### PR TITLE
[codex] organize wallpaper gradient palettes

### DIFF
--- a/frontend/core/constant/wallpaper.ts
+++ b/frontend/core/constant/wallpaper.ts
@@ -1,5 +1,5 @@
 import { GRADIENT_RENDERER, type TGradientRecipe } from '~/lib/wallpaperMesh'
-import type { TWallpaper } from '~/spec'
+import type { TGradientEffectInit, TGradientPalette, TWallpaper } from '~/spec'
 
 export { PATTERN_WALLPAPER, WALLPAPER_PATTERN } from './wallpaper.generated'
 
@@ -166,133 +166,219 @@ export const COVER_GRADIENT_WALLPAPER = {
 } satisfies Record<string, TWallpaper>
 
 export const GRADIENT_WALLPAPER_NAME = {
-  PINK: 'pink',
-  GREEN: 'green',
-  ORANGE: 'orange',
-  PURPLE: 'purple',
-  GREY: 'grey',
-  BLUE: 'blue',
-  PASTEL: 'pastel',
-  MEADOW: 'meadow',
-  AURORA: 'aurora',
-  LAGOON: 'lagoon',
-  SUNSET: 'sunset',
-  OCEAN: 'ocean',
-  BLOOM: 'bloom',
-  CEDAR: 'cedar',
-  DUNE: 'dune',
-  MINT: 'mint',
-  DEEP_SEA: 'deep_sea',
-  TANGERINE: 'tangerine',
-  NEXT_GLOW: 'next_glow',
+  AMBER_MAUVE: 'amber_mauve',
+  STONE_GREEN: 'stone_green',
+  AMBER_ROSE: 'amber_rose',
+  TEAL_INDIGO_MAUVE: 'teal_indigo_mauve',
+  SKY_MAUVE_BLUE: 'sky_mauve_blue',
+  OLIVE_GREEN: 'olive_green',
+  STONE_TAUPE: 'stone_taupe',
+  EMERALD_OLIVE: 'emerald_olive',
+  CYAN_SLATE: 'cyan_slate',
+  AMBER_ORANGE: 'amber_orange',
+  PINK_INDIGO_VIOLET: 'pink_indigo_violet',
+  VIOLET_TEAL_AMBER: 'violet_teal_amber',
+  ROSE_AMBER_SKY: 'rose_amber_sky',
+  SLATE_ROSE_GREEN: 'slate_rose_green',
+  VIOLET_ROSE_MAUVE: 'violet_rose_mauve',
+  SKY_ORANGE_SLATE: 'sky_orange_slate',
+  SLATE_FUCHSIA_AMBER: 'slate_fuchsia_amber',
+  SLATE_ORANGE_CYAN: 'slate_orange_cyan',
+  ZINC_ORANGE_CYAN: 'zinc_orange_cyan',
+  MIST_ROSE_GREEN: 'mist_rose_green',
+  ORANGE_AMBER_VIOLET: 'orange_amber_violet',
+  INDIGO_RED_AMBER: 'indigo_red_amber',
+  SLATE_TEAL_EMERALD: 'slate_teal_emerald',
+  SLATE_CYAN_AMBER: 'slate_cyan_amber',
+  EMERALD_AMBER_ROSE: 'emerald_amber_rose',
+  RED_SKY: 'red_sky',
+  ROSE_SKY_MAUVE: 'rose_sky_mauve',
 } as const
 
-export const GRADIENT_WALLPAPER = {
-  [GRADIENT_WALLPAPER_NAME.PINK]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.PINK,
+const DEFAULT_GRADIENT_EFFECT_INIT = {
+  angle: 180,
+  spread: 58,
+} satisfies TGradientEffectInit
+
+export const GRADIENT_PALETTE = {
+  [GRADIENT_WALLPAPER_NAME.AMBER_MAUVE]: {
+    key: GRADIENT_WALLPAPER_NAME.AMBER_MAUVE,
+    label: 'Amber Mauve',
     colors: ['#FBEFDE', '#D8B9E3'],
-    angle: 180,
-    spread: 52,
   },
-  [GRADIENT_WALLPAPER_NAME.GREEN]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.GREEN,
+  [GRADIENT_WALLPAPER_NAME.STONE_GREEN]: {
+    key: GRADIENT_WALLPAPER_NAME.STONE_GREEN,
+    label: 'Stone Green',
     colors: ['#D6D9B8', '#87BB89'],
-    angle: 180,
-    spread: 58,
   },
-  [GRADIENT_WALLPAPER_NAME.ORANGE]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.ORANGE,
+  [GRADIENT_WALLPAPER_NAME.AMBER_ROSE]: {
+    key: GRADIENT_WALLPAPER_NAME.AMBER_ROSE,
+    label: 'Amber Rose',
     colors: ['#ffefc4', '#c06577'],
-    angle: 180,
-    spread: 48,
   },
-  [GRADIENT_WALLPAPER_NAME.PURPLE]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.PURPLE,
+  [GRADIENT_WALLPAPER_NAME.TEAL_INDIGO_MAUVE]: {
+    key: GRADIENT_WALLPAPER_NAME.TEAL_INDIGO_MAUVE,
+    label: 'Teal Indigo Mauve',
     colors: ['#69999F', '#6B80A7', '#8C8EBB'],
-    angle: 180,
-    spread: 62,
   },
-  [GRADIENT_WALLPAPER_NAME.BLUE]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.BLUE,
+  [GRADIENT_WALLPAPER_NAME.SKY_MAUVE_BLUE]: {
+    key: GRADIENT_WALLPAPER_NAME.SKY_MAUVE_BLUE,
+    label: 'Sky Mauve Blue',
     colors: ['#daf3fb', '#B8D1FA', '#c7bbf2', '#6390c5'],
-    angle: 180,
-    spread: 58,
   },
-  [GRADIENT_WALLPAPER_NAME.CEDAR]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.CEDAR,
+  [GRADIENT_WALLPAPER_NAME.OLIVE_GREEN]: {
+    key: GRADIENT_WALLPAPER_NAME.OLIVE_GREEN,
+    label: 'Olive Green',
     colors: ['#4f6851', '#203a27'],
-    angle: 112,
-    spread: 74,
   },
-  [GRADIENT_WALLPAPER_NAME.DUNE]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.DUNE,
+  [GRADIENT_WALLPAPER_NAME.STONE_TAUPE]: {
+    key: GRADIENT_WALLPAPER_NAME.STONE_TAUPE,
+    label: 'Stone Taupe',
     colors: ['#e6cda7', '#b58a58'],
-    angle: 118,
-    spread: 72,
   },
-  [GRADIENT_WALLPAPER_NAME.MINT]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.MINT,
+  [GRADIENT_WALLPAPER_NAME.EMERALD_OLIVE]: {
+    key: GRADIENT_WALLPAPER_NAME.EMERALD_OLIVE,
+    label: 'Emerald Olive',
     colors: ['#5fcf94', '#9a9634'],
-    angle: 116,
-    spread: 68,
   },
-  [GRADIENT_WALLPAPER_NAME.DEEP_SEA]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.DEEP_SEA,
+  [GRADIENT_WALLPAPER_NAME.CYAN_SLATE]: {
+    key: GRADIENT_WALLPAPER_NAME.CYAN_SLATE,
+    label: 'Cyan Slate',
     colors: ['#4dbfc0', '#223148'],
-    angle: 132,
-    spread: 78,
   },
-  [GRADIENT_WALLPAPER_NAME.TANGERINE]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.TANGERINE,
+  [GRADIENT_WALLPAPER_NAME.AMBER_ORANGE]: {
+    key: GRADIENT_WALLPAPER_NAME.AMBER_ORANGE,
+    label: 'Amber Orange',
     colors: ['#ffc767', '#ff7834'],
-    angle: 124,
-    spread: 70,
   },
-  [GRADIENT_WALLPAPER_NAME.NEXT_GLOW]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.NEXT_GLOW,
+  [GRADIENT_WALLPAPER_NAME.PINK_INDIGO_VIOLET]: {
+    key: GRADIENT_WALLPAPER_NAME.PINK_INDIGO_VIOLET,
+    label: 'Pink Indigo Violet',
     colors: ['#d79bc6', '#5f6fb3', '#4d3b70', '#272f55'],
-    angle: 128,
-    spread: 78,
   },
-  [GRADIENT_WALLPAPER_NAME.AURORA]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.AURORA,
+  [GRADIENT_WALLPAPER_NAME.VIOLET_TEAL_AMBER]: {
+    key: GRADIENT_WALLPAPER_NAME.VIOLET_TEAL_AMBER,
+    label: 'Violet Teal Amber',
     colors: ['#24143e', '#0c5878', '#2b8c90', '#ff746d', '#ffc66d', '#5b2f65'],
-    angle: 92,
-    spread: 94,
   },
-  [GRADIENT_WALLPAPER_NAME.LAGOON]: {
-    version: 2,
-    renderer: GRADIENT_RENDERER.LINEAR,
-    preset: GRADIENT_WALLPAPER_NAME.LAGOON,
+  [GRADIENT_WALLPAPER_NAME.ROSE_AMBER_SKY]: {
+    key: GRADIENT_WALLPAPER_NAME.ROSE_AMBER_SKY,
+    label: 'Rose Amber Sky',
     colors: ['#ffd8cb', '#fff0cf', '#ff6338', '#a8d7ff', '#f1aaa2'],
-    angle: 18,
-    spread: 92,
   },
-} satisfies Record<string, TGradientRecipe>
+  [GRADIENT_WALLPAPER_NAME.SLATE_ROSE_GREEN]: {
+    key: GRADIENT_WALLPAPER_NAME.SLATE_ROSE_GREEN,
+    label: 'Slate Rose Green',
+    colors: ['#050716', '#4C093B', '#F6D9BC', '#9CCB8D'],
+  },
+  [GRADIENT_WALLPAPER_NAME.VIOLET_ROSE_MAUVE]: {
+    key: GRADIENT_WALLPAPER_NAME.VIOLET_ROSE_MAUVE,
+    label: 'Violet Rose Mauve',
+    colors: ['#52308B', '#C45493', '#D5B4DE', '#F0A2C4'],
+  },
+  [GRADIENT_WALLPAPER_NAME.SKY_ORANGE_SLATE]: {
+    key: GRADIENT_WALLPAPER_NAME.SKY_ORANGE_SLATE,
+    label: 'Sky Orange Slate',
+    colors: ['#BBD6DD', '#EC4B0C', '#F7C27A', '#2D5570'],
+  },
+  [GRADIENT_WALLPAPER_NAME.SLATE_FUCHSIA_AMBER]: {
+    key: GRADIENT_WALLPAPER_NAME.SLATE_FUCHSIA_AMBER,
+    label: 'Slate Fuchsia Amber',
+    colors: ['#020817', '#8A22DA', '#FF2B8C', '#FFBC44'],
+  },
+  [GRADIENT_WALLPAPER_NAME.SLATE_ORANGE_CYAN]: {
+    key: GRADIENT_WALLPAPER_NAME.SLATE_ORANGE_CYAN,
+    label: 'Slate Orange Cyan',
+    colors: ['#020405', '#F26A2F', '#E8D6D8', '#0E6D90'],
+  },
+  [GRADIENT_WALLPAPER_NAME.ZINC_ORANGE_CYAN]: {
+    key: GRADIENT_WALLPAPER_NAME.ZINC_ORANGE_CYAN,
+    label: 'Zinc Orange Cyan',
+    colors: ['#171A1F', '#FF9247', '#F8FBFF', '#57D8EC'],
+  },
+  [GRADIENT_WALLPAPER_NAME.MIST_ROSE_GREEN]: {
+    key: GRADIENT_WALLPAPER_NAME.MIST_ROSE_GREEN,
+    label: 'Mist Rose Green',
+    colors: ['#DCEEF2', '#F4D4DB', '#D7D5C8', '#72BF98'],
+  },
+  [GRADIENT_WALLPAPER_NAME.ORANGE_AMBER_VIOLET]: {
+    key: GRADIENT_WALLPAPER_NAME.ORANGE_AMBER_VIOLET,
+    label: 'Orange Amber Violet',
+    colors: ['#D94D2B', '#E9B879', '#B5A9D6', '#4A1737'],
+  },
+  [GRADIENT_WALLPAPER_NAME.INDIGO_RED_AMBER]: {
+    key: GRADIENT_WALLPAPER_NAME.INDIGO_RED_AMBER,
+    label: 'Indigo Red Amber',
+    colors: ['#30477A', '#FF5145', '#FFB84E', '#B93368'],
+  },
+  [GRADIENT_WALLPAPER_NAME.SLATE_TEAL_EMERALD]: {
+    key: GRADIENT_WALLPAPER_NAME.SLATE_TEAL_EMERALD,
+    label: 'Slate Teal Emerald',
+    colors: ['#07130F', '#0C6B69', '#B8E7E4', '#65C987'],
+  },
+  [GRADIENT_WALLPAPER_NAME.SLATE_CYAN_AMBER]: {
+    key: GRADIENT_WALLPAPER_NAME.SLATE_CYAN_AMBER,
+    label: 'Slate Cyan Amber',
+    colors: ['#020608', '#214B5A', '#7BAEBB', '#E9D2A2'],
+  },
+  [GRADIENT_WALLPAPER_NAME.EMERALD_AMBER_ROSE]: {
+    key: GRADIENT_WALLPAPER_NAME.EMERALD_AMBER_ROSE,
+    label: 'Emerald Amber Rose',
+    colors: ['#69B59F', '#F5E9D0', '#E6BE55', '#E86E86'],
+  },
+  [GRADIENT_WALLPAPER_NAME.RED_SKY]: {
+    key: GRADIENT_WALLPAPER_NAME.RED_SKY,
+    label: 'Red Sky',
+    colors: ['#F7F7F4', '#E15B57', '#9FBCC2', '#B9D9E4'],
+  },
+  [GRADIENT_WALLPAPER_NAME.ROSE_SKY_MAUVE]: {
+    key: GRADIENT_WALLPAPER_NAME.ROSE_SKY_MAUVE,
+    label: 'Rose Sky Mauve',
+    colors: ['#F5E5E8', '#FF8E86', '#9ABDE7', '#AC70A6'],
+  },
+} satisfies Record<string, TGradientPalette>
+
+const GRADIENT_EFFECT_INIT: Record<string, TGradientEffectInit> = {
+  [GRADIENT_WALLPAPER_NAME.AMBER_MAUVE]: { angle: 180, spread: 52 },
+  [GRADIENT_WALLPAPER_NAME.STONE_GREEN]: { angle: 180, spread: 58 },
+  [GRADIENT_WALLPAPER_NAME.AMBER_ROSE]: { angle: 180, spread: 48 },
+  [GRADIENT_WALLPAPER_NAME.TEAL_INDIGO_MAUVE]: { angle: 180, spread: 62 },
+  [GRADIENT_WALLPAPER_NAME.SKY_MAUVE_BLUE]: { angle: 180, spread: 58 },
+  [GRADIENT_WALLPAPER_NAME.OLIVE_GREEN]: { angle: 112, spread: 74 },
+  [GRADIENT_WALLPAPER_NAME.STONE_TAUPE]: { angle: 118, spread: 72 },
+  [GRADIENT_WALLPAPER_NAME.EMERALD_OLIVE]: { angle: 116, spread: 68 },
+  [GRADIENT_WALLPAPER_NAME.CYAN_SLATE]: { angle: 132, spread: 78 },
+  [GRADIENT_WALLPAPER_NAME.AMBER_ORANGE]: { angle: 124, spread: 70 },
+  [GRADIENT_WALLPAPER_NAME.PINK_INDIGO_VIOLET]: { angle: 128, spread: 78 },
+  [GRADIENT_WALLPAPER_NAME.VIOLET_TEAL_AMBER]: { angle: 92, spread: 94 },
+  [GRADIENT_WALLPAPER_NAME.ROSE_AMBER_SKY]: { angle: 18, spread: 92 },
+  [GRADIENT_WALLPAPER_NAME.SLATE_ROSE_GREEN]: { angle: 38, spread: 88 },
+  [GRADIENT_WALLPAPER_NAME.VIOLET_ROSE_MAUVE]: { angle: 132, spread: 72 },
+  [GRADIENT_WALLPAPER_NAME.SKY_ORANGE_SLATE]: { angle: 155, spread: 82 },
+  [GRADIENT_WALLPAPER_NAME.SLATE_FUCHSIA_AMBER]: { angle: 180, spread: 90 },
+  [GRADIENT_WALLPAPER_NAME.SLATE_ORANGE_CYAN]: { angle: 135, spread: 80 },
+  [GRADIENT_WALLPAPER_NAME.ZINC_ORANGE_CYAN]: { angle: 45, spread: 86 },
+  [GRADIENT_WALLPAPER_NAME.MIST_ROSE_GREEN]: { angle: 90, spread: 68 },
+  [GRADIENT_WALLPAPER_NAME.ORANGE_AMBER_VIOLET]: { angle: 145, spread: 76 },
+  [GRADIENT_WALLPAPER_NAME.INDIGO_RED_AMBER]: { angle: 90, spread: 84 },
+  [GRADIENT_WALLPAPER_NAME.SLATE_TEAL_EMERALD]: { angle: 120, spread: 76 },
+  [GRADIENT_WALLPAPER_NAME.SLATE_CYAN_AMBER]: { angle: 130, spread: 78 },
+  [GRADIENT_WALLPAPER_NAME.EMERALD_AMBER_ROSE]: { angle: 25, spread: 74 },
+  [GRADIENT_WALLPAPER_NAME.RED_SKY]: { angle: 180, spread: 70 },
+  [GRADIENT_WALLPAPER_NAME.ROSE_SKY_MAUVE]: { angle: 135, spread: 72 },
+} satisfies Record<string, TGradientEffectInit>
+
+const buildGradientWallpaper = (palette: TGradientPalette): TGradientRecipe => ({
+  version: 2,
+  renderer: GRADIENT_RENDERER.LINEAR,
+  preset: palette.key,
+  colors: palette.colors,
+  ...(GRADIENT_EFFECT_INIT[palette.key] ?? DEFAULT_GRADIENT_EFFECT_INIT),
+})
+
+export const GRADIENT_WALLPAPER = Object.fromEntries(
+  Object.values(GRADIENT_PALETTE).map((palette) => [palette.key, buildGradientWallpaper(palette)]),
+) as Record<string, TGradientRecipe>
 
 export const GRADIENT_DIRECTION = {
   TOP: 'top',

--- a/frontend/core/hooks/useFullWallpaper/helper.ts
+++ b/frontend/core/hooks/useFullWallpaper/helper.ts
@@ -1,8 +1,13 @@
 import { clone } from 'ramda'
 
-import { GRADIENT_WALLPAPER, PATTERN_WALLPAPER, WALLPAPER_TYPE } from '~/const/wallpaper'
+import {
+  GRADIENT_PALETTE,
+  GRADIENT_WALLPAPER,
+  PATTERN_WALLPAPER,
+  WALLPAPER_TYPE,
+} from '~/const/wallpaper'
 import type { TGradientRecipe } from '~/lib/wallpaperMesh'
-import type { TWallpaper, TWallpaperPic, TWallpaperType } from '~/spec'
+import type { TGradientPalette, TWallpaper, TWallpaperPic, TWallpaperType } from '~/spec'
 
 type TGradientEffectState = {
   source: string
@@ -20,6 +25,9 @@ type TPatternEffectState = {
 
 export const buildGradientCatalogWallpapers = (): Record<string, TGradientRecipe> =>
   clone(GRADIENT_WALLPAPER)
+
+export const buildGradientCatalogPalettes = (): Record<string, TGradientPalette> =>
+  clone(GRADIENT_PALETTE)
 
 export const buildPatternCatalogWallpapers = (): Record<string, TWallpaper> => {
   const wallpapers = clone(PATTERN_WALLPAPER)

--- a/frontend/core/hooks/useFullWallpaper/index.test.tsx
+++ b/frontend/core/hooks/useFullWallpaper/index.test.tsx
@@ -17,7 +17,7 @@ describe('useFullWallpaper', () => {
   it('returns data and can commit wallpaper changes', async () => {
     const wrapper = makeStoreWrapper({
       wallpaper: {
-        source: GRADIENT_WALLPAPER_NAME.PINK,
+        source: GRADIENT_WALLPAPER_NAME.AMBER_MAUVE,
         type: WALLPAPER_TYPE.GRADIENT,
         hasPattern: true,
         patternId: DEFAULT_WALLPAPER_PATTERN_ID,
@@ -28,14 +28,14 @@ describe('useFullWallpaper', () => {
         brightness: 100,
         saturation: 100,
         texture: { type: WALLPAPER_TEXTURE.NOISE, intensity: 0, params: {} },
-        gradient: GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.PINK],
+        gradient: GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.AMBER_MAUVE],
       },
     })
 
     const { result } = renderHook(() => useFullWallpaper(), { wrapper })
 
     const data = result.current.getWallpaper()
-    expect(data.source).toBe(GRADIENT_WALLPAPER_NAME.PINK)
+    expect(data.source).toBe(GRADIENT_WALLPAPER_NAME.AMBER_MAUVE)
     expect(data.type).toBe(WALLPAPER_TYPE.GRADIENT)
     expect(data.patternId).toBe(DEFAULT_WALLPAPER_PATTERN_ID)
     expect(data.patternIntensity).toBe(100)
@@ -45,9 +45,16 @@ describe('useFullWallpaper', () => {
     expect(data.saturation).toBe(100)
     expect(data.texture).toEqual({ type: WALLPAPER_TEXTURE.NOISE, intensity: 0, params: {} })
 
-    const pink = data.gradientWallpapers.pink
-    expect('colors' in pink).toBe(true)
-    expect(pink.renderer).toBe(GRADIENT_RENDERER.LINEAR)
+    const amberMauve = data.gradientWallpapers.amber_mauve
+    expect('colors' in amberMauve).toBe(true)
+    expect(amberMauve.renderer).toBe(GRADIENT_RENDERER.LINEAR)
+    expect(data.gradientPalettes.amber_mauve).toEqual({
+      key: GRADIENT_WALLPAPER_NAME.AMBER_MAUVE,
+      label: 'Amber Mauve',
+      colors: GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.AMBER_MAUVE].colors,
+    })
+    expect(data.gradientPalettes.amber_mauve).not.toHaveProperty('angle')
+    expect(data.gradientPalettes.amber_mauve).not.toHaveProperty('spread')
 
     act(() => result.current.changePatternWallpaper('dots'))
 
@@ -59,22 +66,22 @@ describe('useFullWallpaper', () => {
   it('keeps gradient catalog previews static', () => {
     const wrapper = makeStoreWrapper({
       wallpaper: {
-        source: GRADIENT_WALLPAPER_NAME.PURPLE,
+        source: GRADIENT_WALLPAPER_NAME.TEAL_INDIGO_MAUVE,
         type: WALLPAPER_TYPE.GRADIENT,
         hasPattern: true,
         patternId: DEFAULT_WALLPAPER_PATTERN_ID,
         patternIntensity: 100,
         patternTone: WALLPAPER_PATTERN_TONE.DARK,
         blurIntensity: 50,
-        gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.PURPLE], angle: 90 },
+        gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.TEAL_INDIGO_MAUVE], angle: 90 },
       },
     })
 
     const { result } = renderHook(() => useFullWallpaper(), { wrapper })
     const data = result.current.getWallpaper()
 
-    const active = data.gradientWallpapers[GRADIENT_WALLPAPER_NAME.PURPLE]
-    const defaultPattern = data.gradientWallpapers[GRADIENT_WALLPAPER_NAME.GREEN]
+    const active = data.gradientWallpapers[GRADIENT_WALLPAPER_NAME.TEAL_INDIGO_MAUVE]
+    const defaultPattern = data.gradientWallpapers[GRADIENT_WALLPAPER_NAME.STONE_GREEN]
 
     expect(active).toMatchObject({ renderer: GRADIENT_RENDERER.LINEAR, angle: 180 })
 

--- a/frontend/core/hooks/useFullWallpaper/index.ts
+++ b/frontend/core/hooks/useFullWallpaper/index.ts
@@ -1,11 +1,15 @@
 import { GRADIENT_WALLPAPER, WALLPAPER_TYPE } from '~/const/wallpaper'
 import useTheme from '~/hooks/useTheme'
 import type { TGradientRecipe } from '~/lib/wallpaperMesh'
-import type { TWallpaper, TWallpaperData } from '~/spec'
+import type { TGradientPalette, TWallpaper, TWallpaperData } from '~/spec'
 import { resolveWallpaperThemeState, toWallpaperThemePatch } from '~/stores/wallpaper/helper'
 import useWallpaperDomain from '~/stores/wallpaper/hooks'
 
-import { buildGradientCatalogWallpapers, buildPatternCatalogWallpapers } from './helper'
+import {
+  buildGradientCatalogPalettes,
+  buildGradientCatalogWallpapers,
+  buildPatternCatalogWallpapers,
+} from './helper'
 
 type TRet = {
   source: string
@@ -13,6 +17,7 @@ type TRet = {
   changePatternWallpaper: (source: string) => void
   getWallpaper: () => TWallpaperData
   getGradientWallpapers: () => Record<string, TGradientRecipe>
+  getGradientPalettes: () => Record<string, TGradientPalette>
   getPatternWallpapers: () => Record<string, TWallpaper>
 }
 
@@ -22,6 +27,10 @@ export default function useFullWallpaper(): TRet {
 
   const getGradientWallpapers = (): Record<string, TGradientRecipe> => {
     return buildGradientCatalogWallpapers()
+  }
+
+  const getGradientPalettes = (): Record<string, TGradientPalette> => {
+    return buildGradientCatalogPalettes()
   }
 
   const getPatternWallpapers = (): Record<string, TWallpaper> => {
@@ -48,7 +57,7 @@ export default function useFullWallpaper(): TRet {
     } = themedState
 
     const hasBlur = blurIntensity > 0
-    const activeGradient = gradient || GRADIENT_WALLPAPER[source] || GRADIENT_WALLPAPER.pink
+    const activeGradient = gradient || GRADIENT_WALLPAPER[source] || GRADIENT_WALLPAPER.amber_mauve
 
     return {
       source,
@@ -78,6 +87,7 @@ export default function useFullWallpaper(): TRet {
       gradientDark: store.gradientDark,
       texture,
       textureDark: store.textureDark,
+      gradientPalettes: getGradientPalettes(),
       gradientWallpapers: getGradientWallpapers(),
       patternWallpapers: getPatternWallpapers(),
       bgSize,
@@ -95,6 +105,7 @@ export default function useFullWallpaper(): TRet {
     source: resolveWallpaperThemeState(store, isDarkTheme).source,
     changeWallpaper,
     changePatternWallpaper,
+    getGradientPalettes,
     getGradientWallpapers,
     getPatternWallpapers,
     getWallpaper,

--- a/frontend/core/hooks/useTopGlow/index.test.tsx
+++ b/frontend/core/hooks/useTopGlow/index.test.tsx
@@ -29,7 +29,7 @@ describe('useTopGlow', () => {
     expect(result.current.glowFixed).toBe(false)
   })
 
-  it('disables glow on landing when wallpaper is not PINK', () => {
+  it('disables glow on landing when wallpaper is not AMBER_MAUVE', () => {
     const wrapper = makeStoreWrapper({
       metric: METRIC.LANDING,
       wallpaper: { source: 'sky_mauve_blue', type: WALLPAPER_TYPE.GRADIENT },

--- a/frontend/core/hooks/useTopGlow/index.test.tsx
+++ b/frontend/core/hooks/useTopGlow/index.test.tsx
@@ -32,7 +32,7 @@ describe('useTopGlow', () => {
   it('disables glow on landing when wallpaper is not PINK', () => {
     const wrapper = makeStoreWrapper({
       metric: METRIC.LANDING,
-      wallpaper: { source: 'blue', type: WALLPAPER_TYPE.GRADIENT },
+      wallpaper: { source: 'sky_mauve_blue', type: WALLPAPER_TYPE.GRADIENT },
       dashboard: { themeTokens: { glowType: null, glowTypeDark: null } },
     })
 

--- a/frontend/core/hooks/useTopGlow/index.ts
+++ b/frontend/core/hooks/useTopGlow/index.ts
@@ -26,7 +26,7 @@ export default function useTopGlow(): TTopGlow {
 
   if (
     includes(metric, [METRIC.APPLY_COMMUNITY]) ||
-    (metric === METRIC.LANDING && source !== GRADIENT_WALLPAPER_NAME.PINK)
+    (metric === METRIC.LANDING && source !== GRADIENT_WALLPAPER_NAME.AMBER_MAUVE)
   ) {
     return {
       glowType: null,

--- a/frontend/core/hooks/useWallpaper/index.test.tsx
+++ b/frontend/core/hooks/useWallpaper/index.test.tsx
@@ -15,7 +15,11 @@ import {
   GRADIENT_RENDERER,
   WALLPAPER_TEXTURE,
 } from '~/lib/wallpaperMesh'
-import type { TMeshGradientRecipe, TWallpaperTexture } from '~/lib/wallpaperMesh'
+import type {
+  TLinearGradientRecipe,
+  TMeshGradientRecipe,
+  TWallpaperTexture,
+} from '~/lib/wallpaperMesh'
 import { WALLPAPER_RENDER_KIND } from '~/lib/wallpaperRenderer/constant'
 
 describe('useWallpaper', () => {
@@ -58,12 +62,12 @@ describe('useWallpaper', () => {
 
   it('resolves lagoon as liquid wallpaper', () => {
     const gradient = buildGradientRecipeForRenderer(
-      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.LAGOON],
+      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.ROSE_AMBER_SKY],
       GRADIENT_RENDERER.LIQUID,
     )
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.LAGOON,
+      source: GRADIENT_WALLPAPER_NAME.ROSE_AMBER_SKY,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
@@ -87,9 +91,9 @@ describe('useWallpaper', () => {
   it('applies current gradient effects to the rendered wallpaper', () => {
     const wrapper = makeStoreWrapper({
       wallpaper: {
-        source: GRADIENT_WALLPAPER_NAME.PURPLE,
+        source: GRADIENT_WALLPAPER_NAME.TEAL_INDIGO_MAUVE,
         type: WALLPAPER_TYPE.GRADIENT,
-        gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.PURPLE], angle: 90 },
+        gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.TEAL_INDIGO_MAUVE], angle: 90 },
         hasPattern: true,
         patternId: DEFAULT_WALLPAPER_PATTERN_ID,
         patternIntensity: 100,
@@ -162,14 +166,14 @@ describe('useWallpaper', () => {
   it('resolves small texture descriptor separately from CSS wallpaper output', () => {
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.GREEN,
+      source: GRADIENT_WALLPAPER_NAME.STONE_GREEN,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
       patternIntensity: 65,
       patternTone: WALLPAPER_PATTERN_TONE.DARK,
       hasTexture: true,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 90 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 90 },
       blurIntensity: 30,
       hasShadow: false,
       brightness: 90,
@@ -193,14 +197,14 @@ describe('useWallpaper', () => {
   it('keeps gradient pattern out of the renderer fallback background', () => {
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.GREEN,
+      source: GRADIENT_WALLPAPER_NAME.STONE_GREEN,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: true,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
       patternIntensity: 10,
       patternTone: WALLPAPER_PATTERN_TONE.DARK,
       hasTexture: false,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 90 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 90 },
       blurIntensity: 0,
       hasShadow: false,
       brightness: 100,
@@ -218,14 +222,17 @@ describe('useWallpaper', () => {
   it('normalizes linear gradient spread as a centered transition band', () => {
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.GREEN,
+      source: GRADIENT_WALLPAPER_NAME.STONE_GREEN,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
       patternIntensity: 100,
       patternTone: WALLPAPER_PATTERN_TONE.DARK,
       hasTexture: false,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], spread: 0 },
+      gradient: {
+        ...(GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN] as TLinearGradientRecipe),
+        spread: 0,
+      },
       blurIntensity: 0,
       hasShadow: false,
       brightness: 100,
@@ -240,14 +247,14 @@ describe('useWallpaper', () => {
 
   it('normalizes radial gradient spread as outward palette reach', () => {
     const radialGradient = buildGradientRecipeForRenderer(
-      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.BLUE],
+      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.SKY_MAUVE_BLUE],
       GRADIENT_RENDERER.RADIAL,
     )
     if (radialGradient.renderer !== GRADIENT_RENDERER.RADIAL) throw new Error('expected radial')
 
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.BLUE,
+      source: GRADIENT_WALLPAPER_NAME.SKY_MAUVE_BLUE,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
@@ -271,14 +278,14 @@ describe('useWallpaper', () => {
 
   it('uses explicit radial gradient stops in the renderer descriptor', () => {
     const radialGradient = buildGradientRecipeForRenderer(
-      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.BLUE],
+      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.SKY_MAUVE_BLUE],
       GRADIENT_RENDERER.RADIAL,
     )
     if (radialGradient.renderer !== GRADIENT_RENDERER.RADIAL) throw new Error('expected radial')
 
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.BLUE,
+      source: GRADIENT_WALLPAPER_NAME.SKY_MAUVE_BLUE,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
@@ -301,14 +308,14 @@ describe('useWallpaper', () => {
   it('falls back unsupported texture payloads to noise', () => {
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.GREEN,
+      source: GRADIENT_WALLPAPER_NAME.STONE_GREEN,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
       patternIntensity: 100,
       patternTone: WALLPAPER_PATTERN_TONE.DARK,
       hasTexture: true,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 90 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 90 },
       blurIntensity: 0,
       hasShadow: false,
       brightness: 100,
@@ -331,14 +338,14 @@ describe('useWallpaper', () => {
   it('accepts dots texture descriptors', () => {
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.GREEN,
+      source: GRADIENT_WALLPAPER_NAME.STONE_GREEN,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
       patternIntensity: 100,
       patternTone: WALLPAPER_PATTERN_TONE.DARK,
       hasTexture: true,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 90 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 90 },
       blurIntensity: 0,
       hasShadow: false,
       brightness: 100,
@@ -357,14 +364,14 @@ describe('useWallpaper', () => {
   it('accepts oil texture descriptors', () => {
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.GREEN,
+      source: GRADIENT_WALLPAPER_NAME.STONE_GREEN,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
       patternIntensity: 100,
       patternTone: WALLPAPER_PATTERN_TONE.DARK,
       hasTexture: true,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 90 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 90 },
       blurIntensity: 0,
       hasShadow: false,
       brightness: 100,
@@ -383,14 +390,14 @@ describe('useWallpaper', () => {
   it('accepts tile texture descriptors', () => {
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.GREEN,
+      source: GRADIENT_WALLPAPER_NAME.STONE_GREEN,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
       patternIntensity: 100,
       patternTone: WALLPAPER_PATTERN_TONE.DARK,
       hasTexture: true,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 90 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 90 },
       blurIntensity: 0,
       hasShadow: false,
       brightness: 100,
@@ -409,14 +416,14 @@ describe('useWallpaper', () => {
   it('keeps texture settings while marking them disabled', () => {
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.GREEN,
+      source: GRADIENT_WALLPAPER_NAME.STONE_GREEN,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: false,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
       patternIntensity: 100,
       patternTone: WALLPAPER_PATTERN_TONE.DARK,
       hasTexture: false,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 90 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 90 },
       blurIntensity: 0,
       hasShadow: false,
       brightness: 100,
@@ -436,14 +443,14 @@ describe('useWallpaper', () => {
   it('uses a light pattern color when pattern tone is light', () => {
     const descriptor = resolveWallpaperRenderDescriptor({
       customWallpaper: null,
-      source: GRADIENT_WALLPAPER_NAME.AURORA,
+      source: GRADIENT_WALLPAPER_NAME.VIOLET_TEAL_AMBER,
       type: WALLPAPER_TYPE.GRADIENT,
       hasPattern: true,
       patternId: DEFAULT_WALLPAPER_PATTERN_ID,
       patternIntensity: 100,
       patternTone: WALLPAPER_PATTERN_TONE.LIGHT,
       hasTexture: false,
-      gradient: GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.AURORA],
+      gradient: GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.VIOLET_TEAL_AMBER],
       blurIntensity: 0,
       hasShadow: false,
       brightness: 100,

--- a/frontend/core/lib/wallpaperMesh/mesh.ts
+++ b/frontend/core/lib/wallpaperMesh/mesh.ts
@@ -39,6 +39,11 @@ export const getGradientRecipeSpread = (recipe: TGradientRecipe): number =>
 const getRecipeStops = (recipe: TGradientRecipe, colorCount: number): number[] | undefined =>
   !isMeshGradientRecipe(recipe) && recipe.stops?.length === colorCount ? recipe.stops : undefined
 
+type TGradientPaletteLike = {
+  key: string
+  colors: string[]
+}
+
 export const buildGradientRecipeForRenderer = (
   recipe: TGradientRecipe,
   renderer: TGradientRenderer,
@@ -95,15 +100,13 @@ export const buildGradientRecipeForRenderer = (
 }
 
 export const applyGradientPalette = (
-  current: TGradientRecipe | null,
-  palette: TGradientRecipe,
+  current: TGradientRecipe,
+  palette: TGradientPaletteLike,
 ): TGradientRecipe => {
-  if (!current) return palette
-
   return buildGradientRecipeForRenderer(
     {
       ...current,
-      preset: palette.preset,
+      preset: palette.key,
       colors: palette.colors,
     },
     current.renderer,

--- a/frontend/core/spec/wallpaper.d.ts
+++ b/frontend/core/spec/wallpaper.d.ts
@@ -46,10 +46,22 @@ export type TWallpaperPatternTone = WALLPAPER_PATTERN_TONE
 
 export type TWallpaperBgSize = WALLPAPER_BG_SIZE
 
+export type TGradientPalette = {
+  key: string
+  label: string
+  colors: string[]
+}
+
+export type TGradientEffectInit = {
+  angle: number
+  spread: number
+}
+
 export type TWallpaperInfo = {
   customWallpaper?: TCustomWallpaper
   source: string
   wallpapers: Record<string, TWallpaper>
+  gradientPalettes?: Record<string, TGradientPalette>
   gradientWallpapers?: Record<string, TGradientRecipe>
 
   changeWallpaper?: (source: string) => void
@@ -58,6 +70,7 @@ export type TWallpaperInfo = {
 export type TWallpaperData = {
   source: string
   sourceDark: string
+  gradientPalettes: Record<string, TGradientPalette>
   gradientWallpapers: Record<string, TGradientRecipe>
   patternWallpapers: Record<string, TWallpaper>
   type: TWallpaperType

--- a/frontend/core/stores/wallpaper/helper.test.ts
+++ b/frontend/core/stores/wallpaper/helper.test.ts
@@ -11,14 +11,14 @@ import {
 describe('stores/wallpaper/helper', () => {
   it('resolves the active light or dark wallpaper state', () => {
     const store = setupStore({
-      source: 'pink',
-      sourceDark: 'purple',
+      source: 'amber_mauve',
+      sourceDark: 'teal_indigo_mauve',
       brightness: 100,
       brightnessDark: 82,
       gradient: {
         version: 2,
         renderer: GRADIENT_RENDERER.LINEAR,
-        preset: 'pink',
+        preset: 'amber_mauve',
         colors: ['#fff', '#ddd'],
         angle: 180,
         spread: 52,
@@ -26,7 +26,7 @@ describe('stores/wallpaper/helper', () => {
       gradientDark: {
         version: 2,
         renderer: GRADIENT_RENDERER.LINEAR,
-        preset: 'purple',
+        preset: 'teal_indigo_mauve',
         colors: ['#111', '#333'],
         angle: 90,
         spread: 52,
@@ -34,14 +34,14 @@ describe('stores/wallpaper/helper', () => {
     })
 
     expect(resolveWallpaperThemeState(store, false)).toMatchObject({
-      source: 'pink',
+      source: 'amber_mauve',
       brightness: 100,
-      gradient: expect.objectContaining({ preset: 'pink' }),
+      gradient: expect.objectContaining({ preset: 'amber_mauve' }),
     })
     expect(resolveWallpaperThemeState(store, true)).toMatchObject({
-      source: 'purple',
+      source: 'teal_indigo_mauve',
       brightness: 82,
-      gradient: expect.objectContaining({ preset: 'purple' }),
+      gradient: expect.objectContaining({ preset: 'teal_indigo_mauve' }),
     })
   })
 
@@ -57,19 +57,19 @@ describe('stores/wallpaper/helper', () => {
 
   it('builds a sparse savable patch from original to current state', () => {
     const store = setupStore({
-      source: 'pink',
-      sourceDark: 'purple',
+      source: 'amber_mauve',
+      sourceDark: 'teal_indigo_mauve',
       texture: { type: WALLPAPER_TEXTURE.NOISE, intensity: 0, params: {} },
       textureDark: { type: WALLPAPER_TEXTURE.TILE, intensity: 40, params: {} },
     })
 
     store.commit({
-      sourceDark: 'blue',
+      sourceDark: 'sky_mauve_blue',
       textureDark: { type: WALLPAPER_TEXTURE.ASCII, intensity: 55, params: {} },
     })
 
     expect(getWallpaperSavablePatch(store)).toEqual({
-      sourceDark: 'blue',
+      sourceDark: 'sky_mauve_blue',
       textureDark: { type: WALLPAPER_TEXTURE.ASCII, intensity: 55, params: {} },
     })
   })

--- a/frontend/core/stores/wallpaper/index.ts
+++ b/frontend/core/stores/wallpaper/index.ts
@@ -15,9 +15,9 @@ import type { TInit, TStore, TWallpaperState } from './spec'
 
 export const INITIAL_WALLPAPER_STATE = {
   customWallpaper: null,
-  source: 'pink',
+  source: 'amber_mauve',
   type: WALLPAPER_TYPE.GRADIENT,
-  sourceDark: 'pink',
+  sourceDark: 'amber_mauve',
   typeDark: WALLPAPER_TYPE.GRADIENT,
   hasPattern: true,
   patternId: DEFAULT_WALLPAPER_PATTERN_ID,
@@ -29,8 +29,8 @@ export const INITIAL_WALLPAPER_STATE = {
   patternIntensityDark: 50,
   patternToneDark: WALLPAPER_PATTERN_TONE.DARK,
   hasTextureDark: false,
-  gradient: GRADIENT_WALLPAPER.pink,
-  gradientDark: GRADIENT_WALLPAPER.pink,
+  gradient: GRADIENT_WALLPAPER.amber_mauve,
+  gradientDark: GRADIENT_WALLPAPER.amber_mauve,
   blurIntensity: 0,
   hasShadow: false,
   brightness: 100,
@@ -52,10 +52,10 @@ const resolveInitialWallpaperState = (init: TInit): TWallpaperState => {
   }
 
   if (state.type === WALLPAPER_TYPE.GRADIENT && !state.gradient) {
-    state.gradient = GRADIENT_WALLPAPER[state.source] ?? GRADIENT_WALLPAPER.pink
+    state.gradient = GRADIENT_WALLPAPER[state.source] ?? GRADIENT_WALLPAPER.amber_mauve
   }
   if (state.typeDark === WALLPAPER_TYPE.GRADIENT && !state.gradientDark) {
-    state.gradientDark = GRADIENT_WALLPAPER[state.sourceDark] ?? GRADIENT_WALLPAPER.pink
+    state.gradientDark = GRADIENT_WALLPAPER[state.sourceDark] ?? GRADIENT_WALLPAPER.amber_mauve
   }
 
   return state

--- a/frontend/core/stores/wallpaper/tests/index.test.ts
+++ b/frontend/core/stores/wallpaper/tests/index.test.ts
@@ -21,7 +21,7 @@ describe('stores/wallpaper', () => {
     expect(store.patternIntensity).toBe(50)
     expect(store.patternTone).toBe(WALLPAPER_PATTERN_TONE.DARK)
     expect(store.hasTexture).toBe(false)
-    expect(store.gradient).toEqual(GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.PINK])
+    expect(store.gradient).toEqual(GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.AMBER_MAUVE])
     expect(store.brightness).toBe(100)
     expect(store.saturation).toBe(100)
     expect(store.texture).toEqual({ type: WALLPAPER_TEXTURE.NOISE, intensity: 0, params: {} })
@@ -38,7 +38,7 @@ describe('stores/wallpaper', () => {
       bgSize: WALLPAPER_BG_SIZE.CONTAIN,
       brightness: 90,
       saturation: 120,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 90 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 90 },
       texture: { type: WALLPAPER_TEXTURE.ASCII, intensity: 55, params: {} },
     })
 
@@ -54,7 +54,7 @@ describe('stores/wallpaper', () => {
     expect(store.brightness).toBe(90)
     expect(store.saturation).toBe(120)
     expect(store.gradient).toEqual({
-      ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN],
+      ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN],
       angle: 90,
     })
     expect(store.texture).toEqual({ type: WALLPAPER_TEXTURE.ASCII, intensity: 55, params: {} })
@@ -69,7 +69,7 @@ describe('stores/wallpaper', () => {
       patternIntensity: 65,
       patternTone: WALLPAPER_PATTERN_TONE.LIGHT,
       hasTexture: true,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 45 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 45 },
       blurIntensity: 35,
       hasShadow: true,
       brightness: 85,
@@ -88,7 +88,7 @@ describe('stores/wallpaper', () => {
       patternIntensity: 65,
       patternTone: WALLPAPER_PATTERN_TONE.LIGHT,
       hasTexture: true,
-      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.GREEN], angle: 45 },
+      gradient: { ...GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN], angle: 45 },
       blurIntensity: 35,
       hasShadow: true,
       brightness: 85,

--- a/frontend/core/unit/CommunityEditor/salon/content/fake_browser/browser_head.ts
+++ b/frontend/core/unit/CommunityEditor/salon/content/fake_browser/browser_head.ts
@@ -1,7 +1,7 @@
 import { includes, keys } from 'ramda'
 
 import { COLOR } from '~/const/colors'
-import { GRADIENT_WALLPAPER, GRADIENT_WALLPAPER_NAME } from '~/const/wallpaper'
+import { GRADIENT_WALLPAPER } from '~/const/wallpaper'
 import useTwBelt from '~/hooks/useTwBelt'
 import useWallpaper from '~/hooks/useWallpaper'
 
@@ -9,10 +9,6 @@ import useWallpaper from '~/hooks/useWallpaper'
 const getPathGradient = (wallpaper: string): string => {
   if (!includes(wallpaper, keys(GRADIENT_WALLPAPER))) {
     return '#f2bc5a,#f76b6b'
-  }
-
-  if (wallpaper === GRADIENT_WALLPAPER_NAME.AMBER_MAUVE) {
-    return '#f8be6d,#c479de'
   }
 
   const { colors } = GRADIENT_WALLPAPER[wallpaper]

--- a/frontend/core/unit/CommunityEditor/salon/content/fake_browser/browser_head.ts
+++ b/frontend/core/unit/CommunityEditor/salon/content/fake_browser/browser_head.ts
@@ -11,12 +11,8 @@ const getPathGradient = (wallpaper: string): string => {
     return '#f2bc5a,#f76b6b'
   }
 
-  if (wallpaper === GRADIENT_WALLPAPER_NAME.PINK) {
+  if (wallpaper === GRADIENT_WALLPAPER_NAME.AMBER_MAUVE) {
     return '#f8be6d,#c479de'
-  }
-
-  if (wallpaper === GRADIENT_WALLPAPER_NAME.GREY) {
-    return '#E1D5CC,#955D29'
   }
 
   const { colors } = GRADIENT_WALLPAPER[wallpaper]

--- a/frontend/core/unit/DashboardThread/Appearance/Wallpaper/GradientTab/GradientSwatchPreview.tsx
+++ b/frontend/core/unit/DashboardThread/Appearance/Wallpaper/GradientTab/GradientSwatchPreview.tsx
@@ -1,17 +1,32 @@
 import { type CSSProperties, useMemo } from 'react'
 
 import { cn } from '~/css'
-import { buildGradientBackground, type TGradientRecipe } from '~/lib/wallpaperMesh'
+import type { TGradientPalette } from '~/spec'
 
 type TProps = {
   className?: string
-  gradient: TGradientRecipe
+  palette: TGradientPalette
 }
 
-export default function GradientSwatchPreview({ className, gradient }: TProps) {
+const buildPaletteSwatchBackground = (colors: string[]): string => {
+  if (colors.length === 0) return 'transparent'
+  if (colors.length === 1) return colors[0]
+
+  const [first, second = first, third = second, ...rest] = colors
+  const baseColors = [first, second, third, ...rest]
+
+  return [
+    `radial-gradient(circle at 26% 22%, ${first} 0, transparent 42%)`,
+    `radial-gradient(circle at 78% 28%, ${second} 0, transparent 44%)`,
+    `radial-gradient(circle at 52% 82%, ${third} 0, transparent 50%)`,
+    `linear-gradient(135deg, ${baseColors.join(', ')})`,
+  ].join(', ')
+}
+
+export default function GradientSwatchPreview({ className, palette }: TProps) {
   const fallbackStyle = useMemo<CSSProperties>(
-    () => ({ background: buildGradientBackground(gradient) }),
-    [gradient],
+    () => ({ background: buildPaletteSwatchBackground(palette.colors) }),
+    [palette],
   )
 
   return <div className={cn(className, 'relative')} style={fallbackStyle} />

--- a/frontend/core/unit/DashboardThread/Appearance/Wallpaper/GradientTab/index.tsx
+++ b/frontend/core/unit/DashboardThread/Appearance/Wallpaper/GradientTab/index.tsx
@@ -13,15 +13,15 @@ export default function GradientTab() {
   const { getWallpaper, changeGradientWallpaper, changePatternId } = useLogic()
 
   const wallpaper = getWallpaper()
-  const { gradientWallpapers, patternId } = wallpaper
+  const { gradientPalettes, patternId } = wallpaper
 
-  const gradientKeys = keys(gradientWallpapers)
+  const gradientKeys = keys(gradientPalettes)
 
   return (
     <div className={s.wrapper}>
       <div className={s.gradientGrid}>
         {gradientKeys.map((name) => {
-          const presetGradient = gradientWallpapers[name]
+          const palette = gradientPalettes[name]
           const selected = isActiveWallpaperSource(wallpaper, WALLPAPER_TYPE.GRADIENT, name)
 
           return (
@@ -29,11 +29,13 @@ export default function GradientTab() {
               type='button'
               key={name}
               className={cnMerge(s.card, selected && s.cardActive)}
+              aria-label={palette.label}
+              title={palette.label}
               onClick={() => {
                 if (!selected) changeGradientWallpaper(name)
               }}
             >
-              <GradientSwatchPreview className={s.preview} gradient={presetGradient} />
+              <GradientSwatchPreview className={s.preview} palette={palette} />
             </button>
           )
         })}

--- a/frontend/core/unit/DashboardThread/Appearance/Wallpaper/useLogic.test.ts
+++ b/frontend/core/unit/DashboardThread/Appearance/Wallpaper/useLogic.test.ts
@@ -1,48 +1,59 @@
 import { GRADIENT_WALLPAPER, GRADIENT_WALLPAPER_NAME, WALLPAPER_TYPE } from '~/const/wallpaper'
-import { buildGradientRecipeForRenderer, GRADIENT_RENDERER } from '~/lib/wallpaperMesh'
+import {
+  buildGradientRecipeForRenderer,
+  getGradientRecipeSpread,
+  GRADIENT_RENDERER,
+} from '~/lib/wallpaperMesh'
 
 import { buildGradientWallpaperPatch } from './useLogic'
 
 describe('buildGradientWallpaperPatch', () => {
   it('defaults to linear when switching from picture to gradient', () => {
     const previousGradient = buildGradientRecipeForRenderer(
-      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.AURORA],
+      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.VIOLET_TEAL_AMBER],
       GRADIENT_RENDERER.LIQUID,
     )
 
     const patch = buildGradientWallpaperPatch(
       { type: WALLPAPER_TYPE.PATTERN, gradient: previousGradient },
-      GRADIENT_WALLPAPER_NAME.GREEN,
+      GRADIENT_WALLPAPER_NAME.STONE_GREEN,
     )
 
     expect(patch.type).toBe(WALLPAPER_TYPE.GRADIENT)
-    expect(patch.source).toBe(GRADIENT_WALLPAPER_NAME.GREEN)
+    expect(patch.source).toBe(GRADIENT_WALLPAPER_NAME.STONE_GREEN)
     expect(patch.gradient?.renderer).toBe(GRADIENT_RENDERER.LINEAR)
   })
 
   it('keeps the active renderer when switching presets inside gradient mode', () => {
     const previousGradient = buildGradientRecipeForRenderer(
-      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.AURORA],
+      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.VIOLET_TEAL_AMBER],
       GRADIENT_RENDERER.LIQUID,
     )
 
     const patch = buildGradientWallpaperPatch(
       { type: WALLPAPER_TYPE.GRADIENT, gradient: previousGradient },
-      GRADIENT_WALLPAPER_NAME.GREEN,
+      GRADIENT_WALLPAPER_NAME.STONE_GREEN,
     )
 
     expect(patch.gradient?.renderer).toBe(GRADIENT_RENDERER.LIQUID)
+    expect(patch.gradient?.angle).toBe(previousGradient.angle)
+    expect(patch.gradient && getGradientRecipeSpread(patch.gradient)).toBe(
+      getGradientRecipeSpread(previousGradient),
+    )
+    expect(patch.gradient?.colors).toEqual(
+      GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.STONE_GREEN].colors,
+    )
   })
 
   it('keeps the original gradient shape after switching away and back', () => {
-    const originalGradient = GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.PINK]
+    const originalGradient = GRADIENT_WALLPAPER[GRADIENT_WALLPAPER_NAME.AMBER_MAUVE]
     const awayPatch = buildGradientWallpaperPatch(
       { type: WALLPAPER_TYPE.GRADIENT, gradient: originalGradient },
-      GRADIENT_WALLPAPER_NAME.GREEN,
+      GRADIENT_WALLPAPER_NAME.STONE_GREEN,
     )
     const backPatch = buildGradientWallpaperPatch(
       { type: WALLPAPER_TYPE.GRADIENT, gradient: awayPatch.gradient },
-      GRADIENT_WALLPAPER_NAME.PINK,
+      GRADIENT_WALLPAPER_NAME.AMBER_MAUVE,
     )
 
     expect(backPatch.gradient).toStrictEqual(originalGradient)

--- a/frontend/core/unit/DashboardThread/Appearance/Wallpaper/useLogic.ts
+++ b/frontend/core/unit/DashboardThread/Appearance/Wallpaper/useLogic.ts
@@ -2,6 +2,7 @@ import { clone, equals, pick } from 'ramda'
 import { createContext, use, useEffect, useMemo, useState } from 'react'
 
 import {
+  GRADIENT_PALETTE,
   GRADIENT_WALLPAPER,
   WALLPAPER_SAVABLE_STATE_KEYS,
   WALLPAPER_STATE_KEYS,
@@ -136,11 +137,12 @@ export const buildGradientWallpaperPatch = (
   wallpaper: Pick<TWallpaperThemeState, 'type' | 'gradient'>,
   source: string,
 ): Pick<TWallpaperThemeState, 'source' | 'type' | 'gradient'> => {
-  const palette = GRADIENT_WALLPAPER[source] ?? GRADIENT_WALLPAPER.pink
+  const palette = GRADIENT_PALETTE[source] ?? GRADIENT_PALETTE.amber_mauve
+  const initialGradient = GRADIENT_WALLPAPER[source] ?? GRADIENT_WALLPAPER.amber_mauve
   const gradient =
-    wallpaper.type === WALLPAPER_TYPE.GRADIENT
+    wallpaper.type === WALLPAPER_TYPE.GRADIENT && wallpaper.gradient
       ? applyGradientPalette(wallpaper.gradient, palette)
-      : buildGradientRecipeForRenderer(palette, GRADIENT_RENDERER.LINEAR)
+      : buildGradientRecipeForRenderer(initialGradient, GRADIENT_RENDERER.LINEAR)
 
   return {
     source,
@@ -296,20 +298,22 @@ export function useLogicValue(): TWallpaperLogic {
 
     if (wallpaperState.gradient) return
 
-    const fallback = GRADIENT_WALLPAPER.pink
+    const fallback = GRADIENT_WALLPAPER.amber_mauve
     scheduleWallpaperPreview({ gradient: { ...fallback, angle } })
   }
   const removeWallpaper = (): void => {
     clearPendingWallpaperDraft()
     clearWallpaperPreview()
-    liveWallpaper$.commit(toWallpaperThemePatch({ source: '', type: WALLPAPER_TYPE.NONE }, isDarkTheme))
+    liveWallpaper$.commit(
+      toWallpaperThemePatch({ source: '', type: WALLPAPER_TYPE.NONE }, isDarkTheme),
+    )
   }
   const changeGradientWallpaper = (source: string): void =>
     commitWallpaperPatch(buildGradientWallpaperPatch(wallpaperState, source))
   const changeGradientRecipe = (gradient: TGradientRecipe): void =>
     commitWallpaperPatch({ source: gradient.preset, type: WALLPAPER_TYPE.GRADIENT, gradient })
   const changeGradientRenderer = (renderer: TGradientRenderer): void => {
-    const gradient = wallpaperState.gradient ?? GRADIENT_WALLPAPER.pink
+    const gradient = wallpaperState.gradient ?? GRADIENT_WALLPAPER.amber_mauve
 
     commitWallpaperPatch({
       source: gradient.preset,

--- a/frontend/core/widgets/Buttons/salon/border_button.ts
+++ b/frontend/core/widgets/Buttons/salon/border_button.ts
@@ -8,25 +8,21 @@ export { cn } from '~/css'
 // TODO: move to @groupher-share
 const getGithubGradient = (wallpaper: string): string => {
   switch (wallpaper) {
-    case GRADIENT_WALLPAPER_NAME.PINK: {
+    case GRADIENT_WALLPAPER_NAME.AMBER_MAUVE: {
       return 'linear-gradient(64deg, #2f2f2f 60%, #211227e0 100%)'
     }
 
-    case GRADIENT_WALLPAPER_NAME.GREEN: {
+    case GRADIENT_WALLPAPER_NAME.STONE_GREEN: {
       return 'linear-gradient(64deg, #2b2b29 60%, #0e230fe0 100%)'
     }
 
-    case GRADIENT_WALLPAPER_NAME.ORANGE: {
+    case GRADIENT_WALLPAPER_NAME.AMBER_ROSE: {
       return 'linear-gradient(64deg, #2f2f2f 60%, #271512e0 100%)'
     }
 
-    case GRADIENT_WALLPAPER_NAME.BLUE:
-    case GRADIENT_WALLPAPER_NAME.PURPLE: {
+    case GRADIENT_WALLPAPER_NAME.SKY_MAUVE_BLUE:
+    case GRADIENT_WALLPAPER_NAME.TEAL_INDIGO_MAUVE: {
       return 'linear-gradient(64deg, #2f2f2f 20%, #0c1d2ee0 100%)'
-    }
-
-    case GRADIENT_WALLPAPER_NAME.GREY: {
-      return 'linear-gradient(64deg, #2f2f2f 60%, #272524e0 100%)'
     }
 
     default: {


### PR DESCRIPTION
## Summary

- split wallpaper gradient color palettes from renderer/effect recipe defaults
- renamed gradient presets to color-only Tailwind-style palette names
- added 14 screenshot-inspired color palettes and updated gradient swatch previews to use palette data only

## Validation

- lint-staged tsc-files hook passed during commit
- oxfmt passed
- vitest target suite passed: 5 files / 29 tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated gradient color palettes from effect defaults and rebuilt recipes from palettes. Renamed presets to Tailwind-style color names; swatch previews now use palette-only backgrounds and include accessible labels; added new palettes.

- **Refactors**
  - Introduced `GRADIENT_PALETTE`, `TGradientPalette`, and `buildGradientCatalogPalettes()`; recipes are built via `GRADIENT_EFFECT_INIT`.
  - Updated `applyGradientPalette` to keep renderer/angle/spread while swapping colors via `palette.key`.
  - Exposed `gradientPalettes` in `useFullWallpaper` (`getGradientPalettes()`) and in `TWallpaperData`; `GradientTab` and swatches consume palettes only.
  - Changed default/fallback from `pink` to `amber_mauve`; updated names across logic and tests; removed preset-specific UI cases.

- **Migration**
  - Update legacy sources (`pink`, `green`, etc.) to new keys (e.g., `amber_mauve`, `stone_green`, `sky_mauve_blue`).
  - Use `getGradientPalettes()` for catalog UIs; swatches take `TGradientPalette` (no angle/spread).

<sup>Written for commit 31f4bff05cf92fc3ea087b6e9ccfd6e7bee50041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/groupher/groupher/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced gradient palette metadata system for enhanced wallpaper customization options.

* **Bug Fixes / Improvements**
  * Updated default gradient wallpaper appearance.
  * Refreshed available gradient wallpaper color schemes with new visual options.
  * Enhanced gradient preview rendering in wallpaper selection interface.

* **Style**
  * Updated gradient color styling across UI components and browser themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->