### PR TITLE
[codex] chore(fe/be): document module boundaries

### DIFF
--- a/backend/main/lib/groupher_server/accounts/achievements/membership.ex
+++ b/backend/main/lib/groupher_server/accounts/achievements/membership.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Achievements.Membership do
-  @moduledoc false
+  @moduledoc """
+  Updates membership flags on the user achievement record.
+
+  A global lock per user prevents concurrent plan changes from racing the
+  achievement row creation/upsert path.
+  """
 
   import ShortMaps
 

--- a/backend/main/lib/groupher_server/accounts/achievements/moderatorable.ex
+++ b/backend/main/lib/groupher_server/accounts/achievements/moderatorable.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Achievements.Moderatorable do
-  @moduledoc false
+  @moduledoc """
+  Lists communities where a user has moderator capability.
+
+  This backs account achievement/profile surfaces that need to show moderation
+  reach without exposing the join rows directly.
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]

--- a/backend/main/lib/groupher_server/accounts/achievements/reputation.ex
+++ b/backend/main/lib/groupher_server/accounts/achievements/reputation.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Achievements.Reputation do
-  @moduledoc false
+  @moduledoc """
+  Maintains reputation counters derived from social/content actions.
+
+  Follow, upvote, and collect events adjust both the source counter and the
+  weighted reputation total under a per-user lock.
+  """
 
   import Helper.Utils, only: [get_config: 2]
   import ShortMaps

--- a/backend/main/lib/groupher_server/accounts/collect_folders/articles.ex
+++ b/backend/main/lib/groupher_server/accounts/collect_folders/articles.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.Accounts.CollectFolders.Articles do
-  @moduledoc false
+  @moduledoc """
+  Paginates articles stored inside a collect folder.
+
+  The folder owns embedded collect refs; this module preloads the concrete
+  thread records, applies privacy checks, and extracts a mixed article page for
+  the GraphQL layer.
+  """
 
   import Helper.ErrorCode
   import Helper.Utils, only: [done: 1, get_config: 2]

--- a/backend/main/lib/groupher_server/accounts/collect_folders/list.ex
+++ b/backend/main/lib/groupher_server/accounts/collect_folders/list.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.Accounts.CollectFolders.List do
-  @moduledoc false
+  @moduledoc """
+  Paginates collect folders with viewer-aware privacy rules.
+
+  Anonymous or non-owner reads only see public folders. Owner reads include
+  private folders and can still apply thread filters through the folder meta
+  flags.
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]

--- a/backend/main/lib/groupher_server/accounts/collect_folders/write.ex
+++ b/backend/main/lib/groupher_server/accounts/collect_folders/write.ex
@@ -1,5 +1,16 @@
 defmodule GroupherServer.Accounts.CollectFolders.Write do
-  @moduledoc false
+  @moduledoc """
+  Mutations for collect folders and their article membership.
+
+  Folder membership is coordinated with the article collect relation so the
+  account folder, article collect row, and denormalized folder meta stay aligned.
+
+      add/remove article
+          |
+          +--> CMS.Articles collect state
+          +--> CollectFolder.collects embed
+          +--> per-thread counts in folder meta
+  """
 
   import GroupherServer.CMS.FrontDesk, only: [thread_of: 1]
   import GroupherServer.CMS.Artiment.Matcher

--- a/backend/main/lib/groupher_server/accounts/events.ex
+++ b/backend/main/lib/groupher_server/accounts/events.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Events do
-  @moduledoc false
+  @moduledoc """
+  Small account-domain event dispatcher.
+
+  Account write paths emit semantic events such as follow/undo-follow here, then
+  notification handlers decide what downstream messages should be created.
+  """
 
   @type event_result :: {:ok, map()} | {:error, any()}
 

--- a/backend/main/lib/groupher_server/accounts/fans/actions.ex
+++ b/backend/main/lib/groupher_server/accounts/fans/actions.ex
@@ -1,5 +1,18 @@
 defmodule GroupherServer.Accounts.Fans.Actions do
-  @moduledoc false
+  @moduledoc """
+  Follow/unfollow write orchestration for account relationships.
+
+      follow user
+          |
+          +--> UserFollower row
+          +--> UserFollowing row
+          +--> user meta/count updates
+          +--> achievement update
+          +--> async account event
+
+  The transaction keeps both relationship directions and denormalized counters
+  aligned before user pages are revalidated.
+  """
 
   import Helper.ErrorCode
 

--- a/backend/main/lib/groupher_server/accounts/fans/list.ex
+++ b/backend/main/lib/groupher_server/accounts/fans/list.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Fans.List do
-  @moduledoc false
+  @moduledoc """
+  Paginates follower and following lists for profile pages.
+
+  Viewer-aware variants enrich each user row with follow-state booleans so the
+  frontend can render follow buttons without extra round trips.
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]

--- a/backend/main/lib/groupher_server/accounts/fans/viewer_state.ex
+++ b/backend/main/lib/groupher_server/accounts/fans/viewer_state.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.Accounts.Fans.ViewerState do
-  @moduledoc false
+  @moduledoc """
+  Adds viewer relationship state to paged user results.
+
+  The base list query returns users only. This helper derives
+  `viewer_has_followed` and `viewer_been_followed` from the current viewer meta
+  so GraphQL fields can stay flat.
+  """
 
   alias GroupherServer.Accounts.Model.User
 

--- a/backend/main/lib/groupher_server/accounts/mailbox.ex
+++ b/backend/main/lib/groupher_server/accounts/mailbox.ex
@@ -1,5 +1,21 @@
 defmodule GroupherServer.Accounts.Mailbox do
-  @moduledoc false
+  @moduledoc """
+  Account-facing mailbox facade and unread counter synchronizer.
+
+  Read operations delegate to `GroupherServer.Messaging`; status updates fold
+  unread counts from mentions and notifications back into the user's embedded
+  mailbox state.
+
+      Messaging row changes
+          |
+          v
+      Mailbox.update_status/1
+          |
+          +--> count unread mentions
+          +--> count unread notifications
+          +--> update User.mailbox
+          +--> revalidate user page
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]

--- a/backend/main/lib/groupher_server/accounts/model/achievement.ex
+++ b/backend/main/lib/groupher_server/accounts/model/achievement.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Model.Achievement do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for user achievement and reputation counters.
+
+  Account achievement services update this row when social or content actions
+  change the user's reputation, membership, or contribution-derived badges.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/accounts/model/collect_folder.ex
+++ b/backend/main/lib/groupher_server/accounts/model/collect_folder.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Model.CollectFolder do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for user-owned collect folders.
+
+  The folder stores embedded article collect refs plus denormalized meta so the
+  account collection UI can page folders and mixed-thread contents efficiently.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/accounts/model/embeds/user_meta.ex
+++ b/backend/main/lib/groupher_server/accounts/model/embeds/user_meta.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Model.Embeds.UserMeta.Macro do
-  @moduledoc false
+  @moduledoc """
+  Macro helpers for thread-specific fields in `UserMeta`.
+
+  Thread lists are config-driven, so the embed generates published-count fields
+  instead of hard-coding post/blog/changelog/doc field definitions.
+  """
 
   import Helper.Utils, only: [get_config: 2, plural: 1]
 

--- a/backend/main/lib/groupher_server/accounts/model/oauth_provider.ex
+++ b/backend/main/lib/groupher_server/accounts/model/oauth_provider.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Model.OauthProvider do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for external OAuth identities linked to a user.
+
+  Each row binds one provider/provider-id pair to one account and stores the raw
+  provider profile needed for future account recovery or sync behavior.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/accounts/model/social.ex
+++ b/backend/main/lib/groupher_server/accounts/model/social.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Model.Social do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for optional profile social links.
+
+  Social links are separate from the core user row so profile edits can update
+  external handles without bloating authentication/account identity fields.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/accounts/model/source_contribute.ex
+++ b/backend/main/lib/groupher_server/accounts/model/source_contribute.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Model.SourceContribute do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for source-specific account contribution records.
+
+  These rows let account/statistics code attribute contribution activity back to
+  the originating content source.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/accounts/model/user.ex
+++ b/backend/main/lib/groupher_server/accounts/model/user.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.Accounts.Model.User do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for Groupher accounts.
+
+  The user row owns identity/profile basics and embeds denormalized account state
+  such as mailbox, meta, achievements, and contribution summaries. Domain
+  modules should update those derived embeds through account helpers.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/accounts/model/user_follower.ex
+++ b/backend/main/lib/groupher_server/accounts/model/user_follower.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Model.UserFollower do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for reverse follow relationships.
+
+  A row means `follower_id` follows `user_id`. It is maintained together with
+  `UserFollowing` so reads can be efficient in both directions.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/accounts/model/user_following.ex
+++ b/backend/main/lib/groupher_server/accounts/model/user_following.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Model.UserFollowing do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for forward follow relationships.
+
+  A row means `user_id` follows `following_id`. Follow actions update this table,
+  the reverse follower table, and user meta counters in one transaction.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/accounts/profiles/list.ex
+++ b/backend/main/lib/groupher_server/accounts/profiles/list.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Profiles.List do
-  @moduledoc false
+  @moduledoc """
+  Profile list queries for users and subscribed communities.
+
+  The module keeps profile-page pagination, default community suggestions, and
+  subscribed-community reads under the account namespace.
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1, get_config: 2]

--- a/backend/main/lib/groupher_server/accounts/profiles/oauth.ex
+++ b/backend/main/lib/groupher_server/accounts/profiles/oauth.ex
@@ -1,5 +1,17 @@
 defmodule GroupherServer.Accounts.Profiles.Oauth do
-  @moduledoc false
+  @moduledoc """
+  OAuth sign-in and account-linking workflow.
+
+      provider payload
+          |
+          +--> find existing provider -> token
+          +--> register user/provider -> token
+          +--> link/unlink provider for existing user
+
+  The workflow keeps provider records, achievement bootstrap, social profile
+  hints, tokens, mailbox bootstrap, and user revalidation in one account domain
+  boundary.
+  """
 
   import Ecto.Query, warn: false
   import Helper.ErrorCode

--- a/backend/main/lib/groupher_server/accounts/profiles/subscribe.ex
+++ b/backend/main/lib/groupher_server/accounts/profiles/subscribe.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Profiles.Subscribe do
-  @moduledoc false
+  @moduledoc """
+  Synchronizes a user's subscribed-community counters and id cache.
+
+  Subscription writes update join rows elsewhere. This helper rebuilds the
+  denormalized profile fields used by viewer state and community navigation.
+  """
 
   import Ecto.Query, warn: false
 

--- a/backend/main/lib/groupher_server/accounts/profiles/user_read.ex
+++ b/backend/main/lib/groupher_server/accounts/profiles/user_read.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.Accounts.Profiles.UserRead do
-  @moduledoc false
+  @moduledoc """
+  Read/update boundary for profile detail pages.
+
+  Reading a user increments views, fills lazy profile meta/contribution embeds
+  when needed, and can add viewer follow-state fields. Profile updates also keep
+  the optional social record and user page cache in sync.
+  """
 
   alias GroupherServer.{Accounts, FrontDesk, Repo, Statistics}
 

--- a/backend/main/lib/groupher_server/accounts/publish/articles.ex
+++ b/backend/main/lib/groupher_server/accounts/publish/articles.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.Accounts.Publish.Articles do
-  @moduledoc false
+  @moduledoc """
+  Account-side view and counters for a user's published articles.
+
+  The CMS article domain owns publication queries. This module adapts those
+  queries for profile pages and keeps the user's published-count meta in sync
+  after write paths change article state.
+  """
 
   import Helper.Utils, only: [plural: 1]
 

--- a/backend/main/lib/groupher_server/accounts/publish/comments.ex
+++ b/backend/main/lib/groupher_server/accounts/publish/comments.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Publish.Comments do
-  @moduledoc false
+  @moduledoc """
+  Account-side read facade for comments a user has published.
+
+  Comment publication remains owned by `CMS.Comments`; this module gives profile
+  and mailbox surfaces a compact account namespace for paged reads.
+  """
 
   alias GroupherServer.CMS
 

--- a/backend/main/lib/groupher_server/accounts/search/user.ex
+++ b/backend/main/lib/groupher_server/accounts/search/user.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Accounts.Search.User do
-  @moduledoc false
+  @moduledoc """
+  Lightweight user search by nickname or login.
+
+  This is intentionally bounded for mention pickers and small search surfaces,
+  not a full text-search pipeline.
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]

