### PR TITLE
chore(fe): enable TypeScript 7 in Next preview.6

### DIFF
--- a/frontend/core/next.config.js
+++ b/frontend/core/next.config.js
@@ -10,6 +10,7 @@ const baseConfig = {
   productionBrowserSourceMaps: false,
   cacheComponents: true,
   experimental: {
+    useTypeScriptCli: true,
     instantInsights: {
       validationLevel: 'manual-warning',
     },

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@groupher/frontend-core": "1.0.0",
-    "next": "16.3.0-preview.5",
+    "next": "16.3.0-preview.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/frontend/gateway/next.config.js
+++ b/frontend/gateway/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
+    useTypeScriptCli: true,
     turbopackFileSystemCacheForBuild: true,
   },
   images: {

--- a/frontend/gateway/package.json
+++ b/frontend/gateway/package.json
@@ -15,7 +15,7 @@
     "clean": "shjs ./utils/scripts/clean.js"
   },
   "dependencies": {
-    "next": "16.3.0-preview.5",
+    "next": "16.3.0-preview.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/frontend/inspire-me/package.json
+++ b/frontend/inspire-me/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@groupher/frontend-core": "1.0.0",
-    "next": "16.3.0-preview.5",
+    "next": "16.3.0-preview.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/frontend/landing/package.json
+++ b/frontend/landing/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@groupher/frontend-core": "1.0.0",
-    "next": "16.3.0-preview.5",
+    "next": "16.3.0-preview.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/frontend/main/package.json
+++ b/frontend/main/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@groupher/frontend-core": "1.0.0",
-    "next": "16.3.0-preview.5",
+    "next": "16.3.0-preview.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "mastani-codehighlight": "0.0.7",
     "motion": "^12.38.0",
     "nanoid": "^5.1.9",
-    "next": "16.3.0-preview.5",
+    "next": "16.3.0-preview.6",
     "next-auth": "5.0.0-beta.30",
     "next-compose-plugins": "^2.2.0",
     "overlayscrollbars": "^2.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,7 +1354,7 @@ __metadata:
   dependencies:
     "@groupher/frontend-core": "npm:1.0.0"
     cross-env: "npm:^10.1.0"
-    next: "npm:16.3.0-preview.5"
+    next: "npm:16.3.0-preview.6"
     react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"
   languageName: unknown
@@ -1365,7 +1365,7 @@ __metadata:
   resolution: "@groupher/frontend-gateway@workspace:frontend/gateway"
   dependencies:
     cross-env: "npm:^10.1.0"
-    next: "npm:16.3.0-preview.5"
+    next: "npm:16.3.0-preview.6"
     react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"
   languageName: unknown
@@ -1377,7 +1377,7 @@ __metadata:
   dependencies:
     "@groupher/frontend-core": "npm:1.0.0"
     cross-env: "npm:^10.1.0"
-    next: "npm:16.3.0-preview.5"
+    next: "npm:16.3.0-preview.6"
     react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"
   languageName: unknown
@@ -1389,7 +1389,7 @@ __metadata:
   dependencies:
     "@groupher/frontend-core": "npm:1.0.0"
     cross-env: "npm:^10.1.0"
-    next: "npm:16.3.0-preview.5"
+    next: "npm:16.3.0-preview.6"
     react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"
     serve: "npm:^14.2.6"
@@ -1402,7 +1402,7 @@ __metadata:
   dependencies:
     "@groupher/frontend-core": "npm:1.0.0"
     cross-env: "npm:^10.1.0"
-    next: "npm:16.3.0-preview.5"
+    next: "npm:16.3.0-preview.6"
     react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"
   languageName: unknown
@@ -1526,7 +1526,7 @@ __metadata:
     mastani-codehighlight: "npm:0.0.7"
     motion: "npm:^12.38.0"
     nanoid: "npm:^5.1.9"
-    next: "npm:16.3.0-preview.5"
+    next: "npm:16.3.0-preview.6"
     next-auth: "npm:5.0.0-beta.30"
     next-compose-plugins: "npm:^2.2.0"
     npm-run-all: "npm:^4.1.1"
@@ -2007,65 +2007,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "@next/env@npm:16.3.0-preview.5"
-  checksum: 10c0/7329512690f94896c87cd33fcdb4f52e77c869accb4faa75dc38bb1497a683ac55bc835f5b24824fd494e7408d81f53725abb9aab9dd00e21a591f81392f22c2
+"@next/env@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "@next/env@npm:16.3.0-preview.6"
+  checksum: 10c0/53ba10a5c43c35e58145d2563913e0417cb73b970e94adf14f9d7cca39460fe9e468031c96eff266feb7f8c20cc2623b0a97f725e8571fda20f865f0093a383c
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "@next/swc-darwin-arm64@npm:16.3.0-preview.5"
+"@next/swc-darwin-arm64@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "@next/swc-darwin-arm64@npm:16.3.0-preview.6"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "@next/swc-darwin-x64@npm:16.3.0-preview.5"
+"@next/swc-darwin-x64@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "@next/swc-darwin-x64@npm:16.3.0-preview.6"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "@next/swc-linux-arm64-gnu@npm:16.3.0-preview.5"
+"@next/swc-linux-arm64-gnu@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.3.0-preview.6"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "@next/swc-linux-arm64-musl@npm:16.3.0-preview.5"
+"@next/swc-linux-arm64-musl@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "@next/swc-linux-arm64-musl@npm:16.3.0-preview.6"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "@next/swc-linux-x64-gnu@npm:16.3.0-preview.5"
+"@next/swc-linux-x64-gnu@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "@next/swc-linux-x64-gnu@npm:16.3.0-preview.6"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "@next/swc-linux-x64-musl@npm:16.3.0-preview.5"
+"@next/swc-linux-x64-musl@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "@next/swc-linux-x64-musl@npm:16.3.0-preview.6"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "@next/swc-win32-arm64-msvc@npm:16.3.0-preview.5"
+"@next/swc-win32-arm64-msvc@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.3.0-preview.6"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "@next/swc-win32-x64-msvc@npm:16.3.0-preview.5"
+"@next/swc-win32-x64-msvc@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "@next/swc-win32-x64-msvc@npm:16.3.0-preview.6"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -11461,19 +11461,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:16.3.0-preview.5":
-  version: 16.3.0-preview.5
-  resolution: "next@npm:16.3.0-preview.5"
+"next@npm:16.3.0-preview.6":
+  version: 16.3.0-preview.6
+  resolution: "next@npm:16.3.0-preview.6"
   dependencies:
-    "@next/env": "npm:16.3.0-preview.5"
-    "@next/swc-darwin-arm64": "npm:16.3.0-preview.5"
-    "@next/swc-darwin-x64": "npm:16.3.0-preview.5"
-    "@next/swc-linux-arm64-gnu": "npm:16.3.0-preview.5"
-    "@next/swc-linux-arm64-musl": "npm:16.3.0-preview.5"
-    "@next/swc-linux-x64-gnu": "npm:16.3.0-preview.5"
-    "@next/swc-linux-x64-musl": "npm:16.3.0-preview.5"
-    "@next/swc-win32-arm64-msvc": "npm:16.3.0-preview.5"
-    "@next/swc-win32-x64-msvc": "npm:16.3.0-preview.5"
+    "@next/env": "npm:16.3.0-preview.6"
+    "@next/swc-darwin-arm64": "npm:16.3.0-preview.6"
+    "@next/swc-darwin-x64": "npm:16.3.0-preview.6"
+    "@next/swc-linux-arm64-gnu": "npm:16.3.0-preview.6"
+    "@next/swc-linux-arm64-musl": "npm:16.3.0-preview.6"
+    "@next/swc-linux-x64-gnu": "npm:16.3.0-preview.6"
+    "@next/swc-linux-x64-musl": "npm:16.3.0-preview.6"
+    "@next/swc-win32-arm64-msvc": "npm:16.3.0-preview.6"
+    "@next/swc-win32-x64-msvc": "npm:16.3.0-preview.6"
     "@swc/helpers": "npm:0.5.15"
     baseline-browser-mapping: "npm:^2.9.19"
     caniuse-lite: "npm:^1.0.30001579"
@@ -11517,7 +11517,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/d9a44d26c22b6bca240fbd7d89465ce77350e51daea0bdb198e28aae02685a8c53e3fa1e39a81499c11a7fa97b7c4df44fb85fdc42c7725490b5db59be15a69e
+  checksum: 10c0/ed21c345bc54cf0d90ae6f4b8de32c451a977c544804c354e9560310335db54d04063a42de344226d8c902a91a22061630d7151836b1102cbad009317827914e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade all frontend apps to `next@16.3.0-preview.6` and enable Next’s TypeScript CLI to unlock TypeScript 7 in preview builds. This prepares the monorepo for TS 7 and aligns type-checking across apps.

- **Dependencies**
  - Bumped `next` from `16.3.0-preview.5` to `16.3.0-preview.6` in root and all `frontend/*` apps; updated `yarn.lock`.
  - Set `experimental.useTypeScriptCli: true` in `frontend/core/next.config.js` and `frontend/gateway/next.config.js`.

<sup>Written for commit 514219306254dab1c2ab3e36162ce50d80bdeb26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/groupher/groupher/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the application framework across frontend experiences to a newer preview release.
  - Enabled improved TypeScript command-line support for supported frontend applications.
  - These updates improve development and build tooling while preserving existing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->