### PR TITLE
feat(cms): add community asset library

### DIFF
--- a/backend/main/lib/groupher_server/cms/articles/write.ex
+++ b/backend/main/lib/groupher_server/cms/articles/write.ex
@@ -20,7 +20,7 @@ defmodule GroupherServer.CMS.Articles.Write do
   alias CMS.Articles.{Document, States}
   alias CMS.Communities.TagStats
   alias CMS.Model.{Author, Community, Embeds}
-  alias CMS.{Communities, Covers, Events, FrontDesk}
+  alias CMS.{Assets, Communities, Covers, Events, FrontDesk}
   alias Helper.{Constant, ContentPipeline, Multi, Later, ORM, T, Transaction}
 
   @default_emotions Embeds.ArticleEmotion.default_emotions()
@@ -43,6 +43,9 @@ defmodule GroupherServer.CMS.Articles.Write do
         end)
         |> Multi.run(:upsert_cover, fn _, %{create_article: article} ->
           Covers.upsert_article_cover(article, attrs)
+        end)
+        |> Multi.run(:sync_asset_refs, fn _, %{upsert_cover: article} ->
+          Assets.sync_article_refs(community, article, attrs)
         end)
         |> Multi.run(:mirror_article, fn _, %{upsert_cover: article} ->
           States.mirror(community, article)
@@ -119,6 +122,9 @@ defmodule GroupherServer.CMS.Articles.Write do
       end)
       |> Multi.run(:upsert_cover, fn _, %{update_article: update_article} ->
         Covers.upsert_article_cover(update_article, attrs)
+      end)
+      |> Multi.run(:sync_asset_refs, fn _, %{upsert_cover: article} ->
+        Assets.sync_article_refs(article, attrs)
       end)
       |> Multi.run(:set_community_tags, fn _, %{upsert_cover: article} ->
         Communities.overwrite_tags(
@@ -247,8 +253,10 @@ defmodule GroupherServer.CMS.Articles.Write do
       Accounts.Publish.update_states(article.author.user, thread)
     end)
     |> Multi.run(:delete_document, fn _, _ ->
-      Document.remove(thread, article.id)
-      {:ok, :pass}
+      with {:ok, _} <- Assets.purge_article_refs(thread, article.id) do
+        Document.remove(thread, article.id)
+        {:ok, :pass}
+      end
     end)
     |> Multi.run(:delete_cover, fn _, _ ->
       Covers.delete_cover_edit_info(article.cover_edit_info_id)
@@ -426,6 +434,8 @@ defmodule GroupherServer.CMS.Articles.Write do
   defp result({:error, :mirror_article, _result, _steps}) do
     {:error, {:create_fails, "set community"}}
   end
+
+  defp result({:error, :sync_asset_refs, result, _steps}), do: {:error, result}
 
   defp result({:error, :set_community_flag, _result, _steps}) do
     {:error, {:create_fails, "set community flag"}}

--- a/backend/main/lib/groupher_server/cms/assets.ex
+++ b/backend/main/lib/groupher_server/cms/assets.ex
@@ -17,37 +17,145 @@ defmodule GroupherServer.CMS.Assets do
   """
 
   alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.Community
+  alias GroupherServer.CMS.Model.{Community, CommunityAsset}
   alias Helper.T
 
   alias __MODULE__.{Read, Write}
 
+  @doc """
+  Lists active assets owned by a community.
+
+  The returned page only includes active, non-deleted rows. Storage usage is not
+  derived from article refs; assets remain billable while active even when no
+  article currently uses them.
+
+  ## Examples
+
+      CMS.Assets.page(community, %{page: 1, size: 20})
+      #=> {:ok, %{entries: assets, total_count: total_count}}
+
+  """
   @spec page(Community.t(), map() | nil) :: T.domain_res(T.paged_data())
   def page(%Community{} = community, filter \\ nil), do: Read.page(community, filter)
 
+  @doc """
+  Returns storage usage for active assets in one community.
+
+  `storage_bytes` is the sum of `community_assets.size_bytes`; repeated article
+  references do not multiply the stored bytes.
+
+  ## Examples
+
+      CMS.Assets.usage(community)
+      #=> {:ok, %{asset_count: 3, storage_bytes: 8192}}
+
+  """
   @spec usage(Community.t()) :: T.domain_res(map())
   def usage(%Community{} = community), do: Read.usage(community)
 
+  @doc """
+  Lists article document refs for one community asset.
+
+  This is the paged lookup used by the asset-library detail view. The asset must
+  belong to the given community and must still be active.
+
+  ## Examples
+
+      CMS.Assets.refs(community, asset.id, %{page: 1, size: 20})
+      #=> {:ok, %{entries: refs, total_count: total_count}}
+
+  """
   @spec refs(Community.t(), T.id(), map() | nil) :: T.domain_res(T.paged_data())
   def refs(%Community{} = community, asset_id, filter \\ nil),
     do: Read.refs(community, asset_id, filter)
 
+  @doc """
+  Registers an uploaded object as a community asset.
+
+  The write path deduplicates active assets by URL hash, or by storage identity
+  when `storage` and `storage_key` are present. Existing active rows are updated
+  with the latest metadata instead of inserting duplicates.
+
+  ## Examples
+
+      CMS.Assets.register(community, %{url: url, size_bytes: 1024}, user)
+      #=> {:ok, %CommunityAsset{}}
+
+  """
   @spec register(Community.t(), map(), User.t() | nil) :: T.domain_res(CommunityAsset.t())
   def register(%Community{} = community, attrs, user \\ nil) do
     Write.register(community, attrs, user)
   end
 
+  @doc """
+  Soft-deletes an unreferenced community asset.
+
+  The asset row is locked before checking refs so a concurrent ref sync cannot
+  race with deletion. Referenced assets return an explicit domain error.
+
+  ## Examples
+
+      CMS.Assets.delete(community, asset.id)
+      #=> {:ok, %CommunityAsset{status: :deleted}}
+
+      CMS.Assets.delete(community, referenced_asset.id)
+      #=> {:error, {:custom, "asset is still referenced"}}
+
+  """
   @spec delete(Community.t(), T.id()) :: T.domain_res(CommunityAsset.t())
   def delete(%Community{} = community, asset_id), do: Write.delete(community, asset_id)
 
+  @doc """
+  Replaces article document refs using an explicit community.
+
+  Use this when the caller already resolved the community boundary, such as the
+  GraphQL article mutation path. The article document row is locked while refs
+  are replaced.
+
+  ## Examples
+
+      CMS.Assets.sync_article_refs(community, post, %{
+        asset_refs: [%{asset_id: asset.id, block_id: "hero"}],
+        cur_user: user
+      })
+      #=> {:ok, %{body: body_refs, cover: cover_refs}}
+
+  """
   @spec sync_article_refs(Community.t(), T.article(), map()) :: T.domain_res(term())
   def sync_article_refs(%Community{} = community, article, attrs) do
     Write.sync_article_refs(community, article, attrs)
   end
 
+  @doc """
+  Replaces article document refs using `article.community_id`.
+
+  This variant is used from article flows where the article already carries its
+  community foreign key. If the article has no community, the sync is skipped.
+
+  ## Examples
+
+      CMS.Assets.sync_article_refs(post, %{asset_refs: [%{asset_id: asset.id}]})
+      #=> {:ok, %{body: body_refs, cover: cover_refs}}
+
+      CMS.Assets.sync_article_refs(article_without_community, %{})
+      #=> {:ok, :pass}
+
+  """
   @spec sync_article_refs(T.article(), map()) :: T.domain_res(term())
   def sync_article_refs(article, attrs), do: Write.sync_article_refs(article, attrs)
 
+  @doc """
+  Deletes all persisted asset refs for one article.
+
+  This is called from article deletion so the resource library keeps ownership
+  data in `community_assets` while removing stale document usage rows.
+
+  ## Examples
+
+      CMS.Assets.purge_article_refs(:post, post.id)
+      #=> {:ok, {deleted_count, nil}}
+
+  """
   @spec purge_article_refs(atom(), T.id()) :: T.domain_res(term())
   def purge_article_refs(thread, article_id), do: Write.purge_article_refs(thread, article_id)
 end

--- a/backend/main/lib/groupher_server/cms/assets.ex
+++ b/backend/main/lib/groupher_server/cms/assets.ex
@@ -1,0 +1,52 @@
+defmodule GroupherServer.CMS.Assets do
+  @moduledoc """
+  Public facade for community assets and article document asset references.
+
+  Assets have two separate responsibilities:
+
+      community_assets
+        - one row per uploaded/community-owned resource
+        - owns storage metadata and billing bytes
+
+      article_document_asset_refs
+        - many rows per article document
+        - records where an asset is used: inline block, cover, attachment
+
+  This split keeps billing independent from article usage. A community asset is
+  counted once while it is active, even if no article references it.
+  """
+
+  alias GroupherServer.Accounts.Model.User
+  alias GroupherServer.CMS.Model.{Community, CommunityAsset}
+  alias Helper.T
+
+  alias __MODULE__.{Read, Write}
+
+  @spec page(Community.t(), map() | nil) :: T.domain_res(T.paged_data())
+  def page(%Community{} = community, filter \\ nil), do: Read.page(community, filter)
+
+  @spec usage(Community.t()) :: T.domain_res(map())
+  def usage(%Community{} = community), do: Read.usage(community)
+
+  @spec refs(CommunityAsset.t()) :: T.domain_res(list())
+  def refs(%CommunityAsset{} = asset), do: Read.refs(asset)
+
+  @spec register(Community.t(), map(), User.t() | nil) :: T.domain_res(CommunityAsset.t())
+  def register(%Community{} = community, attrs, user \\ nil) do
+    Write.register(community, attrs, user)
+  end
+
+  @spec delete(Community.t(), T.id()) :: T.domain_res(CommunityAsset.t())
+  def delete(%Community{} = community, asset_id), do: Write.delete(community, asset_id)
+
+  @spec sync_article_refs(Community.t(), T.article(), map()) :: T.domain_res(term())
+  def sync_article_refs(%Community{} = community, article, attrs) do
+    Write.sync_article_refs(community, article, attrs)
+  end
+
+  @spec sync_article_refs(T.article(), map()) :: T.domain_res(term())
+  def sync_article_refs(article, attrs), do: Write.sync_article_refs(article, attrs)
+
+  @spec purge_article_refs(atom(), T.id()) :: T.domain_res(term())
+  def purge_article_refs(thread, article_id), do: Write.purge_article_refs(thread, article_id)
+end

--- a/backend/main/lib/groupher_server/cms/assets.ex
+++ b/backend/main/lib/groupher_server/cms/assets.ex
@@ -17,7 +17,7 @@ defmodule GroupherServer.CMS.Assets do
   """
 
   alias GroupherServer.Accounts.Model.User
-  alias GroupherServer.CMS.Model.{Community, CommunityAsset}
+  alias GroupherServer.CMS.Model.Community
   alias Helper.T
 
   alias __MODULE__.{Read, Write}
@@ -28,8 +28,9 @@ defmodule GroupherServer.CMS.Assets do
   @spec usage(Community.t()) :: T.domain_res(map())
   def usage(%Community{} = community), do: Read.usage(community)
 
-  @spec refs(CommunityAsset.t()) :: T.domain_res(list())
-  def refs(%CommunityAsset{} = asset), do: Read.refs(asset)
+  @spec refs(Community.t(), T.id(), map() | nil) :: T.domain_res(T.paged_data())
+  def refs(%Community{} = community, asset_id, filter \\ nil),
+    do: Read.refs(community, asset_id, filter)
 
   @spec register(Community.t(), map(), User.t() | nil) :: T.domain_res(CommunityAsset.t())
   def register(%Community{} = community, attrs, user \\ nil) do

--- a/backend/main/lib/groupher_server/cms/assets/read.ex
+++ b/backend/main/lib/groupher_server/cms/assets/read.ex
@@ -14,6 +14,7 @@ defmodule GroupherServer.CMS.Assets.Read do
 
   @default_page 1
   @default_size 20
+  @refs_limit 100
 
   @spec page(Community.t(), map() | nil) :: T.domain_res(T.paged_data())
   def page(%Community{id: community_id}, filter) do
@@ -49,6 +50,7 @@ defmodule GroupherServer.CMS.Assets.Read do
     ArticleDocumentAssetRef
     |> where([ref], ref.asset_id == ^asset_id)
     |> order_by([ref], desc: ref.inserted_at, desc: ref.id)
+    |> limit(^@refs_limit)
     |> Repo.all()
     |> then(&{:ok, &1})
   end

--- a/backend/main/lib/groupher_server/cms/assets/read.ex
+++ b/backend/main/lib/groupher_server/cms/assets/read.ex
@@ -15,26 +15,46 @@ defmodule GroupherServer.CMS.Assets.Read do
   @default_page 1
   @default_size 20
 
+  @doc """
+  Returns a page of active assets for a community.
+
+  This read-side function is the implementation behind `CMS.Assets.page/2`.
+  It applies the shared active-asset predicate and orders newest assets first.
+
+  ## Examples
+
+      Read.page(community, %{page: 1, size: 20})
+      #=> {:ok, %{entries: assets, total_count: total_count}}
+
+  """
   @spec page(Community.t(), map() | nil) :: T.domain_res(T.paged_data())
   def page(%Community{id: community_id}, filter) do
     %{page: page, size: size} = normalize_filter(filter)
 
-    CommunityAsset
-    |> where([asset], asset.community_id == ^community_id)
-    |> where([asset], is_nil(asset.deleted_at))
-    |> where([asset], asset.status == :active)
+    community_id
+    |> CommunityAsset.active_query()
     |> order_by([asset], desc: asset.inserted_at, desc: asset.id)
     |> ORM.paginator(page: page, size: size)
     |> then(&{:ok, &1})
   end
 
+  @doc """
+  Returns active asset counts and storage bytes for one community.
+
+  Usage is computed from `community_assets`, not from refs, so the same uploaded
+  object is counted once regardless of how many articles reference it.
+
+  ## Examples
+
+      Read.usage(community)
+      #=> {:ok, %{asset_count: 2, storage_bytes: 4096}}
+
+  """
   @spec usage(Community.t()) :: T.domain_res(map())
   def usage(%Community{id: community_id}) do
     result =
-      CommunityAsset
-      |> where([asset], asset.community_id == ^community_id)
-      |> where([asset], is_nil(asset.deleted_at))
-      |> where([asset], asset.status == :active)
+      community_id
+      |> CommunityAsset.active_query()
       |> select([asset], %{
         asset_count: count(asset.id),
         storage_bytes: coalesce(sum(asset.size_bytes), 0)
@@ -44,6 +64,18 @@ defmodule GroupherServer.CMS.Assets.Read do
     {:ok, normalize_usage_result(result)}
   end
 
+  @doc """
+  Returns a page of article document refs for one active asset.
+
+  The asset lookup is scoped to the supplied community before refs are loaded,
+  which prevents cross-community ref discovery.
+
+  ## Examples
+
+      Read.refs(community, asset.id, %{page: 1, size: 10})
+      #=> {:ok, %{entries: refs, page_number: 1}}
+
+  """
   @spec refs(Community.t(), T.id(), map() | nil) :: T.domain_res(T.paged_data())
   def refs(%Community{id: community_id}, asset_id, filter) do
     %{page: page, size: size} = normalize_filter(filter)
@@ -75,11 +107,8 @@ defmodule GroupherServer.CMS.Assets.Read do
   defp normalize_usage_result(result), do: result
 
   defp find_active_asset(community_id, asset_id) do
-    CommunityAsset
-    |> where([asset], asset.id == ^asset_id)
-    |> where([asset], asset.community_id == ^community_id)
-    |> where([asset], is_nil(asset.deleted_at))
-    |> where([asset], asset.status == :active)
+    community_id
+    |> CommunityAsset.active_query(asset_id)
     |> Repo.one()
     |> case do
       nil -> {:error, {:not_exist, "asset not found"}}

--- a/backend/main/lib/groupher_server/cms/assets/read.ex
+++ b/backend/main/lib/groupher_server/cms/assets/read.ex
@@ -1,0 +1,72 @@
+defmodule GroupherServer.CMS.Assets.Read do
+  @moduledoc """
+  Read-side helpers for the community asset library.
+
+  Billing-oriented reads only look at active rows in `community_assets`. Usage
+  reads go through `article_document_asset_refs`.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias GroupherServer.{CMS, Repo}
+  alias CMS.Model.{ArticleDocumentAssetRef, Community, CommunityAsset}
+  alias Helper.{ORM, T}
+
+  @default_page 1
+  @default_size 20
+
+  @spec page(Community.t(), map() | nil) :: T.domain_res(T.paged_data())
+  def page(%Community{id: community_id}, filter) do
+    %{page: page, size: size} = normalize_filter(filter)
+
+    CommunityAsset
+    |> where([asset], asset.community_id == ^community_id)
+    |> where([asset], is_nil(asset.deleted_at))
+    |> where([asset], asset.status == :active)
+    |> order_by([asset], desc: asset.inserted_at, desc: asset.id)
+    |> ORM.paginator(page: page, size: size)
+    |> then(&{:ok, &1})
+  end
+
+  @spec usage(Community.t()) :: T.domain_res(map())
+  def usage(%Community{id: community_id}) do
+    result =
+      CommunityAsset
+      |> where([asset], asset.community_id == ^community_id)
+      |> where([asset], is_nil(asset.deleted_at))
+      |> where([asset], asset.status == :active)
+      |> select([asset], %{
+        asset_count: count(asset.id),
+        storage_bytes: coalesce(sum(asset.size_bytes), 0)
+      })
+      |> Repo.one()
+
+    {:ok, normalize_usage_result(result)}
+  end
+
+  @spec refs(CommunityAsset.t()) :: T.domain_res(list(ArticleDocumentAssetRef.t()))
+  def refs(%CommunityAsset{id: asset_id}) do
+    ArticleDocumentAssetRef
+    |> where([ref], ref.asset_id == ^asset_id)
+    |> order_by([ref], desc: ref.inserted_at, desc: ref.id)
+    |> Repo.all()
+    |> then(&{:ok, &1})
+  end
+
+  defp normalize_filter(nil), do: %{page: @default_page, size: @default_size}
+
+  defp normalize_filter(filter) do
+    %{
+      page: Map.get(filter, :page, @default_page),
+      size: Map.get(filter, :size, @default_size)
+    }
+  end
+
+  defp normalize_usage_result(nil), do: %{asset_count: 0, storage_bytes: 0}
+
+  defp normalize_usage_result(%{storage_bytes: %Decimal{} = bytes} = result) do
+    %{result | storage_bytes: Decimal.to_integer(bytes)}
+  end
+
+  defp normalize_usage_result(result), do: result
+end

--- a/backend/main/lib/groupher_server/cms/assets/read.ex
+++ b/backend/main/lib/groupher_server/cms/assets/read.ex
@@ -14,7 +14,6 @@ defmodule GroupherServer.CMS.Assets.Read do
 
   @default_page 1
   @default_size 20
-  @refs_limit 100
 
   @spec page(Community.t(), map() | nil) :: T.domain_res(T.paged_data())
   def page(%Community{id: community_id}, filter) do
@@ -45,14 +44,17 @@ defmodule GroupherServer.CMS.Assets.Read do
     {:ok, normalize_usage_result(result)}
   end
 
-  @spec refs(CommunityAsset.t()) :: T.domain_res(list(ArticleDocumentAssetRef.t()))
-  def refs(%CommunityAsset{id: asset_id}) do
-    ArticleDocumentAssetRef
-    |> where([ref], ref.asset_id == ^asset_id)
-    |> order_by([ref], desc: ref.inserted_at, desc: ref.id)
-    |> limit(^@refs_limit)
-    |> Repo.all()
-    |> then(&{:ok, &1})
+  @spec refs(Community.t(), T.id(), map() | nil) :: T.domain_res(T.paged_data())
+  def refs(%Community{id: community_id}, asset_id, filter) do
+    %{page: page, size: size} = normalize_filter(filter)
+
+    with {:ok, %CommunityAsset{id: asset_id}} <- find_active_asset(community_id, asset_id) do
+      ArticleDocumentAssetRef
+      |> where([ref], ref.community_id == ^community_id and ref.asset_id == ^asset_id)
+      |> order_by([ref], desc: ref.inserted_at, desc: ref.id)
+      |> ORM.paginator(page: page, size: size)
+      |> then(&{:ok, &1})
+    end
   end
 
   defp normalize_filter(nil), do: %{page: @default_page, size: @default_size}
@@ -71,4 +73,17 @@ defmodule GroupherServer.CMS.Assets.Read do
   end
 
   defp normalize_usage_result(result), do: result
+
+  defp find_active_asset(community_id, asset_id) do
+    CommunityAsset
+    |> where([asset], asset.id == ^asset_id)
+    |> where([asset], asset.community_id == ^community_id)
+    |> where([asset], is_nil(asset.deleted_at))
+    |> where([asset], asset.status == :active)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, {:not_exist, "asset not found"}}
+      asset -> {:ok, asset}
+    end
+  end
 end

--- a/backend/main/lib/groupher_server/cms/assets/write.ex
+++ b/backend/main/lib/groupher_server/cms/assets/write.ex
@@ -1,0 +1,387 @@
+defmodule GroupherServer.CMS.Assets.Write do
+  @moduledoc """
+  Write-side helpers for community assets and article refs.
+
+  The write flow mirrors the storage model:
+
+      upload service  ->  community_assets
+                         /        |
+      article cover --'         billing/counting
+      editor block ---->  article_document_asset_refs
+
+  The upload service owns bytes in object storage. This module records the
+  uploaded object's URL/size and projects article usage into queryable rows.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias GroupherServer.{CMS, Repo}
+  alias GroupherServer.Accounts.Model.User
+  alias CMS.FrontDesk
+  alias CMS.Model.{ArticleDocument, ArticleDocumentAssetRef, Community, CommunityAsset}
+  alias Helper.{ORM, T}
+
+  @body_usages ~w(inline attachment embed)a
+  @cover_specs [
+    %{usage: :cover, asset_key: :cover_asset, asset_id_key: :cover_asset_id},
+    %{usage: :cover_dark, asset_key: :cover_asset_dark, asset_id_key: :cover_asset_dark_id}
+  ]
+  @all_usages ArticleDocumentAssetRef.usage_values()
+  @asset_url_conflict_target {:unsafe_fragment,
+                              "(community_id, url_hash) WHERE deleted_at IS NULL"}
+  @asset_storage_conflict_target {:unsafe_fragment,
+                                  "(community_id, storage, storage_key) WHERE storage_key IS NOT NULL AND deleted_at IS NULL"}
+
+  @spec register(Community.t(), map(), User.t() | nil) :: T.domain_res(CommunityAsset.t())
+  def register(%Community{id: community_id}, attrs, user \\ nil) when is_map(attrs) do
+    attrs =
+      attrs
+      |> Map.put(:community_id, community_id)
+      |> put_uploader(user)
+      |> put_default_status()
+      |> put_default_asset_type()
+
+    upsert_active_asset(attrs)
+  end
+
+  @spec delete(Community.t(), T.id()) :: T.domain_res(CommunityAsset.t())
+  def delete(%Community{id: community_id}, asset_id) do
+    with {:ok, asset} <- find_active_asset(community_id, asset_id),
+         false <- referenced?(asset) do
+      ORM.update(asset, %{
+        status: :deleted,
+        deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+    else
+      true -> {:error, {:custom, "asset is still referenced"}}
+      {:error, _} = error -> error
+    end
+  end
+
+  @spec sync_article_refs(Community.t(), T.article(), map()) :: T.domain_res(term())
+  def sync_article_refs(%Community{id: community_id}, article, attrs) do
+    do_sync_article_refs(community_id, article, attrs)
+  end
+
+  @spec sync_article_refs(T.article(), map()) :: T.domain_res(term())
+  def sync_article_refs(article, attrs) do
+    case Map.get(article, :community_id) do
+      nil -> {:ok, :pass}
+      community_id -> do_sync_article_refs(community_id, article, attrs)
+    end
+  end
+
+  @spec purge_article_refs(atom(), T.id()) :: T.domain_res(term())
+  def purge_article_refs(thread, article_id) do
+    ArticleDocumentAssetRef
+    |> where([ref], ref.thread == ^thread and ref.article_id == ^article_id)
+    |> Repo.delete_all()
+    |> then(&{:ok, &1})
+  end
+
+  defp do_sync_article_refs(community_id, article, attrs) do
+    case sync_requested?(attrs) do
+      false ->
+        {:ok, :pass}
+
+      true ->
+        Repo.transaction(fn ->
+          with {:ok, thread} <- FrontDesk.thread_of(article),
+               {:ok, document} <- find_article_document(thread, article.id),
+               base <- base_ref_attrs(community_id, document, thread, article.id),
+               user <- get_attr(attrs, :cur_user),
+               {:ok, body_refs} <- sync_body_refs(document, base, attrs, user),
+               {:ok, cover_refs} <- sync_cover_refs(document, base, attrs, user) do
+            %{body: body_refs, cover: cover_refs}
+          else
+            {:error, reason} -> Repo.rollback(reason)
+          end
+        end)
+    end
+  end
+
+  defp sync_requested?(attrs) when is_map(attrs) do
+    has_attr?(attrs, :asset_refs) or has_attr?(attrs, :cover_asset) or
+      has_attr?(attrs, :cover_asset_id) or has_attr?(attrs, :cover_asset_dark) or
+      has_attr?(attrs, :cover_asset_dark_id) or removed_cover?(attrs)
+  end
+
+  defp sync_requested?(_), do: false
+
+  defp removed_cover?(attrs),
+    do: has_attr?(attrs, :cover_edit_info) and is_nil(get_attr(attrs, :cover_edit_info))
+
+  defp sync_body_refs(document, base, attrs, user) do
+    case has_attr?(attrs, :asset_refs) do
+      false ->
+        {:ok, []}
+
+      true ->
+        inputs = get_attr(attrs, :asset_refs) || []
+
+        with {:ok, usages} <- replace_usages_for_inputs(inputs) do
+          replace_refs(document, usages, inputs, base, user)
+        end
+    end
+  end
+
+  defp sync_cover_refs(document, base, attrs, user) do
+    attrs
+    |> cover_ref_specs()
+    |> Enum.reduce_while({:ok, []}, fn {usage, inputs}, {:ok, acc} ->
+      case replace_refs(document, [usage], inputs, base, user) do
+        {:ok, refs} -> {:cont, {:ok, acc ++ refs}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp cover_ref_specs(attrs) do
+    cond do
+      removed_cover?(attrs) ->
+        Enum.map(@cover_specs, &{&1.usage, []})
+
+      true ->
+        @cover_specs
+        |> Enum.flat_map(fn spec ->
+          if has_attr?(attrs, spec.asset_key) or has_attr?(attrs, spec.asset_id_key) do
+            case cover_ref_input(attrs, spec) do
+              nil -> [{spec.usage, []}]
+              input -> [{spec.usage, [input]}]
+            end
+          else
+            []
+          end
+        end)
+    end
+  end
+
+  defp cover_ref_input(attrs, spec) do
+    asset = get_attr(attrs, spec.asset_key)
+    asset_id = get_attr(attrs, spec.asset_id_key)
+
+    if is_nil(asset) and is_nil(asset_id) do
+      nil
+    else
+      %{
+        asset: asset,
+        asset_id: asset_id,
+        usage: spec.usage,
+        source: "cover"
+      }
+    end
+  end
+
+  defp replace_refs(%ArticleDocument{id: document_id}, usages, inputs, base, user) do
+    ArticleDocumentAssetRef
+    |> where([ref], ref.article_document_id == ^document_id and ref.usage in ^usages)
+    |> Repo.delete_all()
+
+    inputs
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {input, index}, {:ok, acc} ->
+      case create_ref(input, index, base, user) do
+        {:ok, ref} -> {:cont, {:ok, acc ++ [ref]}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp replace_usages_for_inputs([]), do: {:ok, @body_usages}
+
+  defp replace_usages_for_inputs(inputs) do
+    inputs
+    |> Enum.reduce_while({:ok, MapSet.new(@body_usages)}, fn input, {:ok, usage_set} ->
+      case normalize_usage(get_attr(input, :usage)) do
+        {:ok, usage} -> {:cont, {:ok, MapSet.put(usage_set, usage)}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, usage_set} -> {:ok, MapSet.to_list(usage_set)}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp create_ref(input, index, %{community_id: community_id} = base, user) when is_map(input) do
+    with {:ok, usage} <- normalize_usage(get_attr(input, :usage)),
+         {:ok, asset} <- resolve_asset(community_id, input, user) do
+      attrs =
+        base
+        |> Map.merge(%{
+          asset_id: asset.id,
+          usage: usage,
+          block_id: get_attr(input, :block_id),
+          block_type: get_attr(input, :block_type),
+          position: get_attr(input, :position) || index,
+          title: get_attr(input, :title),
+          alt: get_attr(input, :alt),
+          source: get_attr(input, :source),
+          meta: get_attr(input, :meta) || %{}
+        })
+
+      ORM.create(ArticleDocumentAssetRef, attrs)
+    end
+  end
+
+  defp create_ref(_, _, _, _), do: {:error, {:custom, "asset ref is invalid"}}
+
+  defp resolve_asset(community_id, input, user) do
+    asset_id = get_attr(input, :asset_id)
+    asset_attrs = get_attr(input, :asset)
+
+    cond do
+      not is_nil(asset_id) ->
+        find_active_asset(community_id, asset_id)
+
+      is_map(asset_attrs) ->
+        register(%Community{id: community_id}, asset_attrs, user)
+
+      true ->
+        {:error, {:custom, "asset is required"}}
+    end
+  end
+
+  defp find_active_asset(community_id, asset_id) do
+    CommunityAsset
+    |> where([asset], asset.id == ^asset_id)
+    |> where([asset], asset.community_id == ^community_id)
+    |> where([asset], is_nil(asset.deleted_at))
+    |> where([asset], asset.status == :active)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, {:not_exist, "asset not found"}}
+      asset -> {:ok, asset}
+    end
+  end
+
+  defp upsert_active_asset(attrs) do
+    attrs
+    |> upsert_identity()
+    |> then(&insert_active_asset(attrs, &1))
+    |> case do
+      {:ok, asset} -> {:ok, asset}
+      {:error, %Ecto.Changeset{} = changeset} -> retry_active_asset_upsert(attrs, changeset)
+    end
+  end
+
+  defp insert_active_asset(attrs, identity) do
+    changeset = CommunityAsset.changeset(%CommunityAsset{}, attrs)
+
+    set_fields =
+      changeset.changes
+      |> Map.drop(conflict_fields(identity))
+      |> Map.put(:updated_at, DateTime.utc_now(:second))
+      |> Enum.to_list()
+
+    Repo.insert(changeset,
+      on_conflict: [set: set_fields],
+      conflict_target: conflict_target(identity),
+      mode: :savepoint,
+      returning: true
+    )
+  end
+
+  defp retry_active_asset_upsert(attrs, changeset) do
+    cond do
+      unique_constraint_error?(changeset, :community_assets_community_url_hash_index) ->
+        insert_active_asset(attrs, :url_hash)
+
+      storage_identity?(attrs) and
+          unique_constraint_error?(changeset, :community_assets_community_storage_key_index) ->
+        insert_active_asset(attrs, :storage_key)
+
+      true ->
+        {:error, changeset}
+    end
+  end
+
+  defp upsert_identity(attrs) do
+    if storage_identity?(attrs), do: :storage_key, else: :url_hash
+  end
+
+  defp storage_identity?(attrs) do
+    is_binary(get_attr(attrs, :storage)) and is_binary(get_attr(attrs, :storage_key))
+  end
+
+  defp conflict_target(:storage_key), do: @asset_storage_conflict_target
+  defp conflict_target(:url_hash), do: @asset_url_conflict_target
+
+  defp conflict_fields(:storage_key), do: [:community_id, :storage, :storage_key]
+  defp conflict_fields(:url_hash), do: [:community_id, :url_hash]
+
+  defp unique_constraint_error?(%Ecto.Changeset{errors: errors}, constraint_name) do
+    constraint_name = to_string(constraint_name)
+
+    Enum.any?(errors, fn {_field, {_message, opts}} ->
+      opts[:constraint] == :unique and opts[:constraint_name] == constraint_name
+    end)
+  end
+
+  defp referenced?(%CommunityAsset{id: asset_id}) do
+    ArticleDocumentAssetRef
+    |> where([ref], ref.asset_id == ^asset_id)
+    |> Repo.exists?()
+  end
+
+  defp find_article_document(thread, article_id) do
+    ORM.find_by(ArticleDocument, thread: thread, article_id: article_id)
+  end
+
+  defp base_ref_attrs(community_id, %ArticleDocument{id: document_id}, thread, article_id) do
+    %{
+      community_id: community_id,
+      article_document_id: document_id,
+      thread: thread,
+      article_id: article_id
+    }
+  end
+
+  defp put_uploader(attrs, %User{id: user_id}), do: Map.put(attrs, :uploader_id, user_id)
+  defp put_uploader(attrs, _), do: attrs
+
+  defp put_default_status(attrs) do
+    case has_attr?(attrs, :status) do
+      true -> attrs
+      false -> Map.put(attrs, :status, :active)
+    end
+  end
+
+  defp put_default_asset_type(attrs) do
+    case has_attr?(attrs, :asset_type) do
+      true -> attrs
+      false -> Map.put(attrs, :asset_type, guessed_asset_type(get_attr(attrs, :mime_type)))
+    end
+  end
+
+  defp guessed_asset_type("image/" <> _), do: :image
+  defp guessed_asset_type("video/" <> _), do: :video
+  defp guessed_asset_type("audio/" <> _), do: :audio
+  defp guessed_asset_type(_), do: :file
+
+  defp normalize_usage(nil), do: {:ok, :inline}
+  defp normalize_usage(usage) when usage in @all_usages, do: {:ok, usage}
+
+  defp normalize_usage(usage) when is_binary(usage) do
+    @all_usages
+    |> Enum.find(&(to_string(&1) == usage))
+    |> case do
+      nil -> {:error, {:custom, "asset usage is invalid"}}
+      usage -> {:ok, usage}
+    end
+  end
+
+  defp normalize_usage(_), do: {:error, {:custom, "asset usage is invalid"}}
+
+  defp has_attr?(map, key) when is_map(map),
+    do: Map.has_key?(map, key) or Map.has_key?(map, Atom.to_string(key))
+
+  defp get_attr(map, key) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
+  end
+
+  defp get_attr(_, _), do: nil
+end

--- a/backend/main/lib/groupher_server/cms/assets/write.ex
+++ b/backend/main/lib/groupher_server/cms/assets/write.ex
@@ -46,16 +46,20 @@ defmodule GroupherServer.CMS.Assets.Write do
 
   @spec delete(Community.t(), T.id()) :: T.domain_res(CommunityAsset.t())
   def delete(%Community{id: community_id}, asset_id) do
-    with {:ok, asset} <- find_active_asset(community_id, asset_id),
-         false <- referenced?(asset) do
-      ORM.update(asset, %{
-        status: :deleted,
-        deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
-      })
-    else
-      true -> {:error, {:custom, "asset is still referenced"}}
-      {:error, _} = error -> error
-    end
+    Repo.transaction(fn ->
+      with {:ok, asset} <- find_active_asset_for_update(community_id, asset_id),
+           false <- referenced?(asset),
+           {:ok, asset} <-
+             ORM.update(asset, %{
+               status: :deleted,
+               deleted_at: DateTime.utc_now(:second)
+             }) do
+        asset
+      else
+        true -> Repo.rollback({:custom, "asset is still referenced"})
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
   end
 
   @spec sync_article_refs(Community.t(), T.article(), map()) :: T.domain_res(term())
@@ -87,7 +91,7 @@ defmodule GroupherServer.CMS.Assets.Write do
       true ->
         Repo.transaction(fn ->
           with {:ok, thread} <- FrontDesk.thread_of(article),
-               {:ok, document} <- find_article_document(thread, article.id),
+               {:ok, document} <- find_article_document_for_update(thread, article.id),
                base <- base_ref_attrs(community_id, document, thread, article.id),
                user <- get_attr(attrs, :cur_user),
                {:ok, body_refs} <- sync_body_refs(document, base, attrs, user),
@@ -231,28 +235,39 @@ defmodule GroupherServer.CMS.Assets.Write do
     asset_attrs = get_attr(input, :asset)
 
     cond do
+      not is_nil(asset_id) and is_map(asset_attrs) ->
+        {:error, {:custom, "asset_id and asset are mutually exclusive"}}
+
       not is_nil(asset_id) ->
-        find_active_asset(community_id, asset_id)
+        find_active_asset_for_update(community_id, asset_id)
 
       is_map(asset_attrs) ->
-        register(%Community{id: community_id}, asset_attrs, user)
+        with {:ok, asset} <- register(%Community{id: community_id}, asset_attrs, user) do
+          find_active_asset_for_update(community_id, asset.id)
+        end
 
       true ->
         {:error, {:custom, "asset is required"}}
     end
   end
 
-  defp find_active_asset(community_id, asset_id) do
-    CommunityAsset
-    |> where([asset], asset.id == ^asset_id)
-    |> where([asset], asset.community_id == ^community_id)
-    |> where([asset], is_nil(asset.deleted_at))
-    |> where([asset], asset.status == :active)
+  defp find_active_asset_for_update(community_id, asset_id) do
+    community_id
+    |> active_asset_query(asset_id)
+    |> lock("FOR UPDATE")
     |> Repo.one()
     |> case do
       nil -> {:error, {:not_exist, "asset not found"}}
       asset -> {:ok, asset}
     end
+  end
+
+  defp active_asset_query(community_id, asset_id) do
+    CommunityAsset
+    |> where([asset], asset.id == ^asset_id)
+    |> where([asset], asset.community_id == ^community_id)
+    |> where([asset], is_nil(asset.deleted_at))
+    |> where([asset], asset.status == :active)
   end
 
   defp upsert_active_asset(attrs) do
@@ -324,8 +339,15 @@ defmodule GroupherServer.CMS.Assets.Write do
     |> Repo.exists?()
   end
 
-  defp find_article_document(thread, article_id) do
-    ORM.find_by(ArticleDocument, thread: thread, article_id: article_id)
+  defp find_article_document_for_update(thread, article_id) do
+    ArticleDocument
+    |> where([document], document.thread == ^thread and document.article_id == ^article_id)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
+    |> case do
+      nil -> {:error, {:not_exist, "article document not found"}}
+      document -> {:ok, document}
+    end
   end
 
   defp base_ref_attrs(community_id, %ArticleDocument{id: document_id}, thread, article_id) do

--- a/backend/main/lib/groupher_server/cms/assets/write.ex
+++ b/backend/main/lib/groupher_server/cms/assets/write.ex
@@ -32,6 +32,22 @@ defmodule GroupherServer.CMS.Assets.Write do
   @asset_storage_conflict_target {:unsafe_fragment,
                                   "(community_id, storage, storage_key) WHERE storage_key IS NOT NULL AND deleted_at IS NULL"}
 
+  @doc """
+  Creates or updates an active community asset row for uploaded metadata.
+
+  Active rows are deduplicated by URL hash, or by storage identity when both
+  `storage` and `storage_key` are present. The optional user is stored as the
+  uploader when available.
+
+  ## Examples
+
+      Write.register(community, %{url: url, size_bytes: 2048}, user)
+      #=> {:ok, %CommunityAsset{}}
+
+      Write.register(community, %{storage: "s3", storage_key: key, url: url, size_bytes: 2048})
+      #=> {:ok, %CommunityAsset{}}
+
+  """
   @spec register(Community.t(), map(), User.t() | nil) :: T.domain_res(CommunityAsset.t())
   def register(%Community{id: community_id}, attrs, user \\ nil) when is_map(attrs) do
     attrs =
@@ -44,6 +60,22 @@ defmodule GroupherServer.CMS.Assets.Write do
     upsert_active_asset(attrs)
   end
 
+  @doc """
+  Soft-deletes one active community asset when it has no refs.
+
+  The asset row is selected `FOR UPDATE` before the ref check. If any
+  `article_document_asset_refs` row still points to the asset, deletion is
+  rejected.
+
+  ## Examples
+
+      Write.delete(community, asset.id)
+      #=> {:ok, %CommunityAsset{status: :deleted}}
+
+      Write.delete(community, referenced_asset.id)
+      #=> {:error, {:custom, "asset is still referenced"}}
+
+  """
   @spec delete(Community.t(), T.id()) :: T.domain_res(CommunityAsset.t())
   def delete(%Community{id: community_id}, asset_id) do
     Repo.transaction(fn ->
@@ -62,11 +94,42 @@ defmodule GroupherServer.CMS.Assets.Write do
     end)
   end
 
+  @doc """
+  Synchronizes refs for an article using an explicit community boundary.
+
+  The article document row is locked while body and cover refs are replaced, so
+  concurrent syncs for the same article cannot interleave delete/insert steps.
+
+  ## Examples
+
+      Write.sync_article_refs(community, post, %{
+        asset_refs: [%{asset_id: asset.id, block_id: "image-1"}],
+        cover_asset_id: cover_asset.id,
+        cur_user: user
+      })
+      #=> {:ok, %{body: body_refs, cover: cover_refs}}
+
+  """
   @spec sync_article_refs(Community.t(), T.article(), map()) :: T.domain_res(term())
   def sync_article_refs(%Community{id: community_id}, article, attrs) do
     do_sync_article_refs(community_id, article, attrs)
   end
 
+  @doc """
+  Synchronizes refs for an article using `article.community_id`.
+
+  This variant keeps article create/update flows concise. If the article is not
+  associated with a community, the sync is a no-op.
+
+  ## Examples
+
+      Write.sync_article_refs(post, %{asset_refs: [%{asset_id: asset.id}]})
+      #=> {:ok, %{body: body_refs, cover: cover_refs}}
+
+      Write.sync_article_refs(%{post | community_id: nil}, %{asset_refs: []})
+      #=> {:ok, :pass}
+
+  """
   @spec sync_article_refs(T.article(), map()) :: T.domain_res(term())
   def sync_article_refs(article, attrs) do
     case Map.get(article, :community_id) do
@@ -75,6 +138,18 @@ defmodule GroupherServer.CMS.Assets.Write do
     end
   end
 
+  @doc """
+  Removes all article-document asset refs for an article.
+
+  The community asset rows remain intact; only usage projections are deleted.
+  This is used by article deletion cleanup.
+
+  ## Examples
+
+      Write.purge_article_refs(:post, post.id)
+      #=> {:ok, {deleted_count, nil}}
+
+  """
   @spec purge_article_refs(atom(), T.id()) :: T.domain_res(term())
   def purge_article_refs(thread, article_id) do
     ArticleDocumentAssetRef
@@ -253,21 +328,13 @@ defmodule GroupherServer.CMS.Assets.Write do
 
   defp find_active_asset_for_update(community_id, asset_id) do
     community_id
-    |> active_asset_query(asset_id)
+    |> CommunityAsset.active_query(asset_id)
     |> lock("FOR UPDATE")
     |> Repo.one()
     |> case do
       nil -> {:error, {:not_exist, "asset not found"}}
       asset -> {:ok, asset}
     end
-  end
-
-  defp active_asset_query(community_id, asset_id) do
-    CommunityAsset
-    |> where([asset], asset.id == ^asset_id)
-    |> where([asset], asset.community_id == ^community_id)
-    |> where([asset], is_nil(asset.deleted_at))
-    |> where([asset], asset.status == :active)
   end
 
   defp upsert_active_asset(attrs) do

--- a/backend/main/lib/groupher_server/cms/assets/write.ex
+++ b/backend/main/lib/groupher_server/cms/assets/write.ex
@@ -199,7 +199,7 @@ defmodule GroupherServer.CMS.Assets.Write do
         inputs = get_attr(attrs, :asset_refs) || []
 
         with {:ok, usages} <- replace_usages_for_inputs(inputs) do
-          replace_refs(document, usages, inputs, base, user)
+          replace_refs(document, usages, inputs, base, user, &normalize_body_usage/1)
         end
     end
   end
@@ -208,7 +208,7 @@ defmodule GroupherServer.CMS.Assets.Write do
     attrs
     |> cover_ref_specs()
     |> Enum.reduce_while({:ok, []}, fn {usage, inputs}, {:ok, acc} ->
-      case replace_refs(document, [usage], inputs, base, user) do
+      case replace_refs(document, [usage], inputs, base, user, &normalize_usage/1) do
         {:ok, refs} -> {:cont, {:ok, acc ++ refs}}
         {:error, _} = error -> {:halt, error}
       end
@@ -251,7 +251,14 @@ defmodule GroupherServer.CMS.Assets.Write do
     end
   end
 
-  defp replace_refs(%ArticleDocument{id: document_id}, usages, inputs, base, user) do
+  defp replace_refs(
+         %ArticleDocument{id: document_id},
+         usages,
+         inputs,
+         base,
+         user,
+         normalize_usage_fun
+       ) do
     ArticleDocumentAssetRef
     |> where([ref], ref.article_document_id == ^document_id and ref.usage in ^usages)
     |> Repo.delete_all()
@@ -259,7 +266,7 @@ defmodule GroupherServer.CMS.Assets.Write do
     inputs
     |> Enum.with_index()
     |> Enum.reduce_while({:ok, []}, fn {input, index}, {:ok, acc} ->
-      case create_ref(input, index, base, user) do
+      case create_ref(input, index, base, user, normalize_usage_fun) do
         {:ok, ref} -> {:cont, {:ok, acc ++ [ref]}}
         {:error, _} = error -> {:halt, error}
       end
@@ -271,7 +278,7 @@ defmodule GroupherServer.CMS.Assets.Write do
   defp replace_usages_for_inputs(inputs) do
     inputs
     |> Enum.reduce_while({:ok, MapSet.new(@body_usages)}, fn input, {:ok, usage_set} ->
-      case normalize_usage(get_attr(input, :usage)) do
+      case normalize_body_usage(get_attr(input, :usage)) do
         {:ok, usage} -> {:cont, {:ok, MapSet.put(usage_set, usage)}}
         {:error, _} = error -> {:halt, error}
       end
@@ -282,8 +289,9 @@ defmodule GroupherServer.CMS.Assets.Write do
     end
   end
 
-  defp create_ref(input, index, %{community_id: community_id} = base, user) when is_map(input) do
-    with {:ok, usage} <- normalize_usage(get_attr(input, :usage)),
+  defp create_ref(input, index, %{community_id: community_id} = base, user, normalize_usage_fun)
+       when is_map(input) do
+    with {:ok, usage} <- normalize_usage_fun.(get_attr(input, :usage)),
          {:ok, asset} <- resolve_asset(community_id, input, user) do
       attrs =
         base
@@ -303,7 +311,7 @@ defmodule GroupherServer.CMS.Assets.Write do
     end
   end
 
-  defp create_ref(_, _, _, _), do: {:error, {:custom, "asset ref is invalid"}}
+  defp create_ref(_, _, _, _, _), do: {:error, {:custom, "asset ref is invalid"}}
 
   defp resolve_asset(community_id, input, user) do
     asset_id = get_attr(input, :asset_id)
@@ -461,6 +469,16 @@ defmodule GroupherServer.CMS.Assets.Write do
   end
 
   defp normalize_usage(_), do: {:error, {:custom, "asset usage is invalid"}}
+
+  defp normalize_body_usage(usage) do
+    with {:ok, usage} <- normalize_usage(usage),
+         true <- usage in @body_usages do
+      {:ok, usage}
+    else
+      false -> {:error, {:custom, "asset usage is invalid"}}
+      {:error, _} = error -> error
+    end
+  end
 
   defp has_attr?(map, key) when is_map(map),
     do: Map.has_key?(map, key) or Map.has_key?(map, Atom.to_string(key))

--- a/backend/main/lib/groupher_server/cms/hash.ex
+++ b/backend/main/lib/groupher_server/cms/hash.ex
@@ -4,6 +4,7 @@ defmodule GroupherServer.CMS.Hash do
   """
 
   @article_snapshot_content_algorithm :sha256
+  @asset_url_algorithm :sha256
 
   @doc """
   Returns the content hash shape persisted by `ArticleSnapshot`.
@@ -12,6 +13,16 @@ defmodule GroupherServer.CMS.Hash do
   def article_snapshot_content_hash(content_hash, subtitle) do
     @article_snapshot_content_algorithm
     |> :crypto.hash(:erlang.term_to_binary({content_hash, subtitle}))
+    |> Base.encode16(case: :lower)
+  end
+
+  @doc """
+  Returns a stable hash for asset URL uniqueness inside a community.
+  """
+  @spec asset_url_hash(String.t()) :: String.t()
+  def asset_url_hash(url) when is_binary(url) do
+    @asset_url_algorithm
+    |> :crypto.hash(url)
     |> Base.encode16(case: :lower)
   end
 end

--- a/backend/main/lib/groupher_server/cms/hash.ex
+++ b/backend/main/lib/groupher_server/cms/hash.ex
@@ -8,6 +8,15 @@ defmodule GroupherServer.CMS.Hash do
 
   @doc """
   Returns the content hash shape persisted by `ArticleSnapshot`.
+
+  The input is encoded as an Erlang term before hashing so title/body hash pairs
+  remain stable and collision-resistant for publish/change detection.
+
+  ## Examples
+
+      CMS.Hash.article_snapshot_content_hash("body-hash", "subtitle")
+      #=> "a stable sha256 hex string"
+
   """
   @spec article_snapshot_content_hash(String.t() | nil, String.t() | nil) :: String.t()
   def article_snapshot_content_hash(content_hash, subtitle) do
@@ -18,6 +27,15 @@ defmodule GroupherServer.CMS.Hash do
 
   @doc """
   Returns a stable hash for asset URL uniqueness inside a community.
+
+  Community assets store this hash rather than depending on the raw URL for the
+  partial unique index used by active asset deduplication.
+
+  ## Examples
+
+      CMS.Hash.asset_url_hash("https://cdn.example/hero.png")
+      #=> "a stable sha256 hex string"
+
   """
   @spec asset_url_hash(String.t()) :: String.t()
   def asset_url_hash(url) when is_binary(url) do

--- a/backend/main/lib/groupher_server/cms/model/article_document.ex
+++ b/backend/main/lib/groupher_server/cms/model/article_document.ex
@@ -11,6 +11,7 @@ defmodule GroupherServer.CMS.Model.ArticleDocument do
   import Helper.Utils, only: [get_config: 2]
 
   alias GroupherServer.CMS.Artiment.Threads
+  alias GroupherServer.CMS.Model.ArticleDocumentAssetRef
   alias Helper.Constant.DBPrefix
 
   @schema_prefix DBPrefix.cms()
@@ -38,6 +39,8 @@ defmodule GroupherServer.CMS.Model.ArticleDocument do
     field(:digest, :string)
     field(:content_hash, :string)
     field(:schema_version, :integer, default: 1)
+
+    has_many(:asset_refs, ArticleDocumentAssetRef)
 
     timestamps(type: :utc_datetime)
   end

--- a/backend/main/lib/groupher_server/cms/model/article_document_asset_ref.ex
+++ b/backend/main/lib/groupher_server/cms/model/article_document_asset_ref.ex
@@ -1,0 +1,86 @@
+defmodule GroupherServer.CMS.Model.ArticleDocumentAssetRef do
+  @moduledoc """
+  Block-level article document to asset usage projection.
+
+  This table is intentionally separate from `community_assets`:
+
+      article_documents
+             |
+             v
+      article_document_asset_refs  --->  community_assets
+
+  `community_assets` owns bytes and billing. Refs answer product questions such
+  as "where is this image used?", "which cover asset belongs to this article?",
+  and "which resources are currently orphaned?".
+  """
+
+  alias __MODULE__
+
+  use Ecto.Schema
+  use Accessible
+
+  import Ecto.Changeset
+
+  alias GroupherServer.CMS
+  alias CMS.Artiment.Threads
+  alias CMS.Model.{ArticleDocument, Community, CommunityAsset}
+  alias Helper.Constant.DBPrefix
+
+  @schema_prefix DBPrefix.cms()
+  @timestamps_opts [type: :utc_datetime]
+
+  @usage_values ~w(inline cover cover_dark attachment embed)a
+
+  @required_fields ~w(community_id article_document_id asset_id thread article_id usage)a
+  @optional_fields ~w(block_id block_type position title alt source meta)a
+
+  @type usage :: :inline | :cover | :cover_dark | :attachment | :embed
+  @type t :: %ArticleDocumentAssetRef{}
+
+  schema "article_document_asset_refs" do
+    belongs_to(:community, Community)
+    belongs_to(:article_document, ArticleDocument)
+    belongs_to(:asset, CommunityAsset)
+
+    field(:thread, Ecto.Enum, values: Threads.article_enums())
+    field(:article_id, :id)
+    field(:usage, Ecto.Enum, values: @usage_values, default: :inline)
+
+    field(:block_id, :string)
+    field(:block_type, :string)
+    field(:position, :integer)
+    field(:title, :string)
+    field(:alt, :string)
+    field(:source, :string)
+    field(:meta, :map, default: %{})
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(%ArticleDocumentAssetRef{} = ref, attrs) do
+    ref
+    |> cast(attrs, @optional_fields ++ @required_fields)
+    |> validate_required(@required_fields)
+    |> validate_number(:position, greater_than_or_equal_to: 0)
+    |> validate_length(:block_id, max: 120)
+    |> validate_length(:block_type, max: 80)
+    |> validate_length(:title, max: 160)
+    |> validate_length(:alt, max: 255)
+    |> validate_length(:source, max: 80)
+    |> foreign_key_constraint(:community_id)
+    |> foreign_key_constraint(:article_document_id)
+    |> foreign_key_constraint(:asset_id)
+    |> unique_constraint([:article_document_id, :usage],
+      name: :article_document_asset_refs_cover_usage_index
+    )
+    |> unique_constraint([:article_document_id, :asset_id, :usage, :block_id],
+      name: :article_document_asset_refs_block_index
+    )
+  end
+
+  @doc false
+  def update_changeset(%ArticleDocumentAssetRef{} = ref, attrs), do: changeset(ref, attrs)
+
+  def usage_values, do: @usage_values
+end

--- a/backend/main/lib/groupher_server/cms/model/article_document_asset_ref.ex
+++ b/backend/main/lib/groupher_server/cms/model/article_document_asset_ref.ex
@@ -57,7 +57,27 @@ defmodule GroupherServer.CMS.Model.ArticleDocumentAssetRef do
     timestamps(type: :utc_datetime)
   end
 
-  @doc false
+  @doc """
+  Builds a changeset for one article-document asset ref.
+
+  The changeset validates the article/document/asset foreign keys, the ref usage
+  enum, optional block metadata, and the uniqueness constraints used for cover
+  refs and block-level refs.
+
+  ## Examples
+
+      ArticleDocumentAssetRef.changeset(%ArticleDocumentAssetRef{}, %{
+        community_id: community.id,
+        article_document_id: document.id,
+        asset_id: asset.id,
+        thread: :post,
+        article_id: post.id,
+        usage: :inline,
+        block_id: "image-1"
+      })
+      #=> %Ecto.Changeset{valid?: true}
+
+  """
   def changeset(%ArticleDocumentAssetRef{} = ref, attrs) do
     ref
     |> cast(attrs, @optional_fields ++ @required_fields)
@@ -79,8 +99,28 @@ defmodule GroupherServer.CMS.Model.ArticleDocumentAssetRef do
     )
   end
 
-  @doc false
+  @doc """
+  Builds an update changeset for an existing article-document asset ref.
+
+  It reuses `changeset/2` so update paths keep the same validation and
+  constraint behavior as creation.
+
+  ## Examples
+
+      ArticleDocumentAssetRef.update_changeset(ref, %{alt: "Hero image"})
+      #=> %Ecto.Changeset{}
+
+  """
   def update_changeset(%ArticleDocumentAssetRef{} = ref, attrs), do: changeset(ref, attrs)
 
+  @doc """
+  Returns the supported usage values for article-document asset refs.
+
+  ## Examples
+
+      ArticleDocumentAssetRef.usage_values()
+      #=> [:inline, :cover, :cover_dark, :attachment, :embed]
+
+  """
   def usage_values, do: @usage_values
 end

--- a/backend/main/lib/groupher_server/cms/model/community.ex
+++ b/backend/main/lib/groupher_server/cms/model/community.ex
@@ -17,6 +17,7 @@ defmodule GroupherServer.CMS.Model.Community do
     CommunityDashboard,
     CommunityModerator,
     CommunitySubscriber,
+    CommunityAsset,
     CommunityTagGroup,
     Embeds
   }
@@ -60,6 +61,7 @@ defmodule GroupherServer.CMS.Model.Community do
 
     has_one(:dashboard, CommunityDashboard)
     has_many(:tag_groups, CommunityTagGroup)
+    has_many(:assets, CommunityAsset)
 
     field(:articles_count, :integer, default: 0)
     field(:moderators_count, :integer, default: 0)

--- a/backend/main/lib/groupher_server/cms/model/community_asset.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_asset.ex
@@ -24,6 +24,7 @@ defmodule GroupherServer.CMS.Model.CommunityAsset do
   use Accessible
 
   import Ecto.Changeset
+  import Ecto.Query, warn: false
 
   alias GroupherServer.Accounts.Model.User
   alias GroupherServer.CMS
@@ -75,7 +76,22 @@ defmodule GroupherServer.CMS.Model.CommunityAsset do
     timestamps(type: :utc_datetime)
   end
 
-  @doc false
+  @doc """
+  Builds a changeset for creating or updating a community asset.
+
+  The changeset computes `url_hash`, validates storage metadata, and attaches
+  the DB constraints used by the asset deduplication flow.
+
+  ## Examples
+
+      CommunityAsset.changeset(%CommunityAsset{}, %{
+        community_id: community.id,
+        url: "https://cdn.example/hero.png",
+        size_bytes: 2048
+      })
+      #=> %Ecto.Changeset{valid?: true}
+
+  """
   def changeset(%CommunityAsset{} = asset, attrs) do
     asset
     |> cast(attrs, @optional_fields ++ @required_fields)
@@ -101,10 +117,77 @@ defmodule GroupherServer.CMS.Model.CommunityAsset do
     )
   end
 
-  @doc false
+  @doc """
+  Builds an update changeset for an existing community asset.
+
+  It intentionally reuses `changeset/2` so create/update paths share the same
+  URL hash calculation and validation rules.
+
+  ## Examples
+
+      CommunityAsset.update_changeset(asset, %{title: "Updated title"})
+      #=> %Ecto.Changeset{}
+
+  """
   def update_changeset(%CommunityAsset{} = asset, attrs), do: changeset(asset, attrs)
 
+  @doc """
+  Builds the base query for active assets in a community.
+
+  Active assets are rows that still belong to the community catalog and count
+  toward storage usage. Soft-deleted rows are excluded.
+
+  ## Examples
+
+      CommunityAsset.active_query(community.id)
+      #=> #Ecto.Query<from a0 in CommunityAsset, ...>
+
+  """
+  def active_query(community_id) do
+    __MODULE__
+    |> where([asset], asset.community_id == ^community_id)
+    |> where([asset], is_nil(asset.deleted_at))
+    |> where([asset], asset.status == :active)
+  end
+
+  @doc """
+  Builds the active-asset query for one asset inside a community.
+
+  Use this when callers need the shared active predicate plus an asset identity
+  filter. Callers can add ordering, locking, selecting, or pagination on top.
+
+  ## Examples
+
+      CommunityAsset.active_query(community.id, asset.id)
+      #=> #Ecto.Query<from a0 in CommunityAsset, ...>
+
+  """
+  def active_query(community_id, asset_id) do
+    community_id
+    |> active_query()
+    |> where([asset], asset.id == ^asset_id)
+  end
+
+  @doc """
+  Returns the supported community asset type values.
+
+  ## Examples
+
+      CommunityAsset.asset_types()
+      #=> [:image, :video, :audio, :file]
+
+  """
   def asset_types, do: @asset_types
+
+  @doc """
+  Returns the supported lifecycle status values.
+
+  ## Examples
+
+      CommunityAsset.statuses()
+      #=> [:active, :deleted]
+
+  """
   def statuses, do: @statuses
 
   defp put_url_hash(changeset) do

--- a/backend/main/lib/groupher_server/cms/model/community_asset.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_asset.ex
@@ -1,0 +1,116 @@
+defmodule GroupherServer.CMS.Model.CommunityAsset do
+  @moduledoc """
+  Community-level asset catalog entry.
+
+  This table is the billing and library source of truth. An asset counts toward
+  community storage as soon as it exists here, regardless of whether any article
+  currently references it.
+
+      account.users
+           |
+           v
+      community_assets  <----  communities
+           |
+           v
+      article_document_asset_refs  --->  article_documents
+
+  `article_document_asset_refs` describes usage. `community_assets` describes
+  ownership, storage, and bytes.
+  """
+
+  alias __MODULE__
+
+  use Ecto.Schema
+  use Accessible
+
+  import Ecto.Changeset
+
+  alias GroupherServer.Accounts.Model.User
+  alias GroupherServer.CMS
+  alias CMS.Hash
+  alias CMS.Model.{ArticleDocumentAssetRef, Community}
+  alias Helper.Constant.DBPrefix
+
+  @schema_prefix DBPrefix.cms()
+  @timestamps_opts [type: :utc_datetime]
+
+  @asset_types ~w(image video audio file)a
+  @statuses ~w(active deleted)a
+
+  @required_fields ~w(community_id url size_bytes)a
+  @optional_fields ~w(
+    uploader_id asset_type status title filename mime_type url_hash storage storage_key
+    content_hash width height meta deleted_at
+  )a
+
+  @type asset_type :: :image | :video | :audio | :file
+  @type status :: :active | :deleted
+  @type t :: %CommunityAsset{}
+
+  schema "community_assets" do
+    belongs_to(:community, Community)
+    belongs_to(:uploader, User, foreign_key: :uploader_id)
+
+    field(:asset_type, Ecto.Enum, values: @asset_types, default: :file)
+    field(:status, Ecto.Enum, values: @statuses, default: :active)
+
+    field(:title, :string)
+    field(:filename, :string)
+    field(:mime_type, :string)
+
+    field(:url, :string)
+    field(:url_hash, :string)
+    field(:storage, :string)
+    field(:storage_key, :string)
+    field(:content_hash, :string)
+
+    field(:size_bytes, :integer, default: 0)
+    field(:width, :integer)
+    field(:height, :integer)
+    field(:meta, :map, default: %{})
+    field(:deleted_at, :utc_datetime)
+
+    has_many(:article_refs, ArticleDocumentAssetRef, foreign_key: :asset_id)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(%CommunityAsset{} = asset, attrs) do
+    asset
+    |> cast(attrs, @optional_fields ++ @required_fields)
+    |> put_url_hash()
+    |> validate_required(@required_fields ++ [:url_hash])
+    |> validate_number(:size_bytes, greater_than_or_equal_to: 0)
+    |> validate_number(:width, greater_than: 0)
+    |> validate_number(:height, greater_than: 0)
+    |> validate_length(:url, min: 1)
+    |> validate_length(:title, max: 160)
+    |> validate_length(:filename, max: 255)
+    |> validate_length(:mime_type, max: 120)
+    |> validate_length(:storage, max: 80)
+    |> validate_length(:storage_key, max: 500)
+    |> validate_length(:content_hash, max: 160)
+    |> foreign_key_constraint(:community_id)
+    |> foreign_key_constraint(:uploader_id)
+    |> unique_constraint([:community_id, :url_hash],
+      name: :community_assets_community_url_hash_index
+    )
+    |> unique_constraint([:community_id, :storage, :storage_key],
+      name: :community_assets_community_storage_key_index
+    )
+  end
+
+  @doc false
+  def update_changeset(%CommunityAsset{} = asset, attrs), do: changeset(asset, attrs)
+
+  def asset_types, do: @asset_types
+  def statuses, do: @statuses
+
+  defp put_url_hash(changeset) do
+    case get_field(changeset, :url) do
+      url when is_binary(url) -> put_change(changeset, :url_hash, Hash.asset_url_hash(url))
+      _ -> changeset
+    end
+  end
+end

--- a/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
+++ b/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
@@ -34,6 +34,14 @@ defmodule GroupherServerWeb.Resolvers.CMS do
     CMS.Assets.page(community, Map.get(args, :filter))
   end
 
+  def community_asset_refs(
+        _root,
+        %{community: %Community{} = community, asset_id: asset_id} = args,
+        _info
+      ) do
+    CMS.Assets.refs(community, asset_id, Map.get(args, :filter))
+  end
+
   def community_asset_usage(_root, %{community: %Community{} = community}, _info) do
     CMS.Assets.usage(community)
   end

--- a/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
+++ b/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
@@ -30,6 +30,24 @@ defmodule GroupherServerWeb.Resolvers.CMS do
     CMS.Communities.paged(filter)
   end
 
+  def paged_community_assets(_root, %{community: %Community{} = community} = args, _info) do
+    CMS.Assets.page(community, Map.get(args, :filter))
+  end
+
+  def community_asset_usage(_root, %{community: %Community{} = community}, _info) do
+    CMS.Assets.usage(community)
+  end
+
+  def register_community_asset(_root, %{community: %Community{} = community, asset: asset}, %{
+        context: %{cur_user: user}
+      }) do
+    CMS.Assets.register(community, asset, user)
+  end
+
+  def delete_community_asset(_root, %{community: %Community{} = community, id: id}, _info) do
+    CMS.Assets.delete(community, id)
+  end
+
   def create_community(_root, args, %{context: %{cur_user: user}}) do
     CMS.Communities.create(args, user)
   end
@@ -454,7 +472,11 @@ defmodule GroupherServerWeb.Resolvers.CMS do
   end
 
   def create_article(_root, ~m(community thread)a = args, %{context: %{cur_user: user}}) do
-    CMS.Articles.create(community, thread, args, user)
+    CMS.Articles.create(community, thread, Map.put(args, :cur_user, user), user)
+  end
+
+  def update_article(_root, %{article: article} = args, %{context: %{cur_user: user}}) do
+    CMS.Articles.update(article, Map.put(args, :cur_user, user))
   end
 
   def update_article(_root, %{article: article} = args, _info) do

--- a/backend/main/lib/groupher_server_web/schema/cms/cms_queries.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/cms_queries.ex
@@ -110,6 +110,19 @@ defmodule GroupherServerWeb.Schema.CMS.Queries do
       resolve(&R.CMS.community_asset_usage/3)
     end
 
+    @desc "paged article references for one community asset"
+    field :community_asset_refs, :paged_article_document_asset_refs do
+      arg(:community, non_null(:string))
+      arg(:asset_id, non_null(:id))
+      arg(:filter, :pagi_filter)
+
+      middleware(M.Authorize, :login)
+      middleware(M.Passport, action: "community.update")
+      middleware(M.FrontDesk, :community)
+      middleware(M.PageSizeProof)
+      resolve(&R.CMS.community_asset_refs/3)
+    end
+
     @desc "Get all passport rules available to the current user."
     field :all_passport_rules, :all_rules do
       middleware(M.Authorize, :login)

--- a/backend/main/lib/groupher_server_web/schema/cms/cms_queries.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/cms_queries.ex
@@ -88,6 +88,28 @@ defmodule GroupherServerWeb.Schema.CMS.Queries do
       resolve(&R.CMS.community/3)
     end
 
+    @desc "paged assets owned by a community"
+    field :paged_community_assets, :paged_community_assets do
+      arg(:community, non_null(:string))
+      arg(:filter, :pagi_filter)
+
+      middleware(M.Authorize, :login)
+      middleware(M.Passport, action: "community.update")
+      middleware(M.FrontDesk, :community)
+      middleware(M.PageSizeProof)
+      resolve(&R.CMS.paged_community_assets/3)
+    end
+
+    @desc "community asset storage usage"
+    field :community_asset_usage, :community_asset_usage do
+      arg(:community, non_null(:string))
+
+      middleware(M.Authorize, :login)
+      middleware(M.Passport, action: "community.update")
+      middleware(M.FrontDesk, :community)
+      resolve(&R.CMS.community_asset_usage/3)
+    end
+
     @desc "Get all passport rules available to the current user."
     field :all_passport_rules, :all_rules do
       middleware(M.Authorize, :login)

--- a/backend/main/lib/groupher_server_web/schema/cms/cms_types.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/cms_types.ex
@@ -347,7 +347,7 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     field(:uploader, :user, resolve: dataloader(CMS, :uploader))
 
     field(:article_refs, list_of(:article_document_asset_ref),
-      resolve: dataloader(CMS, :article_refs)
+      resolve: fn asset, _, _ -> CMS.Assets.refs(asset) end
     )
 
     timestamp_fields()

--- a/backend/main/lib/groupher_server_web/schema/cms/cms_types.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/cms_types.ex
@@ -346,10 +346,6 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     field(:community, :community, resolve: dataloader(CMS, :community))
     field(:uploader, :user, resolve: dataloader(CMS, :uploader))
 
-    field(:article_refs, list_of(:article_document_asset_ref),
-      resolve: fn asset, _, _ -> CMS.Assets.refs(asset) end
-    )
-
     timestamp_fields()
   end
 
@@ -926,6 +922,11 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
 
   object :paged_community_assets do
     field(:entries, list_of(:community_asset))
+    pagination_fields()
+  end
+
+  object :paged_article_document_asset_refs do
+    field(:entries, list_of(:article_document_asset_ref))
     pagination_fields()
   end
 

--- a/backend/main/lib/groupher_server_web/schema/cms/cms_types.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/cms_types.ex
@@ -60,6 +60,26 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     value(:dashboard)
   end
 
+  enum :community_asset_type do
+    value(:image)
+    value(:video)
+    value(:audio)
+    value(:file)
+  end
+
+  enum :community_asset_status do
+    value(:active)
+    value(:deleted)
+  end
+
+  enum :article_document_asset_usage do
+    value(:inline)
+    value(:cover)
+    value(:cover_dark)
+    value(:attachment)
+    value(:embed)
+  end
+
   enum :marker_type do
     value(:icon)
     value(:emoji)
@@ -307,6 +327,82 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     field(:id, :id)
   end
 
+  object :community_asset do
+    field(:id, :id)
+    field(:asset_type, :community_asset_type)
+    field(:status, :community_asset_status)
+    field(:title, :string)
+    field(:filename, :string)
+    field(:mime_type, :string)
+    field(:url, :string)
+    field(:storage, :string)
+    field(:storage_key, :string)
+    field(:content_hash, :string)
+    field(:size_bytes, :big_int)
+    field(:width, :integer)
+    field(:height, :integer)
+    field(:meta, :json)
+    field(:deleted_at, :datetime)
+    field(:community, :community, resolve: dataloader(CMS, :community))
+    field(:uploader, :user, resolve: dataloader(CMS, :uploader))
+
+    field(:article_refs, list_of(:article_document_asset_ref),
+      resolve: dataloader(CMS, :article_refs)
+    )
+
+    timestamp_fields()
+  end
+
+  object :article_document_asset_ref do
+    field(:id, :id)
+    field(:thread, :thread)
+    field(:article_id, :id)
+    field(:usage, :article_document_asset_usage)
+    field(:block_id, :string)
+    field(:block_type, :string)
+    field(:position, :integer)
+    field(:title, :string)
+    field(:alt, :string)
+    field(:source, :string)
+    field(:meta, :json)
+    field(:asset, :community_asset, resolve: dataloader(CMS, :asset))
+
+    timestamp_fields()
+  end
+
+  object :community_asset_usage do
+    field(:asset_count, :integer)
+    field(:storage_bytes, :big_int)
+  end
+
+  input_object :community_asset_input do
+    field(:asset_type, :community_asset_type)
+    field(:title, :string)
+    field(:filename, :string)
+    field(:mime_type, :string)
+    field(:url, non_null(:string))
+    field(:storage, :string)
+    field(:storage_key, :string)
+    field(:content_hash, :string)
+    field(:size_bytes, non_null(:big_int))
+    field(:width, :integer)
+    field(:height, :integer)
+    field(:meta, :json)
+  end
+
+  input_object :article_document_asset_ref_input do
+    field(:asset_id, :id)
+    field(:asset, :community_asset_input)
+    field(:usage, :article_document_asset_usage)
+    field(:block_id, :string)
+    field(:block_type, :string)
+    field(:position, :integer)
+    field(:title, :string)
+    field(:alt, :string)
+    field(:source, :string)
+    field(:meta, :json)
+  end
+
   object :article_document do
     field(:json, :string)
     field(:markdown, :string)
@@ -314,6 +410,10 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
     field(:html, :string)
     field(:xml, :string)
     field(:rss, :string)
+
+    field(:asset_refs, list_of(:article_document_asset_ref),
+      resolve: dataloader(CMS, :asset_refs)
+    )
   end
 
   object :article_snapshot do
@@ -821,6 +921,11 @@ defmodule GroupherServerWeb.Schema.CMS.Types do
 
   object :paged_mentions do
     field(:entries, list_of(:artiment_mention))
+    pagination_fields()
+  end
+
+  object :paged_community_assets do
+    field(:entries, list_of(:community_asset))
     pagination_fields()
   end
 

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/blog.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/blog.ex
@@ -17,6 +17,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Blog do
       arg(:thread, :thread, default_value: :blog)
       arg(:community_tags, list_of(:id))
       article_cover_args()
+      article_asset_args()
 
       middleware(M.Authorize, :login)
       middleware(M.PublishThrottle, interval: 3, hour_limit: 15, day_limit: 30)
@@ -35,6 +36,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Blog do
       arg(:link_addr, :string)
       arg(:community_tags, list_of(:id))
       article_cover_args()
+      article_asset_args()
 
       middleware(M.Authorize, :login)
       middleware(M.Passport, action: "blog.update", thread: :blog)

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/changelog.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/changelog.ex
@@ -17,6 +17,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Changelog do
       arg(:thread, :thread, default_value: :changelog)
       arg(:community_tags, list_of(:id))
       article_cover_args()
+      article_asset_args()
 
       middleware(M.Authorize, :login)
       middleware(M.PublishThrottle, interval: 3, hour_limit: 15, day_limit: 30)
@@ -35,6 +36,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Changelog do
       arg(:link_addr, :string)
       arg(:community_tags, list_of(:id))
       article_cover_args()
+      article_asset_args()
 
       middleware(M.Authorize, :login)
       middleware(M.Passport, action: "changelog.update", thread: :changelog)

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/community.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/community.ex
@@ -50,6 +50,30 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Community do
       resolve(&R.CMS.delete_community/3)
     end
 
+    @desc "register an uploaded asset into the community asset library"
+    field :register_community_asset, :community_asset do
+      arg(:community, non_null(:string))
+      arg(:asset, non_null(:community_asset_input))
+
+      middleware(M.Authorize, :login)
+      middleware(M.Passport, action: "community.update")
+      middleware(M.FrontDesk, :community)
+
+      resolve(&R.CMS.register_community_asset/3)
+    end
+
+    @desc "delete an unreferenced community asset from the asset library"
+    field :delete_community_asset, :community_asset do
+      arg(:community, non_null(:string))
+      arg(:id, non_null(:id))
+
+      middleware(M.Authorize, :login)
+      middleware(M.Passport, action: "community.update")
+      middleware(M.FrontDesk, :community)
+
+      resolve(&R.CMS.delete_community_asset/3)
+    end
+
     @desc "apply to create a community"
     field :apply_community, :community do
       arg(:title, non_null(:string))

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/doc.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/doc.ex
@@ -17,6 +17,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Doc do
       arg(:thread, :thread, default_value: :doc)
       arg(:community_tags, list_of(:id))
       article_cover_args()
+      article_asset_args()
 
       middleware(M.Authorize, :login)
       middleware(M.PublishThrottle, interval: 3, hour_limit: 15, day_limit: 30)
@@ -35,6 +36,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Doc do
       arg(:link_addr, :string)
       arg(:community_tags, list_of(:id))
       article_cover_args()
+      article_asset_args()
 
       middleware(M.Authorize, :login)
       middleware(M.Passport, action: "doc.update", thread: :doc)

--- a/backend/main/lib/groupher_server_web/schema/cms/mutations/post.ex
+++ b/backend/main/lib/groupher_server_web/schema/cms/mutations/post.ex
@@ -17,6 +17,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Post do
       arg(:thread, :thread, default_value: :post)
       arg(:community_tags, list_of(:id))
       article_cover_args()
+      article_asset_args()
 
       middleware(M.Authorize, :login)
       middleware(M.PublishThrottle, interval: 3, hour_limit: 15, day_limit: 30)
@@ -35,6 +36,7 @@ defmodule GroupherServerWeb.Schema.CMS.Mutations.Post do
       arg(:link_addr, :string)
       arg(:community_tags, list_of(:id))
       article_cover_args()
+      article_asset_args()
 
       middleware(M.Authorize, :login)
       middleware(M.Passport, action: "post.update", thread: :post)

--- a/backend/main/lib/groupher_server_web/schema/helper/metrics.ex
+++ b/backend/main/lib/groupher_server_web/schema/helper/metrics.ex
@@ -6,6 +6,17 @@ defmodule GroupherServerWeb.Schema.Helper.Metrics do
 
   use Absinthe.Schema.Notation
 
+  scalar :big_int, name: "BigInt" do
+    description("""
+    The `BigInt` scalar represents integer values outside GraphQL Int's safe
+    transport range. Responses are serialized as strings to avoid precision loss
+    in JavaScript clients.
+    """)
+
+    serialize(&serialize_big_int/1)
+    parse(&parse_big_int/1)
+  end
+
   object :done do
     field(:done, :boolean)
   end
@@ -25,5 +36,39 @@ defmodule GroupherServerWeb.Schema.Helper.Metrics do
   input_object :common_paged_filter do
     pagination_args()
     field(:sort, :inserted_sort_enum, default_value: :desc_inserted)
+  end
+
+  defp serialize_big_int(nil), do: nil
+
+  defp serialize_big_int(%Decimal{} = value) do
+    value
+    |> Decimal.to_integer()
+    |> Integer.to_string()
+  end
+
+  defp serialize_big_int(value) when is_integer(value), do: Integer.to_string(value)
+  defp serialize_big_int(value) when is_binary(value), do: value
+
+  defp serialize_big_int(value) do
+    raise Absinthe.SerializationError, """
+    Value #{inspect(value)} is not a valid BigInt.
+    """
+  end
+
+  defp parse_big_int(%Absinthe.Blueprint.Input.Integer{value: value}), do: {:ok, value}
+
+  defp parse_big_int(%Absinthe.Blueprint.Input.String{value: value}),
+    do: parse_big_int_value(value)
+
+  defp parse_big_int(%Absinthe.Blueprint.Input.Null{}), do: {:ok, nil}
+  defp parse_big_int(value) when is_integer(value), do: {:ok, value}
+  defp parse_big_int(value) when is_binary(value), do: parse_big_int_value(value)
+  defp parse_big_int(_), do: :error
+
+  defp parse_big_int_value(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> {:ok, integer}
+      _ -> :error
+    end
   end
 end

--- a/backend/main/lib/groupher_server_web/schema/helper/mutations.ex
+++ b/backend/main/lib/groupher_server_web/schema/helper/mutations.ex
@@ -45,6 +45,16 @@ defmodule GroupherServerWeb.Schema.Helper.Mutations do
       arg(:cover_url, :string)
       arg(:cover_url_dark, :string)
       arg(:cover_edit_info, :cover_edit_info_input)
+      arg(:cover_asset_id, :id)
+      arg(:cover_asset, :community_asset_input)
+      arg(:cover_asset_dark_id, :id)
+      arg(:cover_asset_dark, :community_asset_input)
+    end
+  end
+
+  defmacro article_asset_args do
+    quote do
+      arg(:asset_refs, list_of(:article_document_asset_ref_input))
     end
   end
 

--- a/backend/main/priv/repo/migrations/20260704103000_create_community_assets.exs
+++ b/backend/main/priv/repo/migrations/20260704103000_create_community_assets.exs
@@ -1,0 +1,122 @@
+defmodule GroupherServer.Repo.Migrations.CreateCommunityAssets do
+  use Ecto.Migration
+
+  @prefix "cms"
+
+  def change do
+    create table(:community_assets, prefix: @prefix) do
+      add(:community_id, references(:communities, prefix: @prefix, on_delete: :delete_all),
+        null: false
+      )
+
+      add(:uploader_id, references(:users, prefix: "account", on_delete: :nilify_all))
+
+      add(:asset_type, :string, null: false, default: "file")
+      add(:status, :string, null: false, default: "active")
+
+      add(:title, :string)
+      add(:filename, :string)
+      add(:mime_type, :string)
+
+      add(:url, :text, null: false)
+      add(:url_hash, :string, null: false)
+      add(:storage, :string)
+      add(:storage_key, :string)
+      add(:content_hash, :string)
+
+      add(:size_bytes, :bigint, null: false, default: 0)
+      add(:width, :integer)
+      add(:height, :integer)
+      add(:meta, :map, null: false, default: %{})
+      add(:deleted_at, :timestamptz)
+
+      timestamps()
+    end
+
+    create(index(:community_assets, [:community_id], prefix: @prefix))
+    create(index(:community_assets, [:uploader_id], prefix: @prefix))
+    create(index(:community_assets, [:asset_type], prefix: @prefix))
+    create(index(:community_assets, [:status], prefix: @prefix))
+    create(index(:community_assets, [:deleted_at], prefix: @prefix))
+    create(index(:community_assets, [:content_hash], prefix: @prefix))
+
+    create(
+      unique_index(:community_assets, [:community_id, :url_hash],
+        prefix: @prefix,
+        where: "deleted_at IS NULL",
+        name: :community_assets_community_url_hash_index
+      )
+    )
+
+    create(
+      unique_index(:community_assets, [:community_id, :storage, :storage_key],
+        prefix: @prefix,
+        where: "storage_key IS NOT NULL AND deleted_at IS NULL",
+        name: :community_assets_community_storage_key_index
+      )
+    )
+
+    create(
+      index(:community_assets, [:community_id, :status, :inserted_at, :id],
+        prefix: @prefix,
+        where: "deleted_at IS NULL",
+        name: :community_assets_active_page_index
+      )
+    )
+
+    create table(:article_document_asset_refs, prefix: @prefix) do
+      add(:community_id, references(:communities, prefix: @prefix, on_delete: :delete_all),
+        null: false
+      )
+
+      add(
+        :article_document_id,
+        references(:article_documents, prefix: @prefix, on_delete: :delete_all),
+        null: false
+      )
+
+      add(:asset_id, references(:community_assets, prefix: @prefix, on_delete: :restrict),
+        null: false
+      )
+
+      add(:thread, :string, null: false)
+      add(:article_id, :id, null: false)
+      add(:usage, :string, null: false, default: "inline")
+
+      add(:block_id, :string)
+      add(:block_type, :string)
+      add(:position, :integer)
+      add(:title, :string)
+      add(:alt, :string)
+      add(:source, :string)
+      add(:meta, :map, null: false, default: %{})
+
+      timestamps()
+    end
+
+    create(index(:article_document_asset_refs, [:community_id], prefix: @prefix))
+    create(index(:article_document_asset_refs, [:article_document_id], prefix: @prefix))
+    create(index(:article_document_asset_refs, [:asset_id], prefix: @prefix))
+    create(index(:article_document_asset_refs, [:thread, :article_id], prefix: @prefix))
+    create(index(:article_document_asset_refs, [:usage], prefix: @prefix))
+    create(index(:article_document_asset_refs, [:block_id], prefix: @prefix))
+
+    create(
+      unique_index(:article_document_asset_refs, [:article_document_id, :usage],
+        prefix: @prefix,
+        where: "usage IN ('cover', 'cover_dark')",
+        name: :article_document_asset_refs_cover_usage_index
+      )
+    )
+
+    create(
+      unique_index(
+        :article_document_asset_refs,
+        [:article_document_id, :asset_id, :usage, :block_id],
+        prefix: @prefix,
+        where: "block_id IS NOT NULL",
+        name: :article_document_asset_refs_block_index
+      )
+    )
+  end
+end

--- a/backend/main/schema.graphql
+++ b/backend/main/schema.graphql
@@ -97,6 +97,12 @@ type RootQueryType {
   "spec community info"
   community(slug: String!, incViews: Boolean): Community
 
+  "paged assets owned by a community"
+  pagedCommunityAssets(community: String!, filter: PagiFilter): PagedCommunityAssets
+
+  "community asset storage usage"
+  communityAssetUsage(community: String!): CommunityAssetUsage
+
   "Get all passport rules available to the current user."
   allPassportRules: AllRules
 
@@ -255,6 +261,12 @@ type RootMutationType {
   "delete a global community"
   deleteCommunity(community: String!): Community
 
+  "register an uploaded asset into the community asset library"
+  registerCommunityAsset(community: String!, asset: CommunityAssetInput!): CommunityAsset
+
+  "delete an unreferenced community asset from the asset library"
+  deleteCommunityAsset(community: String!, id: ID!): CommunityAsset
+
   "apply to create a community"
   applyCommunity(
     title: String!, desc: String!, slug: String!, logo: String!, locale: String, applyMsg: String, applyCategory: String
@@ -353,12 +365,12 @@ type RootMutationType {
 
   "create a post"
   createPost(
-    title: String!, body: String!, linkAddr: String, copyRight: String, community: String!, thread: Thread, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput
+    title: String!, body: String!, linkAddr: String, copyRight: String, community: String!, thread: Thread, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput, coverAssetId: ID, coverAsset: CommunityAssetInput, coverAssetDarkId: ID, coverAssetDark: CommunityAssetInput, assetRefs: [ArticleDocumentAssetRefInput]
   ): Post
 
   "update a cms\/post"
   updatePost(
-    article: ArticlePathInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput
+    article: ArticlePathInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput, coverAssetId: ID, coverAsset: CommunityAssetInput, coverAssetDarkId: ID, coverAssetDark: CommunityAssetInput, assetRefs: [ArticleDocumentAssetRefInput]
   ): Post
 
   "set cat for a post"
@@ -420,12 +432,12 @@ type RootMutationType {
 
   "create a blog"
   createBlog(
-    title: String!, body: String!, linkAddr: String, copyRight: String, community: String!, thread: Thread, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput
+    title: String!, body: String!, linkAddr: String, copyRight: String, community: String!, thread: Thread, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput, coverAssetId: ID, coverAsset: CommunityAssetInput, coverAssetDarkId: ID, coverAssetDark: CommunityAssetInput, assetRefs: [ArticleDocumentAssetRefInput]
   ): Blog
 
   "update a cms\/blog"
   updateBlog(
-    article: ArticlePathInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput
+    article: ArticlePathInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput, coverAssetId: ID, coverAsset: CommunityAssetInput, coverAssetDarkId: ID, coverAssetDark: CommunityAssetInput, assetRefs: [ArticleDocumentAssetRefInput]
   ): Blog
 
   "upvote to blog"
@@ -481,12 +493,12 @@ type RootMutationType {
 
   "create a changelog"
   createChangelog(
-    title: String!, body: String!, linkAddr: String, copyRight: String, community: String!, thread: Thread, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput
+    title: String!, body: String!, linkAddr: String, copyRight: String, community: String!, thread: Thread, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput, coverAssetId: ID, coverAsset: CommunityAssetInput, coverAssetDarkId: ID, coverAssetDark: CommunityAssetInput, assetRefs: [ArticleDocumentAssetRefInput]
   ): Changelog
 
   "update a cms\/changelog"
   updateChangelog(
-    article: ArticlePathInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput
+    article: ArticlePathInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput, coverAssetId: ID, coverAsset: CommunityAssetInput, coverAssetDarkId: ID, coverAssetDark: CommunityAssetInput, assetRefs: [ArticleDocumentAssetRefInput]
   ): Changelog
 
   "upvote to changelog"
@@ -542,12 +554,12 @@ type RootMutationType {
 
   "create a doc"
   createDoc(
-    title: String!, body: String!, linkAddr: String, copyRight: String, community: String!, thread: Thread, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput
+    title: String!, body: String!, linkAddr: String, copyRight: String, community: String!, thread: Thread, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput, coverAssetId: ID, coverAsset: CommunityAssetInput, coverAssetDarkId: ID, coverAssetDark: CommunityAssetInput, assetRefs: [ArticleDocumentAssetRefInput]
   ): Doc
 
   "update a cms\/doc"
   updateDoc(
-    article: ArticlePathInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput
+    article: ArticlePathInput!, title: String, body: String, digest: String, copyRight: String, linkAddr: String, communityTags: [ID], coverUrl: String, coverUrlDark: String, coverEditInfo: CoverEditInfoInput, coverAssetId: ID, coverAsset: CommunityAssetInput, coverAssetDarkId: ID, coverAssetDark: CommunityAssetInput, assetRefs: [ArticleDocumentAssetRefInput]
   ): Doc
 
   "upvote to doc"
@@ -813,6 +825,26 @@ enum DocCoverView {
   DASHBOARD
 }
 
+enum CommunityAssetType {
+  IMAGE
+  VIDEO
+  AUDIO
+  FILE
+}
+
+enum CommunityAssetStatus {
+  ACTIVE
+  DELETED
+}
+
+enum ArticleDocumentAssetUsage {
+  INLINE
+  COVER
+  COVER_DARK
+  ATTACHMENT
+  EMBED
+}
+
 enum MarkerType {
   ICON
   EMOJI
@@ -1051,6 +1083,79 @@ type CommonComment {
   article: CommonArticle
 }
 
+type CommunityAsset {
+  id: ID
+  assetType: CommunityAssetType
+  status: CommunityAssetStatus
+  title: String
+  filename: String
+  mimeType: String
+  url: String
+  storage: String
+  storageKey: String
+  contentHash: String
+  sizeBytes: BigInt
+  width: Int
+  height: Int
+  meta: Json
+  deletedAt: DateTime
+  community: Community
+  uploader: User
+  articleRefs: [ArticleDocumentAssetRef]
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type ArticleDocumentAssetRef {
+  id: ID
+  thread: Thread
+  articleId: ID
+  usage: ArticleDocumentAssetUsage
+  blockId: String
+  blockType: String
+  position: Int
+  title: String
+  alt: String
+  source: String
+  meta: Json
+  asset: CommunityAsset
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type CommunityAssetUsage {
+  assetCount: Int
+  storageBytes: BigInt
+}
+
+input CommunityAssetInput {
+  assetType: CommunityAssetType
+  title: String
+  filename: String
+  mimeType: String
+  url: String!
+  storage: String
+  storageKey: String
+  contentHash: String
+  sizeBytes: BigInt!
+  width: Int
+  height: Int
+  meta: Json
+}
+
+input ArticleDocumentAssetRefInput {
+  assetId: ID
+  asset: CommunityAssetInput
+  usage: ArticleDocumentAssetUsage
+  blockId: String
+  blockType: String
+  position: Int
+  title: String
+  alt: String
+  source: String
+  meta: Json
+}
+
 type ArticleDocument {
   json: String
   markdown: String
@@ -1058,6 +1163,7 @@ type ArticleDocument {
   html: String
   xml: String
   rss: String
+  assetRefs: [ArticleDocumentAssetRef]
 }
 
 type ArticleSnapshot {
@@ -1821,6 +1927,14 @@ type PagedReports {
 
 type PagedMentions {
   entries: [ArtimentMention]
+  totalCount: Int
+  pageSize: Int
+  totalPages: Int
+  pageNumber: Int
+}
+
+type PagedCommunityAssets {
+  entries: [CommunityAsset]
   totalCount: Int
   pageSize: Int
   totalPages: Int
@@ -2750,6 +2864,13 @@ character sequences. The Json type is most often used to represent a free-form
 human-readable json string.
 """
 scalar Json
+
+"""
+The `BigInt` scalar represents integer values outside GraphQL Int's safe
+transport range. Responses are serialized as strings to avoid precision loss
+in JavaScript clients.
+"""
+scalar BigInt
 
 type Done {
   done: Boolean

--- a/backend/main/schema.graphql
+++ b/backend/main/schema.graphql
@@ -103,6 +103,9 @@ type RootQueryType {
   "community asset storage usage"
   communityAssetUsage(community: String!): CommunityAssetUsage
 
+  "paged article references for one community asset"
+  communityAssetRefs(community: String!, assetId: ID!, filter: PagiFilter): PagedArticleDocumentAssetRefs
+
   "Get all passport rules available to the current user."
   allPassportRules: AllRules
 
@@ -1101,7 +1104,6 @@ type CommunityAsset {
   deletedAt: DateTime
   community: Community
   uploader: User
-  articleRefs: [ArticleDocumentAssetRef]
   insertedAt: DateTime
   updatedAt: DateTime
 }
@@ -1935,6 +1937,14 @@ type PagedMentions {
 
 type PagedCommunityAssets {
   entries: [CommunityAsset]
+  totalCount: Int
+  pageSize: Int
+  totalPages: Int
+  pageNumber: Int
+}
+
+type PagedArticleDocumentAssetRefs {
+  entries: [ArticleDocumentAssetRef]
   totalCount: Int
   pageSize: Int
   totalPages: Int

--- a/backend/main/test/groupher_server/cms/assets_test.exs
+++ b/backend/main/test/groupher_server/cms/assets_test.exs
@@ -201,7 +201,7 @@ defmodule GroupherServer.Test.CMS.AssetsTest do
       assert hd(refs).source in ["sync-a.png", "sync-b.png"]
     end
 
-    test "caps refs returned for one asset", ~m(community post user)a do
+    test "paginates refs for one asset", ~m(community post user)a do
       {:ok, asset} = CMS.Assets.register(community, image_asset_attrs("many-refs.png", 70), user)
 
       asset_refs =
@@ -217,9 +217,11 @@ defmodule GroupherServer.Test.CMS.AssetsTest do
 
       assert length(refs) == 105
 
-      {:ok, capped_refs} = CMS.Assets.refs(asset)
+      {:ok, paged_refs} = CMS.Assets.refs(community, asset.id, %{page: 1, size: 20})
 
-      assert length(capped_refs) == 100
+      assert length(paged_refs.entries) == 20
+      assert paged_refs.total_count == 105
+      assert paged_refs.page_number == 1
     end
 
     test "does not delete assets that are still referenced", ~m(community post user)a do

--- a/backend/main/test/groupher_server/cms/assets_test.exs
+++ b/backend/main/test/groupher_server/cms/assets_test.exs
@@ -141,6 +141,87 @@ defmodule GroupherServer.Test.CMS.AssetsTest do
       assert usage.storage_bytes == 300
     end
 
+    test "rejects refs with both asset_id and inline asset", ~m(community post user)a do
+      {:ok, asset} = CMS.Assets.register(community, image_asset_attrs("existing.png", 50), user)
+
+      assert {:error, {:custom, "asset_id and asset are mutually exclusive"}} =
+               CMS.Assets.sync_article_refs(community, post, %{
+                 cur_user: user,
+                 asset_refs: [
+                   %{
+                     asset_id: asset.id,
+                     asset: image_asset_attrs("ignored.png", 60)
+                   }
+                 ]
+               })
+
+      assert article_refs(:post, post.id) == []
+    end
+
+    test "serializes concurrent ref syncs for the same document", ~m(community post user)a do
+      parent = self()
+
+      tasks =
+        ["sync-a.png", "sync-b.png"]
+        |> Enum.with_index()
+        |> Enum.map(fn {filename, index} ->
+          Task.async(fn ->
+            send(parent, {:task_ready, self()})
+
+            receive do
+              :go ->
+                CMS.Assets.sync_article_refs(community, post, %{
+                  cur_user: user,
+                  asset_refs: [
+                    %{
+                      asset: image_asset_attrs(filename, 20 + index),
+                      source: filename
+                    }
+                  ]
+                })
+            end
+          end)
+        end)
+
+      ready_pids =
+        for _ <- tasks do
+          assert_receive {:task_ready, pid}
+          pid
+        end
+
+      Enum.each(ready_pids, &send(&1, :go))
+
+      Enum.each(tasks, fn task ->
+        assert {:ok, %{body: [_], cover: []}} = Task.await(task, 5_000)
+      end)
+
+      refs = article_refs(:post, post.id)
+
+      assert length(refs) == 1
+      assert hd(refs).source in ["sync-a.png", "sync-b.png"]
+    end
+
+    test "caps refs returned for one asset", ~m(community post user)a do
+      {:ok, asset} = CMS.Assets.register(community, image_asset_attrs("many-refs.png", 70), user)
+
+      asset_refs =
+        Enum.map(1..105, fn position ->
+          %{asset_id: asset.id, position: position}
+        end)
+
+      assert {:ok, %{body: refs, cover: []}} =
+               CMS.Assets.sync_article_refs(community, post, %{
+                 cur_user: user,
+                 asset_refs: asset_refs
+               })
+
+      assert length(refs) == 105
+
+      {:ok, capped_refs} = CMS.Assets.refs(asset)
+
+      assert length(capped_refs) == 100
+    end
+
     test "does not delete assets that are still referenced", ~m(community post user)a do
       asset_attrs = image_asset_attrs("referenced.png", 80)
 

--- a/backend/main/test/groupher_server/cms/assets_test.exs
+++ b/backend/main/test/groupher_server/cms/assets_test.exs
@@ -158,6 +158,35 @@ defmodule GroupherServer.Test.CMS.AssetsTest do
       assert article_refs(:post, post.id) == []
     end
 
+    test "rejects cover usages in body asset refs without changing cover refs",
+         ~m(community post user)a do
+      cover_asset = image_asset_attrs("body-usage-cover.png", 100)
+
+      assert {:ok, %{body: [], cover: [cover_ref]}} =
+               CMS.Assets.sync_article_refs(community, post, %{
+                 cur_user: user,
+                 cover_asset: cover_asset
+               })
+
+      for usage <- [:cover, "cover_dark"] do
+        assert {:error, {:custom, "asset usage is invalid"}} =
+                 CMS.Assets.sync_article_refs(community, post, %{
+                   cur_user: user,
+                   asset_refs: [
+                     %{
+                       asset: image_asset_attrs("invalid-body-#{usage}.png", 40),
+                       usage: usage
+                     }
+                   ]
+                 })
+
+        assert [%ArticleDocumentAssetRef{id: ref_id, usage: :cover}] =
+                 article_refs(:post, post.id)
+
+        assert ref_id == cover_ref.id
+      end
+    end
+
     test "serializes concurrent ref syncs for the same document", ~m(community post user)a do
       parent = self()
 

--- a/backend/main/test/groupher_server/cms/assets_test.exs
+++ b/backend/main/test/groupher_server/cms/assets_test.exs
@@ -221,7 +221,20 @@ defmodule GroupherServer.Test.CMS.AssetsTest do
 
       assert length(paged_refs.entries) == 20
       assert paged_refs.total_count == 105
+      assert paged_refs.total_pages == 6
       assert paged_refs.page_number == 1
+
+      {:ok, second_page_refs} = CMS.Assets.refs(community, asset.id, %{page: 2, size: 20})
+
+      assert length(second_page_refs.entries) == 20
+      assert second_page_refs.total_count == 105
+      assert second_page_refs.total_pages == 6
+      assert second_page_refs.page_number == 2
+
+      first_page_ids = paged_refs.entries |> Enum.map(& &1.id) |> MapSet.new()
+      second_page_ids = second_page_refs.entries |> Enum.map(& &1.id) |> MapSet.new()
+
+      assert MapSet.disjoint?(first_page_ids, second_page_ids)
     end
 
     test "does not delete assets that are still referenced", ~m(community post user)a do

--- a/backend/main/test/groupher_server/cms/assets_test.exs
+++ b/backend/main/test/groupher_server/cms/assets_test.exs
@@ -1,0 +1,194 @@
+defmodule GroupherServer.Test.CMS.AssetsTest do
+  @moduledoc false
+
+  use GroupherServer.TestMate, async: false
+
+  alias GroupherServer.CMS.Hash
+  alias GroupherServer.CMS.Model.{ArticleDocumentAssetRef, CommunityAsset}
+
+  describe "[cms assets]" do
+    setup do
+      {community, post, _attrs, user} = mock_article(:post)
+
+      {:ok, ~m(community post user)a}
+    end
+
+    test "registers community assets and counts active storage once", ~m(community user)a do
+      attrs = image_asset_attrs("hero.png", 120)
+
+      {:ok, asset} = CMS.Assets.register(community, attrs, user)
+
+      assert asset.asset_type == :image
+      assert asset.uploader_id == user.id
+      assert asset.url_hash == Hash.asset_url_hash(attrs.url)
+
+      {:ok, usage} = CMS.Assets.usage(community)
+      assert usage.asset_count == 1
+      assert usage.storage_bytes == 120
+
+      {:ok, same_asset} =
+        CMS.Assets.register(
+          community,
+          Map.merge(attrs, %{size_bytes: 256, title: "updated"}),
+          user
+        )
+
+      assert same_asset.id == asset.id
+      assert same_asset.size_bytes == 256
+
+      {:ok, usage} = CMS.Assets.usage(community)
+      assert usage.asset_count == 1
+      assert usage.storage_bytes == 256
+    end
+
+    test "deduplicates concurrent registrations by url hash", ~m(community user)a do
+      attrs = image_asset_attrs("race.png", 128)
+      parent = self()
+
+      tasks =
+        for _ <- 1..2 do
+          Task.async(fn ->
+            send(parent, {:task_ready, self()})
+
+            receive do
+              :go -> CMS.Assets.register(community, attrs, user)
+            end
+          end)
+        end
+
+      ready_pids =
+        for _ <- tasks do
+          assert_receive {:task_ready, pid}
+          pid
+        end
+
+      Enum.each(ready_pids, &send(&1, :go))
+
+      assets =
+        Enum.map(tasks, fn task ->
+          {:ok, asset} = Task.await(task, 5_000)
+          asset
+        end)
+
+      assert assets |> Enum.map(& &1.id) |> Enum.uniq() |> length() == 1
+
+      {:ok, usage} = CMS.Assets.usage(community)
+      assert usage.asset_count == 1
+      assert usage.storage_bytes == 128
+    end
+
+    test "deduplicates registered storage objects when url changes", ~m(community user)a do
+      attrs =
+        "signed-a.png"
+        |> image_asset_attrs(64)
+        |> Map.merge(%{storage: "s3", storage_key: "community/assets/signed.png"})
+
+      {:ok, asset} = CMS.Assets.register(community, attrs, user)
+
+      {:ok, same_asset} =
+        CMS.Assets.register(
+          community,
+          Map.merge(attrs, %{url: "https://assets.groupher.test/signed-b.png", size_bytes: 96}),
+          user
+        )
+
+      assert same_asset.id == asset.id
+      assert same_asset.url == "https://assets.groupher.test/signed-b.png"
+      assert same_asset.size_bytes == 96
+
+      {:ok, usage} = CMS.Assets.usage(community)
+      assert usage.asset_count == 1
+      assert usage.storage_bytes == 96
+    end
+
+    test "syncs article document refs without changing storage ownership",
+         ~m(community post user)a do
+      body_asset = image_asset_attrs("body.png", 100)
+      cover_asset = image_asset_attrs("cover.png", 200)
+
+      assert {:ok, %{body: [_], cover: [_]}} =
+               CMS.Assets.sync_article_refs(community, post, %{
+                 cur_user: user,
+                 asset_refs: [
+                   %{
+                     asset: body_asset,
+                     block_id: "block-image-1",
+                     block_type: "image",
+                     alt: "body image"
+                   }
+                 ],
+                 cover_asset: cover_asset
+               })
+
+      refs = article_refs(:post, post.id)
+      assert refs |> Enum.map(& &1.usage) |> Enum.sort() == [:cover, :inline]
+      assert Enum.find(refs, &(&1.usage == :inline)).block_id == "block-image-1"
+
+      {:ok, usage} = CMS.Assets.usage(community)
+      assert usage.asset_count == 2
+      assert usage.storage_bytes == 300
+
+      assert {:ok, %{body: [], cover: []}} =
+               CMS.Assets.sync_article_refs(community, post, %{
+                 asset_refs: [],
+                 cover_edit_info: nil
+               })
+
+      assert article_refs(:post, post.id) == []
+
+      {:ok, usage} = CMS.Assets.usage(community)
+      assert usage.asset_count == 2
+      assert usage.storage_bytes == 300
+    end
+
+    test "does not delete assets that are still referenced", ~m(community post user)a do
+      asset_attrs = image_asset_attrs("referenced.png", 80)
+
+      {:ok, %{body: [ref]}} =
+        CMS.Assets.sync_article_refs(community, post, %{
+          cur_user: user,
+          asset_refs: [%{asset: asset_attrs, block_id: "referenced"}]
+        })
+
+      assert {:error, {:custom, "asset is still referenced"}} =
+               CMS.Assets.delete(community, ref.asset_id)
+
+      assert {:ok, %CommunityAsset{}} = ORM.find(CommunityAsset, ref.asset_id)
+    end
+
+    test "deleting an article purges document asset refs", ~m(community post user)a do
+      asset_attrs = image_asset_attrs("delete-cleanup.png", 90)
+
+      {:ok, %{body: [ref]}} =
+        CMS.Assets.sync_article_refs(community, post, %{
+          cur_user: user,
+          asset_refs: [%{asset: asset_attrs, block_id: "delete-cleanup"}]
+        })
+
+      assert [_] = article_refs(:post, post.id)
+
+      assert {:ok, _} = CMS.Articles.delete(post)
+
+      assert article_refs(:post, post.id) == []
+      assert {:ok, %CommunityAsset{}} = ORM.find(CommunityAsset, ref.asset_id)
+    end
+  end
+
+  defp image_asset_attrs(filename, size_bytes) do
+    %{
+      url: "https://assets.groupher.test/#{filename}",
+      filename: filename,
+      mime_type: "image/png",
+      size_bytes: size_bytes,
+      width: 1200,
+      height: 630
+    }
+  end
+
+  defp article_refs(thread, article_id) do
+    ArticleDocumentAssetRef
+    |> where([ref], ref.thread == ^thread and ref.article_id == ^article_id)
+    |> order_by([ref], asc: ref.usage)
+    |> Repo.all()
+  end
+end

--- a/backend/main/test/groupher_server_web/query/cms/assets_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/assets_test.exs
@@ -1,0 +1,76 @@
+defmodule GroupherServer.Test.Query.CMS.Assets do
+  @moduledoc false
+
+  use GroupherServer.TestMate, async: false
+
+  @asset_refs_query """
+  query($community: String!, $assetId: ID!, $filter: PagiFilter) {
+    communityAssetRefs(community: $community, assetId: $assetId, filter: $filter) {
+      entries {
+        id
+        articleId
+        usage
+        source
+      }
+      totalCount
+      totalPages
+      pageSize
+      pageNumber
+    }
+  }
+  """
+
+  setup do
+    {community, post, _attrs, user} = mock_article(:post)
+    rule_conn = simu_conn(:user, user, cms: %{"community.update" => true})
+
+    {:ok, ~m(community post rule_conn user)a}
+  end
+
+  describe "[cms assets]" do
+    test "authorized user can page article refs for one asset",
+         ~m(community post rule_conn user)a do
+      {:ok, asset} = CMS.Assets.register(community, image_asset_attrs("query-refs.png", 70), user)
+
+      asset_refs =
+        Enum.map(1..25, fn position ->
+          %{asset_id: asset.id, position: position, source: "query-refs.png"}
+        end)
+
+      assert {:ok, %{body: refs, cover: []}} =
+               CMS.Assets.sync_article_refs(community, post, %{
+                 cur_user: user,
+                 asset_refs: asset_refs
+               })
+
+      assert length(refs) == 25
+
+      result =
+        rule_conn
+        |> gq_query(@asset_refs_query, %{
+          community: community.slug,
+          assetId: asset.id,
+          filter: %{page: 1, size: 10}
+        })
+
+      assert result |> is_valid_pagination?
+      assert result["totalCount"] == 25
+      assert result["pageSize"] == 10
+      assert result["pageNumber"] == 1
+      assert length(result["entries"]) == 10
+      assert result["entries"] |> hd() |> Map.get("source") == "query-refs.png"
+    end
+  end
+
+  defp image_asset_attrs(filename, size_bytes) do
+    %{
+      asset_type: :image,
+      filename: filename,
+      mime_type: "image/png",
+      url: "https://assets.groupher.test/#{filename}",
+      size_bytes: size_bytes,
+      width: 640,
+      height: 360
+    }
+  end
+end

--- a/backend/main/test/groupher_server_web/query/cms/assets_test.exs
+++ b/backend/main/test/groupher_server_web/query/cms/assets_test.exs
@@ -55,10 +55,15 @@ defmodule GroupherServer.Test.Query.CMS.Assets do
 
       assert result |> is_valid_pagination?
       assert result["totalCount"] == 25
+      assert result["totalPages"] == 3
       assert result["pageSize"] == 10
       assert result["pageNumber"] == 1
       assert length(result["entries"]) == 10
-      assert result["entries"] |> hd() |> Map.get("source") == "query-refs.png"
+
+      first_entry = hd(result["entries"])
+      assert first_entry["articleId"] == to_string(post.id)
+      assert first_entry["usage"] == "INLINE"
+      assert first_entry["source"] == "query-refs.png"
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a community asset library that dedupes and tracks assets per community, projects their usage in articles, and exposes GraphQL APIs to manage and paginate them. Asset refs sync on article create/update and are purged on article delete.

- **New Features**
  - Community asset catalog with dedupe by URL hash or `storage`/`storage_key`, active-only storage usage, and uploader attribution.
  - Article document asset refs (inline, cover, cover_dark, attachment, embed) with auto-sync on create/update and purge on delete.
  - GraphQL: `pagedCommunityAssets`, `communityAssetUsage`, `communityAssetRefs`, `registerCommunityAsset`, `deleteCommunityAsset`; new inputs `coverAssetId`/`coverAsset`/`coverAssetDarkId`/`coverAssetDark` and `assetRefs`; related types/enums and `BigInt` scalar.
  - Conflict-safe upserts; URL hashing for asset uniqueness; deletion blocked while referenced.
  - Validation: body refs only allow `inline`/`attachment`/`embed`; `cover`/`cover_dark` in body refs are rejected.

- **Migration**
  - Run migration `20260704103000_create_community_assets.exs`.
  - Existing cover URL fields still work; new asset inputs are optional.
  - To use, pass `coverAssetId`/`coverAsset`/`coverAssetDarkId`/`coverAssetDark` and `assetRefs` when creating/updating articles.
  - Asset management queries/mutations require `community.update` permission.

<sup>Written for commit c4324a5d7584976fae779c61187b1e87cdad7f45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/groupher/groupher/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a community asset library with upload/register, paging, usage/storage summaries, and per-asset article reference browsing.
  * Extended CMS article editors to accept asset-based cover variants (light/dark) and asset reference inputs (including block placement metadata).
  * Introduced GraphQL APIs for registering/deleting assets and listing/paging asset references and usage.
  * Added a `BigInt` scalar for large numeric fields.
* **Bug Fixes**
  * Asset reference syncing is now applied automatically across article create/update, and article deletion safely purges related asset references before removing the article content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->