### PR TITLE
chore(fe): set local dev ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ fe.install:
 
 # landing
 fe.dev.landing:
-	yarn run dev:landing
+	PORT=3002 NEXT_PUBLIC_SITE_URL=http://localhost:3002 yarn run dev:landing
 
 fe.build.landing:
 	yarn run build:prod:landing
@@ -22,7 +22,7 @@ inspire: fe.dev.inspire
 
 # main
 fe.dev.main:
-	yarn run dev:main
+	PORT=3000 NEXT_PUBLIC_SITE_URL=http://localhost:3000 yarn run dev:main
 
 fe.build.main:
 	yarn run build:prod:main
@@ -32,7 +32,7 @@ fe.serve.main:
 
 # dashboard
 fe.dev.dashboard:
-	yarn run dev:dashboard
+	PORT=3001 NEXT_PUBLIC_SITE_URL=http://localhost:3001/dashboard yarn run dev:dashboard
 
 fe.build.dashboard:
 	yarn run build:prod:dashboard


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized local dev ports and site URLs in the Makefile: main 3000, dashboard 3001 (/dashboard), landing 3002. This avoids port conflicts and makes absolute URLs resolve correctly during development.

<sup>Written for commit 48383a47df233454711c53ca854eafe64165d302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/groupher/groupher/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