--- a/backend/main/lib/groupher_server/application.ex
+++ b/backend/main/lib/groupher_server/application.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.Application do
-  @moduledoc false
+  @moduledoc """
+  OTP application entrypoint for the Groupher backend.
+
+  It assembles runtime workers for Phoenix, Repo, PubSub, DNS clustering,
+  Rihanna jobs, and Cachex pools. Seed/test environments intentionally skip
+  workers that would perform network or background-job side effects.
+  """
   use Application
   import Helper.Utils, only: [get_config: 2]
 

--- a/backend/main/lib/groupher_server/application.ex
+++ b/backend/main/lib/groupher_server/application.ex
@@ -3,8 +3,8 @@ defmodule GroupherServer.Application do
   OTP application entrypoint for the Groupher backend.
 
   It assembles runtime workers for Phoenix, Repo, PubSub, DNS clustering,
-  Rihanna jobs, and Cachex pools. Seed/test environments intentionally skip
-  workers that would perform network or background-job side effects.
+  Rihanna jobs, and Cachex pools. Seed environments skip DNS, endpoint,
+  Cachex, and Rihanna workers; test environments only skip Rihanna-backed jobs.
   """
   use Application
   import Helper.Utils, only: [get_config: 2]

--- a/backend/main/lib/groupher_server/cms/artiment_mentions/parser.ex
+++ b/backend/main/lib/groupher_server/cms/artiment_mentions/parser.ex
@@ -1,5 +1,24 @@
 defmodule GroupherServer.CMS.ArtimentMentions.Parser do
-  @moduledoc false
+  @moduledoc """
+  Extracts mention candidates from the canonical Plate AST.
+
+  The parser walks blocks and inline children, preserves the block/path location
+  for each occurrence, and normalizes both editor mention nodes and pasted links
+  into the same downstream shape.
+
+      Plate AST
+          |
+          v
+      inline mention nodes + text/link URLs
+          |
+          v
+      internal candidates  ----> resolved article/comment/user structs
+      external URLs        ----> url + hash facts
+
+  This module only parses and resolves mention targets. It does not delete,
+  insert, notify, or update mailbox state; those side effects belong to the
+  mention sync and messaging layers.
+  """
 
   import Ecto.Query, warn: false
   import GroupherServer.CMS.Artiment.Matcher

--- a/backend/main/lib/groupher_server/cms/dashboard/base_info.ex
+++ b/backend/main/lib/groupher_server/cms/dashboard/base_info.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.CMS.Dashboard.BaseInfo do
-  @moduledoc false
+  @moduledoc """
+  Declares dashboard base-info fields that mirror `Community` fields.
+
+  Base info is edited from the dashboard, but some fields also belong to the
+  canonical community record. `Dashboard.Write` uses this helper to split those
+  fields from section-only payload before saving.
+  """
 
   @community_fields [:title, :locale, :desc, :logo, :favicon, :slug, :homepage]
 

--- a/backend/main/lib/groupher_server/cms/dashboard/link_validator.ex
+++ b/backend/main/lib/groupher_server/cms/dashboard/link_validator.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.CMS.Dashboard.LinkValidator do
-  @moduledoc false
+  @moduledoc """
+  Validates dashboard link-tree payloads before they are embedded.
+
+  Header and footer links are user-authored nested maps coming from GraphQL.
+  This helper keeps only the structural contract here: groups contain child
+  links, links require a URL, and every visible node has an id and title.
+  """
 
   def valid_tree?(%{id: id, type: type, title: title} = item)
       when is_binary(id) and is_binary(title) do

--- a/backend/main/lib/groupher_server/cms/dashboard/section_payload.ex
+++ b/backend/main/lib/groupher_server/cms/dashboard/section_payload.ex
@@ -1,5 +1,23 @@
 defmodule GroupherServer.CMS.Dashboard.SectionPayload do
-  @moduledoc false
+  @moduledoc """
+  Normalizes dashboard section payloads before persistence.
+
+  The dashboard stores a mix of replace-style list sections and sparse
+  `embeds_one` sections. This module prepares the final payload so validation
+  and persistence see the same data.
+
+      incoming args
+          |
+          +--> replace section: keep final list payload
+          |
+          +--> embed section: merge current embed + sparse patch
+                              |
+                              v
+                           embed changeset
+
+  Keep shape-specific rules here instead of leaking them into resolvers or the
+  `CommunityDashboard` schema.
+  """
 
   import Helper.Utils, only: [strip_struct: 1, deep_merge: 2]
 

--- a/backend/main/lib/groupher_server/cms/dashboard/theme_presets.ex
+++ b/backend/main/lib/groupher_server/cms/dashboard/theme_presets.ex
@@ -1,5 +1,19 @@
 defmodule GroupherServer.CMS.Dashboard.ThemePresets do
-  @moduledoc false
+  @moduledoc """
+  Handles dashboard theme preset selection and custom preset persistence.
+
+  Custom themes are stored as a composed preset in the layout section, with the
+  read-only base preset plus the user overwrite. Selecting a preset updates only
+  layout state; saving a custom preset composes the durable custom payload first.
+
+      save custom
+          |
+          v
+      current layout + base preset + incoming overwrite
+          |
+          v
+      layout.custom_theme_preset
+  """
 
   alias GroupherServer.CMS.Dashboard.{ThemePreset, Write}
   alias GroupherServer.CMS.Model.{Community, CommunityDashboard, Embeds}

--- a/backend/main/lib/groupher_server/cms/dashboard/write.ex
+++ b/backend/main/lib/groupher_server/cms/dashboard/write.ex
@@ -1,5 +1,25 @@
 defmodule GroupherServer.CMS.Dashboard.Write do
-  @moduledoc false
+  @moduledoc """
+  Mutation layer for persisted community dashboard sections.
+
+  Dashboard updates arrive as GraphQL section payloads and are normalized before
+  replacing the matching section on `CommunityDashboard`. Base-info writes are a
+  special case because they must keep the community row and dashboard embed in
+  sync inside one transaction.
+
+      CMS resolver
+          |
+          v
+      Dashboard.Write.update/2
+          |
+          +--> ensure CommunityDashboard exists
+          +--> SectionPayload.prepare/3
+          +--> ORM.replace_dsb_section/3
+
+  Use this module for write orchestration only. Section-specific validation and
+  merge rules should stay in `SectionPayload`, `LinkValidator`, or focused
+  section helpers.
+  """
 
   alias GroupherServer.{CMS, Repo}
   alias GroupherServer.CMS.Dashboard.{BaseInfo, SectionPayload}

--- a/backend/main/lib/groupher_server/cms/dashboard/write.ex
+++ b/backend/main/lib/groupher_server/cms/dashboard/write.ex
@@ -5,7 +5,8 @@ defmodule GroupherServer.CMS.Dashboard.Write do
   Dashboard updates arrive as GraphQL section payloads and are normalized before
   replacing the matching section on `CommunityDashboard`. Base-info writes are a
   special case because they must keep the community row and dashboard embed in
-  sync inside one transaction.
+  sync. Dashboard creation is ensured before the write; `sync_base_info` and
+  `ORM.replace_dsb_section` then run inside one transaction.
 
       CMS resolver
           |

--- a/backend/main/lib/groupher_server/cms/doc_tree/published_fields.ex
+++ b/backend/main/lib/groupher_server/cms/doc_tree/published_fields.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.CMS.DocTree.PublishedFields do
-  @moduledoc false
+  @moduledoc """
+  Single source of published doc-tree fields copied from staged events.
+
+  Publish code uses this list when applying event payloads to public
+  `doc_tree_nodes`. Keep it small and explicit so transient editor fields do not
+  leak into the published tree snapshot.
+  """
 
   @node_fields ~w(type title slug index href marker badge hidden ui_config)a
 

--- a/backend/main/lib/groupher_server/cms/events/sync_mentions.ex
+++ b/backend/main/lib/groupher_server/cms/events/sync_mentions.ex
@@ -1,5 +1,19 @@
 defmodule GroupherServer.CMS.Events.SyncMentions do
-  @moduledoc false
+  @moduledoc """
+  Event handler that refreshes mention facts after content changes.
+
+      CMS event bus
+          |
+          v
+      %Event{type: :sync_mentions, payload: %{artiment: ...}}
+          |
+          v
+      CMS.ArtimentMentions.sync/1
+
+  The event payload carries the article or comment that changed. The handler is
+  intentionally thin so parsing, persistence, and notification decisions remain
+  owned by the mention domain modules.
+  """
 
   alias GroupherServer.CMS
   alias CMS.Events.Event

--- a/backend/main/lib/groupher_server/cms/model/abuse_report.ex
+++ b/backend/main/lib/groupher_server/cms/model/abuse_report.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.CMS.Model.AbuseReport do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for user-submitted abuse reports.
+
+  Report records connect a reporter, source content, and moderation case payload
+  so audit/review workflows can process unsafe content independently of the
+  source article or comment table.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/article_collect.ex
+++ b/backend/main/lib/groupher_server/cms/model/article_collect.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.ArticleCollect do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for article collect/bookmark rows.
+
+  Each row binds a user to one concrete artiment thread item. Account collect
+  folders may embed references to these rows for grouped collection views.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/article_upvote.ex
+++ b/backend/main/lib/groupher_server/cms/model/article_upvote.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.ArticleUpvote do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for article upvote rows.
+
+  The schema enforces one upvote per user/source item and lets article counters
+  and user achievement reputation be updated from a durable relation.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/article_user_emotion.ex
+++ b/backend/main/lib/groupher_server/cms/model/article_user_emotion.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.ArticleUserEmotion do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for per-user article emotion reactions.
+
+  Emotion rows are separate from upvotes so lightweight reaction state can be
+  toggled without changing ranking/vote semantics.
+  """
 
   use Ecto.Schema
 

--- a/backend/main/lib/groupher_server/cms/model/artiment_mention.ex
+++ b/backend/main/lib/groupher_server/cms/model/artiment_mention.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.CMS.Model.ArtimentMention do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for CMS mention graph facts.
+
+  A row records one mentioner artiment, one mentioned internal/external target,
+  and occurrence details. Messaging delivery consumes these facts but does not
+  own this schema.
+  """
 
   alias __MODULE__
 

--- a/backend/main/lib/groupher_server/cms/model/author.ex
+++ b/backend/main/lib/groupher_server/cms/model/author.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.Author do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for article author snapshots.
+
+  The author row links CMS content to the account user while preserving CMS-side
+  author metadata used by article queries and GraphQL responses.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/blog.ex
+++ b/backend/main/lib/groupher_server/cms/model/blog.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.Blog do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for blog artiments.
+
+  Blog shares the article workflow shape with other artiment threads while
+  keeping its own table, constraints, meta embed, and community joins.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/category.ex
+++ b/backend/main/lib/groupher_server/cms/model/category.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.Category do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for community categories.
+
+  Categories group communities at the discovery/navigation layer and are joined
+  to communities through `CommunityCategory`.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/changelog.ex
+++ b/backend/main/lib/groupher_server/cms/model/changelog.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.Changelog do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for changelog artiments.
+
+  Changelogs use the shared article publishing and reaction machinery while
+  representing release/update content in a dedicated table.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/comment.ex
+++ b/backend/main/lib/groupher_server/cms/model/comment.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.CMS.Model.Comment do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for comments across article threads.
+
+  Comment rows carry source-thread foreign keys, author data, floor/reply state,
+  and moderation/reaction embeds. Keep public comment identity separate from
+  internal database ids when exposing this schema through GraphQL.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/comment_reply.ex
+++ b/backend/main/lib/groupher_server/cms/model/comment_reply.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommentReply do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for reply relationships between comments.
+
+  The row links a comment to the comment it replies to so reply trees can be
+  queried without overloading the main comment record.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/comment_upvote.ex
+++ b/backend/main/lib/groupher_server/cms/model/comment_upvote.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommentUpvote do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for comment upvote rows.
+
+  Comment upvotes are tracked separately from article upvotes because they affect
+  comment-level viewer state and counters.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/comment_user_emotion.ex
+++ b/backend/main/lib/groupher_server/cms/model/comment_user_emotion.ex
@@ -1,5 +1,9 @@
 defmodule GroupherServer.CMS.Model.CommentUserEmotion do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for per-user comment emotion reactions.
+
+  This keeps expressive reaction state independent from comment upvote state.
+  """
 
   use Ecto.Schema
 

--- a/backend/main/lib/groupher_server/cms/model/community.ex
+++ b/backend/main/lib/groupher_server/cms/model/community.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.Community do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for communities.
+
+  A community is the main CMS container for threads, dashboard settings, tags,
+  subscribers, moderators, and public navigation identity.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_category.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_category.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityCategory do
-  @moduledoc false
+  @moduledoc """
+  Join schema linking communities to discovery categories.
+
+  The relation supports category-filtered community listing without embedding
+  category state into the community row.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_dashboard.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_dashboard.ex
@@ -1,7 +1,13 @@
 defmodule GroupherServer.CMS.Model.CommunityDashboard do
   @type t :: %__MODULE__{}
 
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for persisted community dashboard configuration.
+
+  The dashboard row stores editable presentation sections such as base info,
+  wallpaper, SEO, layout, enabled threads, links, social links, and docs FAQ.
+  Domain write helpers normalize section payloads before updating this schema.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_join_blog.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_join_blog.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityJoinBlog do
-  @moduledoc false
+  @moduledoc """
+  Join schema linking communities to blog artiments.
+
+  Thread-specific join tables keep community membership/query constraints clear
+  while each artiment type keeps its own content table.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_join_changelog.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_join_changelog.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityJoinChangelog do
-  @moduledoc false
+  @moduledoc """
+  Join schema linking communities to changelog artiments.
+
+  It lets changelog content stay in its own table while community feeds can query
+  membership and ordering through a dedicated relation.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_join_doc.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_join_doc.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityJoinDoc do
-  @moduledoc false
+  @moduledoc """
+  Join schema linking communities to published docs.
+
+  Docs have their own identity and publish workflow; this relation anchors the
+  published doc into a community surface.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_join_post.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_join_post.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityJoinPost do
-  @moduledoc false
+  @moduledoc """
+  Join schema linking communities to post artiments.
+
+  The join keeps post membership explicit for community feeds, tag stats, and
+  moderation queries.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_join_tag.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_join_tag.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityJoinTag do
-  @moduledoc false
+  @moduledoc """
+  Join schema linking artiments to community tags.
+
+  The relation stores tag assignments by thread/source item so tag filtering does
+  not need to mutate the source article row.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_moderator.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_moderator.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityModerator do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for community moderator membership.
+
+  Moderator rows grant community-level permissions and back account surfaces that
+  list where a user can moderate.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_subscriber.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_subscriber.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunitySubscriber do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for community subscriptions.
+
+  Subscription rows connect users to communities and are the source for
+  denormalized subscriber ids/counts on user and community meta.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_tag.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_tag.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityTag do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for tags configured inside a community.
+
+  Tags are community-scoped presentation/filter entities. Assignments to content
+  are stored through `CommunityJoinTag`.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_tag_group.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_tag_group.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityTagGroup do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for grouping community tags.
+
+  Tag groups organize tag presentation per thread without changing the tag's
+  identity or content assignments.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/community_tag_stat.ex
+++ b/backend/main/lib/groupher_server/cms/model/community_tag_stat.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CommunityTagStat do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for per-tag article counters in a community.
+
+  These rows cache tag usage by thread/source so tag bars and dashboards avoid
+  recounting joins on each request.
+  """
 
   use Ecto.Schema
   use Accessible

--- a/backend/main/lib/groupher_server/cms/model/cover_background.ex
+++ b/backend/main/lib/groupher_server/cms/model/cover_background.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CoverBackground do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for reusable cover background assets.
+
+  Cover editing stores background choices by id so article/doc cover payloads can
+  reuse curated background definitions instead of duplicating image metadata.
+  """
 
   alias __MODULE__
 

--- a/backend/main/lib/groupher_server/cms/model/cover_edit_info.ex
+++ b/backend/main/lib/groupher_server/cms/model/cover_edit_info.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.CoverEditInfo do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for reusable article/doc cover editing state.
+
+  The row stores canvas dimensions plus light/dark cover configs so authored
+  cover layouts can be reconstructed in the dashboard editor.
+  """
 
   alias __MODULE__
 
@@ -43,7 +48,12 @@ defmodule GroupherServer.CMS.Model.CoverEditInfo do
   def update_changeset(%CoverEditInfo{} = info, attrs), do: changeset(info, attrs)
 
   defmodule CoverConfig do
-    @moduledoc false
+    @moduledoc """
+    Embedded schema for one theme branch of cover editor configuration.
+
+    It stores the selected background and ordered image layers used by the cover
+    renderer.
+    """
 
     use Ecto.Schema
     use Accessible

--- a/backend/main/lib/groupher_server/cms/model/embeds/community_meta.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/community_meta.ex
@@ -1,6 +1,11 @@
 defmodule GroupherServer.CMS.Model.Embeds.CommunityMeta.Macro do
 
-  @moduledoc false
+  @moduledoc """
+  Macro helpers for config-driven fields in `CommunityMeta`.
+
+  Thread counts and inner-id indexes are generated from article thread config so
+  new thread types do not require hand-editing this embed.
+  """
 
   import Helper.Utils, only: [get_config: 2, plural: 1]
 

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard/link.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard/link.ex
@@ -1,7 +1,12 @@
 defmodule GroupherServer.CMS.Model.Embeds.Dashboard.Link do
   @type t :: %__MODULE__{}
 
-  @moduledoc false
+  @moduledoc """
+  Embedded schema for one dashboard navigation link or group.
+
+  A `:link` item requires a URL and no children; a `:group` item owns child
+  links and should not carry its own URL.
+  """
   use Ecto.Schema
   use Accessible
 

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard/link_child.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard/link_child.ex
@@ -1,7 +1,11 @@
 defmodule GroupherServer.CMS.Model.Embeds.Dashboard.LinkChild do
   @type t :: %__MODULE__{}
 
-  @moduledoc false
+  @moduledoc """
+  Embedded schema for child links inside dashboard link groups.
+
+  Child links are the flat leaf nodes rendered in header/footer dropdowns.
+  """
   use Ecto.Schema
   use Accessible
 

--- a/backend/main/lib/groupher_server/cms/model/embeds/dashboard/wallpaper.ex
+++ b/backend/main/lib/groupher_server/cms/model/embeds/dashboard/wallpaper.ex
@@ -30,7 +30,13 @@ defmodule GroupherServer.CMS.Model.Embeds.Dashboard.Wallpaper do
   end
 
   defmodule BgConfig do
-    @moduledoc false
+    @moduledoc """
+    Embedded schema for one theme branch of dashboard wallpaper config.
+
+    The fields are generated from dashboard GraphQL field metadata and validated
+    through `BgConfigValidator` so frontend wallpaper controls and backend
+    storage share the same accepted shape.
+    """
 
     use Ecto.Schema
     use Accessible

--- a/backend/main/lib/groupher_server/cms/model/passport.ex
+++ b/backend/main/lib/groupher_server/cms/model/passport.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.Passport do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for community passport/rule configuration.
+
+  A passport belongs to the editing user and stores the rules that gate or
+  describe community access.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/pinned_article.ex
+++ b/backend/main/lib/groupher_server/cms/model/pinned_article.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.PinnedArticle do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for pinned article records.
+
+  The row marks a concrete artiment thread item as pinned without moving or
+  duplicating the source article.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/pinned_comment.ex
+++ b/backend/main/lib/groupher_server/cms/model/pinned_comment.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.PinnedComment do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for pinned comments.
+
+  Pin records keep presentation ordering separate from the comment's own content
+  and reply state.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/cms/model/post.ex
+++ b/backend/main/lib/groupher_server/cms/model/post.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Model.Post do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for post artiments.
+
+  Posts are the default discussion thread and share the CMS article workflow:
+  author, community join, tags, reactions, comments, and publish state.
+  """
 
   alias __MODULE__
 

--- a/backend/main/lib/groupher_server/cms/search/article.ex
+++ b/backend/main/lib/groupher_server/cms/search/article.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.CMS.Search.Article do
-  @moduledoc false
+  @moduledoc """
+  Lightweight title search for CMS article threads.
+
+  The search entrypoint receives a public thread atom, resolves it through the
+  artiment matcher, and runs the same bounded paginator for posts, blogs,
+  changelogs, or docs.
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]

--- a/backend/main/lib/groupher_server/cms/search/community.ex
+++ b/backend/main/lib/groupher_server/cms/search/community.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.CMS.Search.Community do
-  @moduledoc false
+  @moduledoc """
+  Lightweight community search used by public and viewer-aware surfaces.
+
+  Anonymous searches return matching communities by title, slug, or aka. Viewer
+  searches enrich each entry with subscription state without changing the base
+  pagination contract.
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]

--- a/backend/main/lib/groupher_server/cms/seeds/articles.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/articles.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Seeds.Articles do
-  @moduledoc false
+  @moduledoc """
+  Seed helpers for inserting sample CMS articles.
+
+  These helpers support development/demo data setup and should not be used by
+  runtime write paths.
+  """
 
   import GroupherServer.Support.Factory
   import Helper.Utils, only: [get_config: 2]

--- a/backend/main/lib/groupher_server/cms/seeds/categories.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/categories.ex
@@ -1,5 +1,9 @@
 defmodule GroupherServer.CMS.Seeds.Categories do
-  @moduledoc false
+  @moduledoc """
+  Seed helpers for community category fixtures.
+
+  Category seed data gives local/dev communities predictable discovery grouping.
+  """
   @doc """
   default categories seeds for general community
   """

--- a/backend/main/lib/groupher_server/cms/seeds/clean_up.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/clean_up.ex
@@ -1,5 +1,9 @@
 defmodule GroupherServer.CMS.Seeds.CleanUp do
-  @moduledoc false
+  @moduledoc """
+  Cleanup helpers for seed data reset.
+
+  Use this only from seed/setup flows where destructive cleanup is expected.
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]

--- a/backend/main/lib/groupher_server/cms/seeds/comments.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/comments.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Seeds.Comments do
-  @moduledoc false
+  @moduledoc """
+  Seed helpers for sample comments and replies.
+
+  The module creates development comment data that exercises article detail and
+  conversation UI paths.
+  """
 
   import GroupherServer.Support.Factory
   import Helper.Utils, only: [get_config: 2]

--- a/backend/main/lib/groupher_server/cms/seeds/config.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/config.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Seeds.Config do
-  @moduledoc false
+  @moduledoc """
+  Static configuration used by CMS seed flows.
+
+  Keep seed-only constants here so demo data choices do not leak into runtime
+  CMS defaults.
+  """
 
   @tag_threads [:post, :changelog, :kanban, :doc, :about]
   @content_threads [:post, :changelog, :doc]

--- a/backend/main/lib/groupher_server/cms/seeds/full_community.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/full_community.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Seeds.FullCommunity do
-  @moduledoc false
+  @moduledoc """
+  End-to-end seed flow for a full demo community.
+
+  It coordinates community, category, thread, article, and comment seeds for
+  local environments that need realistic content.
+  """
 
   import Ecto.Query, warn: false
 

--- a/backend/main/lib/groupher_server/cms/seeds/helper.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/helper.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Seeds.Helper do
-  @moduledoc false
+  @moduledoc """
+  Shared utility helpers for CMS seed modules.
+
+  Seed modules use this for reusable lookup, randomization, and fixture helpers
+  while keeping runtime helpers separate.
+  """
 
   import ShortMaps
 

--- a/backend/main/lib/groupher_server/cms/seeds/threads.ex
+++ b/backend/main/lib/groupher_server/cms/seeds/threads.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.CMS.Seeds.Threads do
-  @moduledoc false
+  @moduledoc """
+  Seed helpers for enabling community threads.
+
+  The returned thread lists define which product surfaces each seeded community
+  exposes in local/demo data.
+  """
 
   def get(:home), do: []
 

--- a/backend/main/lib/groupher_server/logs/user_activity.ex
+++ b/backend/main/lib/groupher_server/logs/user_activity.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Logs.UserActivity do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for user activity log entries.
+
+  The log records which content source a user interacted with so audit and
+  activity surfaces can be built without joining every source table.
+  """
   # alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/messaging/inbox.ex
+++ b/backend/main/lib/groupher_server/messaging/inbox.ex
@@ -1,5 +1,18 @@
 defmodule GroupherServer.Messaging.Inbox do
-  @moduledoc false
+  @moduledoc """
+  Facade for mailbox message operations across message types.
+
+  Account code calls this module with a message type, then the facade delegates
+  to the concrete mention or notification store.
+
+      Accounts.Mailbox
+          |
+          v
+      Messaging.Inbox
+          |
+          +--> Mentions
+          +--> Notifications
+  """
 
   alias GroupherServer.Messaging.{Mentions, Notifications}
 

--- a/backend/main/lib/groupher_server/messaging/mentions.ex
+++ b/backend/main/lib/groupher_server/messaging/mentions.ex
@@ -1,5 +1,24 @@
 defmodule GroupherServer.Messaging.Mentions do
-  @moduledoc false
+  @moduledoc """
+  Stores direct mention messages shown in a user's inbox.
+
+  Mention rows are viewer-facing mailbox items, separate from the CMS mention
+  fact graph. Sending mentions replaces the previous rows for the same content
+  and author, inserts the current recipients, then refreshes affected mailbox
+  counters.
+
+      CMS content save
+          |
+          v
+      mention recipients
+          |
+          v
+      Messaging.Mentions.send/3
+          |
+          +--> delete old rows for this content/author
+          +--> insert current recipient rows
+          +--> Accounts.Mailbox.update_status_many/1
+  """
 
   import Ecto.Query, warn: false
   import Helper.Utils, only: [done: 1]

--- a/backend/main/lib/groupher_server/messaging/model/mention.ex
+++ b/backend/main/lib/groupher_server/messaging/model/mention.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.Messaging.Model.Mention do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for direct mention inbox rows.
+
+  Mention rows are delivery records for users who were mentioned in a piece of
+  content. They are separate from CMS mention facts, which describe the content
+  graph regardless of mailbox delivery.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/messaging/model/notification.ex
+++ b/backend/main/lib/groupher_server/messaging/model/notification.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Messaging.Model.Notification do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for grouped activity notifications.
+
+  Notifications collect one or more actors around a target action so inbox UI can
+  show compact activity rows instead of one row per repeated action.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/messaging/notifications.ex
+++ b/backend/main/lib/groupher_server/messaging/notifications.ex
@@ -1,5 +1,22 @@
 defmodule GroupherServer.Messaging.Notifications do
-  @moduledoc false
+  @moduledoc """
+  Stores grouped activity notifications for a user's inbox.
+
+  Unlike direct mentions, notifications can merge repeated activity into an
+  existing row for a configured period. Revoking activity removes one actor from
+  a grouped notification or deletes the row when no actors remain.
+
+      activity event
+          |
+          v
+      validate action + target user
+          |
+          v
+      create / merge / revoke notification
+          |
+          v
+      refresh mailbox status
+  """
 
   import Ecto.Query, warn: false
 

--- a/backend/main/lib/groupher_server/messaging/notify.ex
+++ b/backend/main/lib/groupher_server/messaging/notify.ex
@@ -2,9 +2,9 @@ defmodule GroupherServer.Messaging.Notify do
   @moduledoc """
   Placeholder dispatch boundary for future async notification delivery.
 
-  Today the function validates the event shape and returns `:pass`. Keeping the
-  boundary explicit lets callers depend on a stable notification dispatch API
-  while delivery channels are added later.
+  Today the function validates the event shape and returns `{:ok, :pass}`.
+  Keeping the boundary explicit lets callers depend on a stable notification
+  dispatch API while delivery channels are added later.
   """
 
   @spec dispatch(atom(), map()) :: {:ok, :pass} | {:error, term()}

--- a/backend/main/lib/groupher_server/messaging/notify.ex
+++ b/backend/main/lib/groupher_server/messaging/notify.ex
@@ -1,5 +1,11 @@
 defmodule GroupherServer.Messaging.Notify do
-  @moduledoc false
+  @moduledoc """
+  Placeholder dispatch boundary for future async notification delivery.
+
+  Today the function validates the event shape and returns `:pass`. Keeping the
+  boundary explicit lets callers depend on a stable notification dispatch API
+  while delivery channels are added later.
+  """
 
   @spec dispatch(atom(), map()) :: {:ok, :pass} | {:error, term()}
   def dispatch(event, payload) when is_atom(event) and is_map(payload) do

--- a/backend/main/lib/groupher_server/statistics/model/community_contribute.ex
+++ b/backend/main/lib/groupher_server/statistics/model/community_contribute.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Statistics.Model.CommunityContribute do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for daily community contribution counters.
+
+  Community dashboards use these date-bucketed rows to render activity trends
+  without scanning article/comment history on every request.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/statistics/model/publish_throttle.ex
+++ b/backend/main/lib/groupher_server/statistics/model/publish_throttle.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Statistics.Model.PublishThrottle do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for publish-rate throttle records.
+
+  These rows let middleware/domain code track publishing frequency per actor and
+  apply rate limits without coupling that state to article tables.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/statistics/model/user_contribute.ex
+++ b/backend/main/lib/groupher_server/statistics/model/user_contribute.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Statistics.Model.UserContribute do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for daily user contribution counters.
+
+  Statistics jobs and middleware aggregate user activity into these date-bucketed
+  rows for profile contribution charts.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server/statistics/model/user_geo_info.ex
+++ b/backend/main/lib/groupher_server/statistics/model/user_geo_info.ex
@@ -1,5 +1,9 @@
 defmodule GroupherServer.Statistics.Model.UserGeoInfo do
-  @moduledoc false
+  @moduledoc """
+  Ecto schema for user geo metadata used by statistics surfaces.
+
+  Keep this as derived analytics state, not account identity state.
+  """
   alias __MODULE__
 
   use Ecto.Schema

--- a/backend/main/lib/groupher_server_web/middleware/convert_to_int.ex
+++ b/backend/main/lib/groupher_server_web/middleware/convert_to_int.ex
@@ -3,7 +3,13 @@
 # see https://hexdocs.pm/absinthe/Absinthe.Middleware.html#content
 # ---
 defmodule GroupherServerWeb.Middleware.ConvertToInt do
-  @moduledoc false
+  @moduledoc """
+  Normalizes aggregate-list resolver results into a single integer value.
+
+  SQL aggregate paths sometimes surface as `[value]` or `[]` through Absinthe.
+  This middleware unwraps the one-value case and treats an empty aggregate result
+  as zero.
+  """
   @behaviour Absinthe.Middleware
   # google: must appear in the GROUP BY clause or be used in an aggregate function
 

--- a/backend/main/lib/groupher_server_web/middleware/count_length.ex
+++ b/backend/main/lib/groupher_server_web/middleware/count_length.ex
@@ -2,7 +2,12 @@
 # see https://hexdocs.pm/absinthe/Absinthe.Middleware.html#content
 # ---
 defmodule GroupherServerWeb.Middleware.CountLength do
-  @moduledoc false
+  @moduledoc """
+  Converts list-valued resolver results into their count for GraphQL metrics.
+
+  Use this only at schema fields whose public contract is an integer count, not
+  at fields that should expose the list itself.
+  """
   @behaviour Absinthe.Middleware
   # google: must appear in the GROUP BY clause or be used in an aggregate function
 

--- a/backend/main/lib/groupher_server_web/middleware/put_current_user.ex
+++ b/backend/main/lib/groupher_server_web/middleware/put_current_user.ex
@@ -3,7 +3,17 @@
 # see https://hexdocs.pm/absinthe/Absinthe.Middleware.html#content
 # ---
 defmodule GroupherServerWeb.Middleware.PutCurrentUser do
-  @moduledoc false
+  @moduledoc """
+  Copies the authenticated viewer from Absinthe context into field arguments.
+
+      context.cur_user
+          |
+          v
+      resolution.arguments.cur_user
+
+  Use this middleware when downstream resolver code expects the viewer in the
+  argument map instead of reading from the Absinthe context directly.
+  """
   @behaviour Absinthe.Middleware
 
   def call(%{context: %{cur_user: cur_user}} = resolution, _) do

--- a/backend/main/lib/groupher_server_web/middleware/put_root_source.ex
+++ b/backend/main/lib/groupher_server_web/middleware/put_root_source.ex
@@ -3,7 +3,14 @@
 # see https://hexdocs.pm/absinthe/Absinthe.Middleware.html#content
 # ---
 defmodule GroupherServerWeb.Middleware.PutRootSource do
-  @moduledoc false
+  @moduledoc """
+  Copies a parent resolver source id into child-field arguments.
+
+  This middleware is used by nested GraphQL fields that need the parent object's
+  id while still calling a resolver that reads from `resolution.arguments`.
+  Preserve the current argument name unless the consuming resolver contract is
+  migrated at the same time.
+  """
   @behaviour Absinthe.Middleware
 
   # def call(%{source: %{id: id}} = resolution, _) do

--- a/backend/main/lib/groupher_server_web/middleware/see_me.ex
+++ b/backend/main/lib/groupher_server_web/middleware/see_me.ex
@@ -3,7 +3,12 @@
 # see https://hexdocs.pm/absinthe/Absinthe.Middleware.html#content
 # ---
 defmodule GroupherServerWeb.Middleware.SeeMe do
-  @moduledoc false
+  @moduledoc """
+  No-op middleware reserved for resolver inspection during GraphQL debugging.
+
+  Keeping this as an explicit middleware makes it possible to attach temporary
+  breakpoints or logging in one place without changing schema definitions.
+  """
   @behaviour Absinthe.Middleware
 
   def call(resolution, _) do

--- a/backend/main/lib/groupher_server_web/middleware/statistics/make_contribute.ex
+++ b/backend/main/lib/groupher_server_web/middleware/statistics/make_contribute.ex
@@ -3,7 +3,20 @@
 # see https://hexdocs.pm/absinthe/Absinthe.Middleware.html#content
 # ---
 defmodule GroupherServerWeb.Middleware.Statistics.MakeContribute do
-  @moduledoc false
+  @moduledoc """
+  Refreshes contribution aggregates after a successful GraphQL field resolves.
+
+      resolver result
+          |
+          v
+      MakeContribute
+          |
+          +--> Statistics.make_contribute(user)
+          +--> Statistics.make_contribute(community)
+
+  The middleware is side-effect only and leaves the Absinthe resolution value
+  unchanged.
+  """
 
   @behaviour Absinthe.Middleware
   # google: must appear in the GROUP BY clause or be used in an aggregate function

--- a/backend/main/lib/groupher_server_web/middleware/viewer_did_convert.ex
+++ b/backend/main/lib/groupher_server_web/middleware/viewer_did_convert.ex
@@ -4,7 +4,13 @@
 # ---
 
 defmodule GroupherServerWeb.Middleware.ViewerDidConvert do
-  @moduledoc false
+  @moduledoc """
+  Converts viewer-state lookup results into GraphQL booleans.
+
+  Several viewer state resolvers return a list from an existence query. This
+  middleware turns nil/empty results into `false` and a single matched row into
+  `true` for public schema fields.
+  """
   @behaviour Absinthe.Middleware
 
   def call(%{value: nil} = resolution, _) do

--- a/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
+++ b/backend/main/lib/groupher_server_web/resolvers/cms_resolver.ex
@@ -1,5 +1,23 @@
 defmodule GroupherServerWeb.Resolvers.CMS do
-  @moduledoc false
+  @moduledoc """
+  Absinthe resolver boundary for CMS-facing queries and mutations.
+
+  This module keeps GraphQL concerns at the edge: it unpacks typed arguments,
+  reads authenticated viewer context when present, and delegates domain work to
+  `GroupherServer.CMS` modules. It should not own persistence rules.
+
+      GraphQL field
+          |
+          v
+      Resolvers.CMS
+          |
+          +--> CMS.Communities / CMS.Articles / CMS.DocTree
+          +--> CMS.DocCover / CMS.Dashboard / CMS.Comments
+
+  The resolver layer is also where public API terms such as article/comment
+  paths are translated into backend calls. Keep internal database ids and public
+  path contracts separate here.
+  """
 
   import ShortMaps
   import Ecto.Query, warn: false

--- a/backend/main/lib/groupher_server_web/router.ex
+++ b/backend/main/lib/groupher_server_web/router.ex
@@ -1,5 +1,15 @@
 defmodule GroupherServerWeb.Router do
-  @moduledoc false
+  @moduledoc """
+  Phoenix router for server-rendered health, OG, and GraphQL tooling endpoints.
+
+      /
+      /health
+      /api/og-info
+      /graphiql
+
+  Frontend application routes are owned by the Next.js apps; this router keeps
+  only backend HTTP surfaces that Phoenix serves directly.
+  """
 
   use GroupherServerWeb, :router
 

--- a/backend/main/lib/groupher_server_web/schema/account/account_metrics.ex
+++ b/backend/main/lib/groupher_server_web/schema/account/account_metrics.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServerWeb.Schema.Account.Metrics do
-  @moduledoc false
+  @moduledoc """
+  Absinthe field groups for account metrics.
+
+  These definitions keep metric field names and middleware close to the account
+  schema layer while resolver behavior remains in account/statistics modules.
+  """
 
   use Absinthe.Schema.Notation
   import GroupherServerWeb.Schema.Helper.Fields

--- a/backend/main/lib/groupher_server_web/schema/statistics/statistics_types.ex
+++ b/backend/main/lib/groupher_server_web/schema/statistics/statistics_types.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServerWeb.Schema.Statistics.Types do
-  @moduledoc false
+  @moduledoc """
+  Absinthe object types for statistics and contribution summaries.
+
+  The statistics domain owns the calculations; this module describes the public
+  GraphQL shape used by frontend dashboards and profile surfaces.
+  """
   use Absinthe.Schema.Notation
 
   # import GroupherServerWeb.Schema.Helper.Fields

--- a/backend/main/lib/helper/converter/editor_to_html/validator/editor_schema.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/validator/editor_schema.ex
@@ -1,5 +1,10 @@
 defmodule Helper.Converter.EditorToHTML.Validator.EditorSchema do
-  @moduledoc false
+  @moduledoc """
+  Schema definitions for legacy Editor.js blocks accepted by the HTML converter.
+
+  Keep this module as data-only validation metadata. Conversion logic belongs in
+  the editor-to-HTML fragments.
+  """
 
   # header
   @valid_header_level [1, 2, 3]

--- a/backend/main/lib/helper/converter/editor_to_html/validator/index.ex
+++ b/backend/main/lib/helper/converter/editor_to_html/validator/index.ex
@@ -1,5 +1,11 @@
 defmodule Helper.Converter.EditorToHTML.Validator do
-  @moduledoc false
+  @moduledoc """
+  Validates legacy Editor.js payloads before HTML conversion.
+
+  The validator checks the top-level editor shape, then validates each supported
+  block against `EditorSchema`. It returns converter-friendly errors instead of
+  leaking raw changeset/schema failures.
+  """
 
   alias Helper.{Converter, Validator}
 

--- a/backend/main/lib/helper/converter/html_sanitizer.ex
+++ b/backend/main/lib/helper/converter/html_sanitizer.ex
@@ -5,7 +5,12 @@ defmodule Helper.Converter.HtmlSanitizer do
   see; http://katafrakt.me/2016/09/03/custom-rules-in-htmlsanitizeex/
   """
   defmodule Scrubber do
-    @moduledoc false
+    @moduledoc """
+    HtmlSanitizeEx scrubber policy for editor-rendered HTML.
+
+    The policy allows the tags and attributes produced by the article converter
+    while stripping comments, CDATA, unsafe URI schemes, and unsupported markup.
+    """
 
     require HtmlSanitizeEx.Scrubber.Meta
     alias HtmlSanitizeEx.Scrubber.Meta

--- a/backend/main/lib/helper/og_info.ex
+++ b/backend/main/lib/helper/og_info.ex
@@ -1,5 +1,19 @@
 defmodule Helper.OgInfo do
-  @moduledoc false
+  @moduledoc """
+  Fetches and normalizes Open Graph metadata for external URLs.
+
+  The helper validates URLs before network access, follows the site-favicon
+  adapter for page/favicon loading, and returns the compact metadata shape used
+  by link previews.
+
+      input URL
+          |
+          v
+      UrlSafety.validate_http_url/1
+          |
+          v
+      SiteFavicon adapter -> OpenGraph.parse/1 -> favicon merge
+  """
   import Helper.Utils, only: [done: 1]
 
   alias Helper.UrlSafety

--- a/backend/main/lib/support/factory/articles.ex
+++ b/backend/main/lib/support/factory/articles.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Support.Factory.Articles do
-  @moduledoc false
+  @moduledoc """
+  Test factory helpers for CMS article schemas.
+
+  Factories centralize valid article/thread attributes so tests do not duplicate
+  schema defaults.
+  """
 
   alias GroupherServer.Support.FakeData
   alias Helper.Datetime

--- a/backend/main/lib/support/factory/oauth.ex
+++ b/backend/main/lib/support/factory/oauth.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Support.Factory.Oauth do
-  @moduledoc false
+  @moduledoc """
+  Test factory helpers for OAuth provider payloads.
+
+  Use these fixtures when account/OAuth tests need realistic provider identity
+  maps without hitting external services.
+  """
 
   alias GroupherServer.Support.FakeData
 

--- a/backend/main/lib/support/fake_data.ex
+++ b/backend/main/lib/support/fake_data.ex
@@ -1,5 +1,10 @@
 defmodule GroupherServer.Support.FakeData do
-  @moduledoc false
+  @moduledoc """
+  Test/support fake data helpers.
+
+  These functions provide deterministic sample payloads for factories, tests,
+  and local support code outside production flows.
+  """
 
   @first_names ~w(Ada Alan Grace Linus Yukihiro Jose Sophie Alex Morgan Taylor)
   @companies ~w(Orbit Labs CoderPlanets Byte Garden Graph Studio Kernel Works)

--- a/backend/main/lib/support/fake_data.ex
+++ b/backend/main/lib/support/fake_data.ex
@@ -2,8 +2,9 @@ defmodule GroupherServer.Support.FakeData do
   @moduledoc """
   Test/support fake data helpers.
 
-  These functions provide deterministic sample payloads for factories, tests,
-  and local support code outside production flows.
+  These functions provide sample payloads for factories, tests, and local
+  support code outside production flows. Values may include randomized picks and
+  monotonic unique suffixes so callers can avoid fixture collisions.
   """
 
   @first_names ~w(Ada Alan Grace Linus Yukihiro Jose Sophie Alex Morgan Taylor)

--- a/frontend/core/hooks/useDidMount/index.ts
+++ b/frontend/core/hooks/useDidMount/index.ts
@@ -1,6 +1,12 @@
 // ~/hooks/useDidMount.ts
 import { useEffect, useState } from 'react'
 
+/**
+ * Returns true only after the component has mounted on the client.
+ *
+ * Use this when a render branch depends on browser-only APIs but should still
+ * produce deterministic markup during SSR/hydration.
+ */
 export default function useDidMount(): boolean {
   const [didMount, setDidMount] = useState(false)
 

--- a/frontend/core/hooks/useDsbCrumbItems/index.ts
+++ b/frontend/core/hooks/useDsbCrumbItems/index.ts
@@ -64,6 +64,13 @@ const buildActiveChain = (relative: string, root: TDsbCrumbNode): TDsbCrumbNode[
   return chain
 }
 
+/**
+ * Resolves dashboard breadcrumbs from route segments and a declared crumb tree.
+ *
+ * Route matching (`seg`) and navigation target (`toSeg`) are intentionally
+ * separate so product labels can keep stable breadcrumbs while individual pages
+ * move under different dashboard URLs.
+ */
 export default function useDsbCrumbItems(root: TDsbCrumbNode): TBreadcrumbItem[] {
   const pathname = usePathname()
   const { slug } = useCommunity()

--- a/frontend/core/hooks/useGraphQLClient.ts
+++ b/frontend/core/hooks/useGraphQLClient.ts
@@ -24,6 +24,14 @@ const clarifyVariables = <TVars extends AnyVariables>(variables?: TVars): TVars 
   return clarify((variables ?? {}) as TClarifyInput) as TVars
 }
 
+/**
+ * Imperative GraphQL client wrapper for event handlers and store actions.
+ *
+ * urql cache objects often contain `__typename`, but mutation inputs cannot
+ * send that field back to Absinthe. The wrapper recursively strips it from
+ * variables, unwraps urql promises, and throws GraphQL/network errors so callers
+ * can use ordinary try/catch flows.
+ */
 export default function useGraphQL() {
   const client = useClient()
 

--- a/frontend/core/hooks/useHeaderLinks/helper.ts
+++ b/frontend/core/hooks/useHeaderLinks/helper.ts
@@ -31,6 +31,12 @@ type TCustomHeaderLinkType = typeof DASHBOARD_LINK_TYPE.LINK | typeof DASHBOARD_
 
 type TMoreTabLinkItem = Extract<TResolvedHeaderLinkItem, { usage: typeof MORE_TAB.USAGE }>
 
+/**
+ * Type guard for the resolved synthetic More tab.
+ *
+ * The More tab is a render-time group produced by `resolveHeaderLinks`; it is
+ * never persisted back to dashboard headerLinks.
+ */
 export const isMoreTabGroup = (item: TResolvedHeaderLinkItem): item is TMoreTabLinkItem =>
   item.type === DASHBOARD_LINK_TYPE.GROUP && 'usage' in item && item.usage === MORE_TAB.USAGE
 
@@ -132,6 +138,13 @@ const asMoreTabLink = (id: string, title: string, url: string): TLinkChild => ({
 export const shouldFoldAboutToMore = (links: readonly TLinkItem[]): boolean =>
   hasCustomHeaderItems(links)
 
+/**
+ * Builds the navigation-ready header links for a community.
+ *
+ * Dashboard stores only user-authored links. This resolver removes fixed About /
+ * Dashboard duplicates, folds those fixed entries into a synthetic More group
+ * when custom links exist, and adds the Dashboard link only for moderators.
+ */
 export const resolveHeaderLinks = (
   links: readonly TLinkItem[],
   community: string,

--- a/frontend/core/hooks/useHeaderLinks/index.ts
+++ b/frontend/core/hooks/useHeaderLinks/index.ts
@@ -12,6 +12,12 @@ type THeaderLinks = {
   getCustomLinks: () => readonly TResolvedHeaderLinkItem[]
 }
 
+/**
+ * Reads dashboard header config and exposes the resolved navigation contract.
+ *
+ * Consumers get both the raw persisted links and a lazy resolver so render paths
+ * can decide when to include synthetic More-tab entries.
+ */
 export default function useHeaderLinks(): THeaderLinks {
   const { headerLayout, headerLinks } = useDashboard()
   const { slug: community } = useCommunity()

--- a/frontend/core/hooks/useInitialNow/index.tsx
+++ b/frontend/core/hooks/useInitialNow/index.tsx
@@ -9,12 +9,18 @@ type TProps = {
 
 const InitialNowContext = createContext<number | null>(null)
 
+/**
+ * Provides the server-captured timestamp used by relative-time rendering.
+ */
 export const InitialNowProvider = ({ children, initialNow }: TProps) => {
   return (
     <InitialNowContext.Provider value={initialNow ?? null}>{children}</InitialNowContext.Provider>
   )
 }
 
+/**
+ * Reads the stable initial timestamp for components that format relative time.
+ */
 export default function useInitialNow(): number | null {
   return useContext(InitialNowContext)
 }

--- a/frontend/core/hooks/usePagedPosts/index.ts
+++ b/frontend/core/hooks/usePagedPosts/index.ts
@@ -17,6 +17,12 @@ type TRes = {
   pagedParams: ReturnType<typeof getPagedArticlesParams>
 }
 
+/**
+ * Reads and updates the current community post-list state.
+ *
+ * The hook keeps URL-derived filters next to the articleList store data so list
+ * pages, tag bars, and refresh actions all talk through the same paging shape.
+ */
 export default function usePagedPosts(): TRes {
   const articleList$ = useArticleList()
   const { slug } = useCommunity()

--- a/frontend/core/hooks/usePagedPosts/useFetchPagedPosts.ts
+++ b/frontend/core/hooks/usePagedPosts/useFetchPagedPosts.ts
@@ -17,6 +17,13 @@ type TRefreshPayload = {
   page?: number
 }
 
+/**
+ * Synchronizes the post list with URL filters and refresh events.
+ *
+ * The request sequence guard prevents stale responses from older filter changes
+ * from overwriting newer list state. The initial server-hydrated list is left in
+ * place until the first real filter or refresh event.
+ */
 export default function useFetchPagedPosts() {
   const searchParams = useSearchParams()
   const { slug } = useCommunity()

--- a/frontend/core/hooks/usePublicThreads/index.ts
+++ b/frontend/core/hooks/usePublicThreads/index.ts
@@ -7,6 +7,13 @@ import type { TCommunityThread, TNameAlias } from '~/spec'
 import useCommunity from '~/stores/community/hooks'
 import useDashboard from '~/stores/dashboard/hooks'
 
+/**
+ * Computes the public thread list after dashboard configuration is applied.
+ *
+ * The community owns raw available threads; dashboard config controls enabled
+ * state, name aliases, and whether About should be hidden from the main nav
+ * because it is folded into the header More tab.
+ */
 export default function usePublicThreads(): TCommunityThread[] {
   const dsb$ = useDashboard()
   const { slug, threads } = useCommunity()

--- a/frontend/core/hooks/useThemePreset.ts
+++ b/frontend/core/hooks/useThemePreset.ts
@@ -1,5 +1,11 @@
 import useThemePresetStore from '~/stores/ThemePreset/hooks'
 
+/**
+ * Public hook alias for the ThemePreset store.
+ *
+ * Keeping this hook in `~/hooks` gives feature components a stable import path
+ * while the Valtio store implementation stays under `~/stores/ThemePreset`.
+ */
 export default function useThemePreset() {
   return useThemePresetStore()
 }

--- a/frontend/core/lib/angle.ts
+++ b/frontend/core/lib/angle.ts
@@ -1,3 +1,9 @@
+/**
+ * Normalizes any angle into the -180..180 range.
+ *
+ * Controls such as AngleWheel need this signed range so dragging across 0/360
+ * does not create a visible jump.
+ */
 export const normalizeSignedAngle = (angle: number): number => {
   const rounded = Math.round(angle)
   const normalized = ((rounded % 360) + 360) % 360
@@ -6,6 +12,9 @@ export const normalizeSignedAngle = (angle: number): number => {
   return normalized > 180 ? normalized - 360 : normalized
 }
 
+/**
+ * Returns the shortest distance between two circular angles.
+ */
 export const circularAngleDistance = (angle: number, target: number): number => {
   const diff = Math.abs(normalizeSignedAngle(angle) - normalizeSignedAngle(target))
 

--- a/frontend/core/lib/color.ts
+++ b/frontend/core/lib/color.ts
@@ -70,6 +70,9 @@ const getDarkPageBgTintRatio = (intensity: number): number => {
   return 0.08 + strength * 0.24
 }
 
+/**
+ * Sanitizes the custom page-background hue used by theme preset controls.
+ */
 export const normalizePageBgHue = (value?: number | null): number => {
   if (typeof value !== 'number' || Number.isNaN(value)) {
     return PAGE_CUSTOM_HUE_DEFAULT
@@ -78,6 +81,9 @@ export const normalizePageBgHue = (value?: number | null): number => {
   return clamp(value, 0, 360)
 }
 
+/**
+ * Sanitizes the custom page-background tint strength.
+ */
 export const normalizePageBgIntensity = (value?: number | null): number => {
   if (typeof value !== 'number' || Number.isNaN(value)) {
     return PAGE_CUSTOM_INTENSITY_DEFAULT
@@ -102,6 +108,12 @@ export const mapToPresetColorHex = (
   theme: keyof typeof RAINBOW_COLOR_HEX,
 ): string => RAINBOW_COLOR_HEX[theme][color] ?? RAINBOW_COLOR_HEX[theme][COLOR.BLACK]
 
+/**
+ * Computes the final custom page background color for a theme.
+ *
+ * The hue is mixed into a light or dark base instead of being used directly, so
+ * the page remains readable while still reflecting the selected color.
+ */
 export const getPageBgCustomColor = (
   theme: string,
   hue?: number | null,
@@ -120,6 +132,9 @@ export const getPageBgCustomColor = (
   return rgbToHex(...mixed)
 }
 
+/**
+ * Picks a stable fallback avatar color from the first username letter.
+ */
 export const getLetterColor = (username: string): TColorName => {
   const firstLetter = username[0].toLowerCase()
 

--- a/frontend/core/lib/dsb-demo.ts
+++ b/frontend/core/lib/dsb-demo.ts
@@ -7,11 +7,20 @@ import persist from '~/utils/persist'
 const DEMO_CONFIG_KEY = `${DSB_DEMO_KEY}:config`
 const DEMO_SNAPSHOT_KEY = `${DSB_DEMO_KEY}:snapshot`
 
+/**
+ * Checks whether the dashboard should run against local demo persistence.
+ *
+ * Demo mode is limited to `/home?mode=demo` so ordinary community dashboards do
+ * not accidentally read localStorage overrides.
+ */
 export const isDsbDemoMode = (
   community: string | null | undefined,
   mode?: string | null,
 ): boolean => community === ROUTE.HOME && mode === 'demo'
 
+/**
+ * Builds a complete dashboard field map from a partial demo payload.
+ */
 export const buildDsbDemoConfig = (source: Partial<TDsbFieldMap>): TDsbFieldMap => {
   const base = { ...FIELDS, ...source }
 
@@ -22,18 +31,33 @@ export const buildDsbDemoConfig = (source: Partial<TDsbFieldMap>): TDsbFieldMap 
   }, {} as TDsbFieldMap)
 }
 
+/**
+ * Reads the editable demo dashboard state from localStorage.
+ */
 export const getDsbDemoConfig = (fallback?: TDsbFieldMap): TDsbFieldMap | null =>
   persist.get<TDsbFieldMap>(DEMO_CONFIG_KEY, fallback)
 
+/**
+ * Persists the editable demo dashboard state.
+ */
 export const setDsbDemoConfig = (config: TDsbFieldMap): void =>
   persist.set<TDsbFieldMap>(DEMO_CONFIG_KEY, config)
 
+/**
+ * Reads the reset snapshot captured before the demo was edited.
+ */
 export const getDsbDemoSnapshot = (fallback?: TDsbFieldMap): TDsbFieldMap | null =>
   persist.get<TDsbFieldMap>(DEMO_SNAPSHOT_KEY, fallback)
 
+/**
+ * Stores the reset snapshot for the demo dashboard.
+ */
 export const setDsbDemoSnapshot = (config: TDsbFieldMap): void =>
   persist.set<TDsbFieldMap>(DEMO_SNAPSHOT_KEY, config)
 
+/**
+ * Restores the editable demo config from its original snapshot.
+ */
 export const resetDsbDemoConfig = (): TDsbFieldMap | null => {
   const snapshot = getDsbDemoSnapshot()
   if (!snapshot) return null

--- a/frontend/core/lib/graphql.ts
+++ b/frontend/core/lib/graphql.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared fetch options for browser-to-GraphQL requests.
+ *
+ * Cookies must be included because the web app and API can run on different
+ * hosts in production and on different localhost ports during development.
+ */
 export const FETCH_OPTIONS = (): RequestInit => ({
   // make sure cookie is included
   // since groupher.com and api.groupher.com is different domain
@@ -10,6 +16,12 @@ export const FETCH_OPTIONS = (): RequestInit => ({
 })
 
 // None of these options have to be added, these are the default values.
+/**
+ * Network-only retry policy for urql exchanges.
+ *
+ * GraphQL validation/business errors should be returned to callers unchanged;
+ * only transient network failures are retried.
+ */
 export const RETRY_OPTIONS = {
   initialDelayMs: 1000,
   maxDelayMs: 15000,
@@ -27,6 +39,12 @@ const normalizeGQLQuery = (query: string): string => {
   return normalized
 }
 
+/**
+ * Extracts an operation name or first field name from a GraphQL document string.
+ *
+ * This powers logging/telemetry for both named operations and anonymous queries
+ * generated from colocated schema snippets.
+ */
 export const extractQueryName = (schema: string): string | null => {
   const normalized = normalizeGQLQuery(schema)
 

--- a/frontend/core/lib/signal.ts
+++ b/frontend/core/lib/signal.ts
@@ -5,7 +5,12 @@ import type { TArticle, TArticlePubSelector } from '~/spec'
 import PubSub from './pubsub'
 
 /**
- * publish event message, 'send' inspired by Elixir
+ * Publish an in-app event message.
+ *
+ * This is the small event boundary between distant UI surfaces such as drawers,
+ * article lists, passport editor, and search panel. Prefer a focused React prop
+ * or store action for local state; use `send` when the sender and receiver do
+ * not share a direct component owner.
  */
 export const send = (msg: string, data = {}): void => {
   // TODO: check the msg is valid
@@ -26,10 +31,17 @@ export const logout = (): void => {
  */
 export const closeDrawer = (type = ''): void => send(EVENT.DRAWER.CLOSE, { type })
 
+/**
+ * Broadcasts optimistic upvote state for the currently viewed article.
+ */
 export const upvoteArticle = (article: TArticle, viewerHasUpvoted): void => {
   send(EVENT.UPVOTE_ARTICLE, { type: 'upvote_article', data: { article, viewerHasUpvoted } })
 }
 
+/**
+ * Broadcasts a hydrated article payload to surfaces that mirror the viewer's
+ * current article state.
+ */
 export const updateViewingArticle = (article: TArticle): void => {
   send(EVENT.UPDATE_VIEWING_ARTICLE, { type: EVENT.UPDATE_VIEWING_ARTICLE, data: { article } })
 }
@@ -49,11 +61,17 @@ export const listUsers = (type: 'modal' | 'drawer'): void => {
   send(EVENT.LIST_USER_MODAL, { type })
 }
 
+/**
+ * Opens the community passport editor drawer from any toolbar/action surface.
+ */
 export const callPassportEditor = (): void => {
   const type = TYPE.DRAWER.PASSPORT_EDITOR
   send(EVENT.DRAWER.OPEN, { type })
 }
 
+/**
+ * Opens the global article editor drawer.
+ */
 export const callGEditor = (): void => {
   send(EVENT.DRAWER.OPEN, { type: TYPE.DRAWER.G_EDITOR })
 }

--- a/frontend/core/lib/thread.ts
+++ b/frontend/core/lib/thread.ts
@@ -5,6 +5,15 @@ const THREAD_BY_PATH = Object.fromEntries(
   Object.entries(THREAD_PATH).map(([thread, path]) => [path, thread]),
 ) as Record<TThreadPath, TThread>
 
+/**
+ * Converts the internal thread key to the public URL path segment.
+ */
 export const thread2Path = (slug: TThread): TThreadPath => THREAD_PATH[slug]
+
+/**
+ * Converts a public URL path segment back to the internal thread key.
+ *
+ * Unknown paths fall back to posts because post is the default public thread.
+ */
 export const path2Thread = (path: string): TThread =>
   THREAD_BY_PATH[path as TThreadPath] ?? THREAD.POST

--- a/frontend/core/lib/validator.ts
+++ b/frontend/core/lib/validator.ts
@@ -15,6 +15,9 @@ import {
   values,
 } from 'ramda'
 
+/**
+ * Shared nil-or-empty predicate used by legacy form validation chains.
+ */
 export const nilOrEmpty = either(isNil, isEmpty)
 
 const hasValue: (v: string) => boolean = compose(not, nilOrEmpty)
@@ -27,6 +30,13 @@ export type TSlugValidation = {
   reason?: 'empty' | 'format'
 }
 
+/**
+ * Validates public slugs before they cross the GraphQL/backend boundary.
+ *
+ * The accepted shape is lowercase words separated by single dashes. Returning a
+ * reason lets form UIs distinguish empty input from invalid formatting without
+ * duplicating the regex.
+ */
 export const validateSlug = (value?: string | null): TSlugValidation => {
   const next = isString(value) ? trim(value) : ''
 
@@ -43,6 +53,9 @@ export const validateSlug = (value?: string | null): TSlugValidation => {
 
 export const isValidSlug = (value?: string | null): boolean => validateSlug(value).valid
 
+/**
+ * Runtime object guard used by older validation and merge helpers.
+ */
 export const isObject = (value: unknown): boolean => {
   const type = typeof value
   return value != null && (type === 'object' || type === 'function')

--- a/frontend/core/lib/wallpaperPreview.ts
+++ b/frontend/core/lib/wallpaperPreview.ts
@@ -8,6 +8,12 @@ export type TWallpaperPreviewDetail = {
 
 type TWallpaperPreviewEvent = CustomEvent<TWallpaperPreviewDetail>
 
+/**
+ * Emits an ephemeral wallpaper preview outside the persisted wallpaper store.
+ *
+ * This keeps hover/drag previews cheap and reversible while the final selected
+ * value is still committed through the wallpaper store.
+ */
 export const emitWallpaperPreview = (state: TWallpaperThemeState | null): void => {
   if (typeof window === 'undefined') return
 
@@ -18,6 +24,9 @@ export const emitWallpaperPreview = (state: TWallpaperThemeState | null): void =
   )
 }
 
+/**
+ * Subscribes to transient wallpaper preview changes and returns a cleanup.
+ */
 export const subscribeWallpaperPreview = (
   listener: (state: TWallpaperThemeState | null) => void,
 ): (() => void) => {

--- a/frontend/core/widgets/RangeInput/helper.ts
+++ b/frontend/core/widgets/RangeInput/helper.ts
@@ -1,20 +1,35 @@
 import { MIN_VISUAL_RATIO } from './constant'
 
+/**
+ * Clamps a number while tolerating reversed min/max input.
+ */
 export const clamp = (value: number, min: number, max: number): number => {
   if (min === max) return min
   return Math.min(Math.max(value, Math.min(min, max)), Math.max(min, max))
 }
 
+/**
+ * Converts a value in min/max space into a 0..100 logical ratio.
+ */
 export const getRatio = (value: number, min: number, max: number): number => {
   if (min === max) return 0
   return ((value - min) / (max - min)) * 100
 }
 
+/**
+ * Ensures the thumb remains visually reachable near the left edge.
+ */
 export const getVisualRatio = (ratio: number): number =>
   clamp(Math.max(ratio, MIN_VISUAL_RATIO), 0, 100)
 
+/**
+ * Converts the visual ratio back to logical value ratio.
+ */
 export const getRatioFromVisualRatio = (visualRatio: number): number =>
   visualRatio <= MIN_VISUAL_RATIO ? 0 : visualRatio
 
+/**
+ * Default label formatter for compact numeric range values.
+ */
 export const defaultFormatValue = (value: number): string =>
   Number.isInteger(value) ? String(value) : value.toFixed(1)

--- a/frontend/core/widgets/RangeInput/hooks.ts
+++ b/frontend/core/widgets/RangeInput/hooks.ts
@@ -25,6 +25,13 @@ const getStepPrecision = (step: number): number => {
   return stepText.split('.')[1]?.length || 0
 }
 
+/**
+ * Interaction model for the custom range input.
+ *
+ * The visible indicator sits above a transparent native range input. This hook
+ * mirrors pointer interactions from the indicator into numeric values so the UI
+ * gets custom hover/drag behavior without losing native keyboard/input support.
+ */
 export default function useRangeInputLogic({
   value,
   min,

--- a/frontend/core/widgets/WordsCounter/helper.ts
+++ b/frontend/core/widgets/WordsCounter/helper.ts
@@ -53,6 +53,12 @@ const extractWords = (body: string): string => {
   return pureText
 }
 
+/**
+ * Counts editor body text using CJK characters plus latin word tokens.
+ *
+ * The editor payload can contain HTML, so text is sanitized before counting to
+ * keep formatting tags out of article length metrics.
+ */
 export const countWords = (body: string): number => {
   const str = extractWords(body)
   if (str.length === 0) return 0


### PR DESCRIPTION
## Summary

- add backend moduledoc coverage across `backend/main/lib`, including business modules, schema/model boundaries, seed/support helpers, middleware, and GraphQL schema modules
- document key backend flows with short ASCII diagrams where they clarify ownership and data movement
- add frontend JSDoc notes for shared hooks/libs/widgets that explain purpose, boundaries, and caller expectations

## Validation

- `git diff --check`
- `mix format --check-formatted` on changed backend files
- `yarn oxfmt -c frontend/core/config/oxfmt.json --check` on changed frontend core files
- `yarn workspace @groupher/frontend-core type-check`

## Notes

- `backend/main/lib` now has zero `@moduledoc false` entries.
- `mix compile --warnings-as-errors` was attempted earlier but this worktree did not have Mix deps installed, so Mix stopped at missing dependency checks before compilation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents backend module boundaries and data flow across accounts, CMS, messaging, statistics, and GraphQL middleware with no runtime changes. Follow-up updates address review feedback with clearer concurrency notes, dashboard rules, and inbox/mention flows.

- **Refactors**
  - Replaced `@moduledoc false` with clear docs across backend modules and schemas, adding small ASCII diagrams where helpful.
  - Clarified concurrency and write orchestration (follows/reputation/membership, collects, OAuth), and documented mailbox counters and messaging flows (CMS mention facts vs. inbox notifications).
  - Explained dashboard rules: section payload normalization, base-info sync with `Community`, and theme preset composition.
  - Added docs for GraphQL middleware behavior, bounded search, seed helpers, and the published doc-tree field list; kept JSDoc in `@groupher/frontend-core`.

<sup>Written for commit 54cf245aa94425d98eb7aae314bd82405bbab423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/groupher/groupher/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default formatter for range input values to present integers and decimals consistently.
* **Bug Fixes**
  * Improved account-domain event dispatch by adding explicit handling for follow/undo-follow and returning a clear error when an unsupported event type is used.
* **Documentation**
  * Expanded public module and inline documentation across account, CMS, messaging, statistics, GraphQL middleware, and frontend utilities (including hooks and helpers) to better explain behavior and expected inputs/outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->